### PR TITLE
Target subscribe state metric

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -46,6 +46,7 @@ func (a *App) newAPIServer() (*http.Server, error) {
 		a.reg.MustRegister(collectors.NewGoCollector())
 		a.reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 		a.reg.MustRegister(subscribeResponseReceivedCounter)
+		a.reg.MustRegister(subscribeTargetState)
 		go a.startClusterMetrics()
 	}
 	s := &http.Server{

--- a/app/collector.go
+++ b/app/collector.go
@@ -43,6 +43,7 @@ func (a *App) StartCollector(ctx context.Context) {
 		if t == nil {
 			continue
 		}
+		subscribeTargetState.WithLabelValues(t.Config.Name).Set(0)
 		a.operLock.RLock()
 		_, ok := a.activeTargets[t.Config.Name]
 		a.operLock.RUnlock()
@@ -65,6 +66,7 @@ func (a *App) StartCollector(ctx context.Context) {
 			for {
 				select {
 				case rsp := <-rspChan:
+					subscribeTargetState.WithLabelValues(t.Config.Name).Set(1)
 					subscribeResponseReceivedCounter.WithLabelValues(t.Config.Name, rsp.SubscriptionConfig.Name).Add(1)
 					if a.Config.Debug {
 						a.Logger.Printf("target %q: gNMI Subscribe Response: %+v", t.Config.Name, rsp)

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -27,6 +27,12 @@ var subscribeResponseReceivedCounter = prometheus.NewCounterVec(prometheus.Count
 	Name:      "number_of_received_subscribe_response_messages_total",
 	Help:      "Total number of received subscribe response messages",
 }, []string{"source", "subscription"})
+var subscribeTargetState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "gnmic",
+	Subsystem: "subscribe",
+	Name:      "target_is_subscribed",
+	Help:      "Has value 1 if target is subscribed, 0 otherwise",
+}, []string{"source"})
 
 // cluster
 var clusterNumberOfLockedTargets = prometheus.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
feature: add api server gauge metrics for target subscribe state

What I'm trying to accomplish here is to expose the subscription state of loaded targets for reporting or alerting.  If this isn't the right way to implement such a feature, please point me in the right direction and I'll implement it in a way that better follows the architecture of gNMIc.