### PR TITLE
make username and password optional

### DIFF
--- a/config/targets.go
+++ b/config/targets.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/openconfig/gnmic/types"
-	"golang.org/x/term"
 )
 
 const (
@@ -31,21 +30,6 @@ func (c *Config) GetTargets() (map[string]*types.TargetConfig, error) {
 	var err error
 	// case address is defined in .Address
 	if len(c.Address) > 0 {
-		if c.Username == "" && c.Token == "" {
-			defUsername, err := readUsername()
-			if err != nil {
-				return nil, err
-			}
-			c.Username = defUsername
-		}
-		if c.Password == "" && c.Token == "" {
-			defPassword, err := readPassword()
-			if err != nil {
-				return nil, err
-			}
-			c.Password = defPassword
-		}
-
 		for _, addr := range c.Address {
 			tc := &types.TargetConfig{
 				Name:    addr,
@@ -147,25 +131,6 @@ func (c *Config) GetTargets() (map[string]*types.TargetConfig, error) {
 		c.logger.Printf("targets: %v", c.Targets)
 	}
 	return c.Targets, nil
-}
-
-func readUsername() (string, error) {
-	var username string
-	fmt.Print("username: ")
-	_, err := fmt.Scan(&username)
-	if err != nil {
-		return "", err
-	}
-	return username, nil
-}
-func readPassword() (string, error) {
-	fmt.Print("password: ")
-	pass, err := term.ReadPassword(int(os.Stdin.Fd()))
-	if err != nil {
-		return "", err
-	}
-	fmt.Println()
-	return string(pass), nil
 }
 
 func (c *Config) SetTargetConfigDefaults(tc *types.TargetConfig) error {

--- a/docs/global_flags.md
+++ b/docs/global_flags.md
@@ -16,7 +16,7 @@ gnmic -a 192.168.113.11:57400 --address 192.168.113.12:57400
 
 ### cluster-name
 
-The `[--cluster-name]` flag is used to specify the cluster name the `gnmic` instance will join. 
+The `[--cluster-name]` flag is used to specify the cluster name the `gnmic` instance will join.
 
 The cluster name is used as part of the locked keys to share targets between multiple gnmic instances.
 
@@ -24,7 +24,7 @@ Defaults to `default-cluster`
 
 ### config
 
-The `--config` flag specifies the location of a configuration file that `gnmic` will read. 
+The `--config` flag specifies the location of a configuration file that `gnmic` will read.
 
 If not specified, gnmic searches for a file named `.gnmic` with extensions `yaml, yml, toml or json` in the following locations:
 
@@ -215,7 +215,7 @@ Note that in case a single target is specified, the prefix is not added.
 
 ### password
 
-The password flag `[-p | --password]` is used to specify the target password as part of the user credentials. If omitted, the password input prompt is used to provide the password.
+The password flag `[-p | --password]` is used to specify the target password as part of the user credentials.
 
 Note that in case multiple targets are used, all should use the same credentials.
 
@@ -291,4 +291,4 @@ Applied only in the case of a secure gRPC connection.
 
 ### username
 
-The username flag `[-u | --username]` is used to specify the target username as part of the user credentials. If omitted, the input prompt is used to provide the username.
+The username flag `[-u | --username]` is used to specify the target username as part of the user credentials.

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -89,6 +88,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a // indirect
 	github.com/onsi/gomega v1.19.0 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect

--- a/target/subscribe.go
+++ b/target/subscribe.go
@@ -34,10 +34,10 @@ SUBSC:
 	default:
 		nctx, cancel = context.WithCancel(ctx)
 		defer cancel()
-		if t.Config.Username != nil {
+		if t.Config.Username != nil && *t.Config.Username != "" {
 			nctx = metadata.AppendToOutgoingContext(nctx, "username", *t.Config.Username)
 		}
-		if t.Config.Password != nil {
+		if t.Config.Password != nil && *t.Config.Password != "" {
 			nctx = metadata.AppendToOutgoingContext(nctx, "password", *t.Config.Password)
 		}
 		subscribeClient, err = t.Client.Subscribe(nctx)

--- a/target/target.go
+++ b/target/target.go
@@ -146,10 +146,10 @@ func (t *Target) CreateGNMIClient(ctx context.Context, opts ...grpc.DialOption) 
 
 // Capabilities sends a gnmi.CapabilitiesRequest to the target *t and returns a gnmi.CapabilitiesResponse and an error
 func (t *Target) Capabilities(ctx context.Context, ext ...*gnmi_ext.Extension) (*gnmi.CapabilityResponse, error) {
-	if t.Config.Username != nil {
+	if t.Config.Username != nil && *t.Config.Username != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "username", *t.Config.Username)
 	}
-	if t.Config.Password != nil {
+	if t.Config.Password != nil && *t.Config.Password != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "password", *t.Config.Password)
 	}
 	return t.Client.Capabilities(ctx, &gnmi.CapabilityRequest{Extension: ext})
@@ -157,10 +157,10 @@ func (t *Target) Capabilities(ctx context.Context, ext ...*gnmi_ext.Extension) (
 
 // Get sends a gnmi.GetRequest to the target *t and returns a gnmi.GetResponse and an error
 func (t *Target) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetResponse, error) {
-	if t.Config.Username != nil {
+	if t.Config.Username != nil && *t.Config.Username != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "username", *t.Config.Username)
 	}
-	if t.Config.Password != nil {
+	if t.Config.Password != nil && *t.Config.Password != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "password", *t.Config.Password)
 	}
 	return t.Client.Get(ctx, req)
@@ -168,10 +168,10 @@ func (t *Target) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 
 // Set sends a gnmi.SetRequest to the target *t and returns a gnmi.SetResponse and an error
 func (t *Target) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetResponse, error) {
-	if t.Config.Username != nil {
+	if t.Config.Username != nil && *t.Config.Username != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "username", *t.Config.Username)
 	}
-	if t.Config.Password != nil {
+	if t.Config.Password != nil && *t.Config.Password != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "password", *t.Config.Password)
 	}
 	return t.Client.Set(ctx, req)


### PR DESCRIPTION
Fix #18
This PR makes username/password optional for targets, gNMIc will not prompt the user for credentials when either username or password are not configured (via flags or config file)