### PR TITLE
Configurable TLS server clientCertificate request and validation behavior

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -34,8 +34,10 @@ func (a *App) newAPIServer() (*http.Server, error) {
 			a.Config.APIServer.TLS.CaFile,
 			a.Config.APIServer.TLS.CertFile,
 			a.Config.APIServer.TLS.KeyFile,
-			a.Config.APIServer.TLS.SkipVerify,
-			true)
+			a.Config.APIServer.TLS.ClientAuth,
+			false, // skip-verify
+			true, // genSelfSigned
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/app/gnmi_server.go
+++ b/app/gnmi_server.go
@@ -202,11 +202,15 @@ func (a *App) gRPCServerOpts() ([]grpc.ServerOption, error) {
 		a.reg.MustRegister(grpcMetrics)
 	}
 
+	if a.Config.GnmiServer.TLS == nil {
+		return opts,nil
+	}
 	tlscfg, err := utils.NewTLSConfig(
-		a.Config.GnmiServer.CaFile,
-		a.Config.GnmiServer.CertFile,
-		a.Config.GnmiServer.KeyFile,
-		a.Config.GnmiServer.SkipVerify,
+		a.Config.GnmiServer.TLS.CaFile,
+		a.Config.GnmiServer.TLS.CertFile,
+		a.Config.GnmiServer.TLS.KeyFile,
+		a.Config.GnmiServer.TLS.ClientAuth,
+		false,
 		true,
 	)
 	if err != nil {

--- a/app/tunnel.go
+++ b/app/tunnel.go
@@ -107,10 +107,11 @@ func (a *App) gRPCTunnelServerOpts() ([]grpc.ServerOption, error) {
 	}
 
 	tlscfg, err := utils.NewTLSConfig(
-		a.Config.TunnelServer.CaFile,
-		a.Config.TunnelServer.CertFile,
-		a.Config.TunnelServer.KeyFile,
-		a.Config.TunnelServer.SkipVerify,
+		a.Config.TunnelServer.TLS.CaFile,
+		a.Config.TunnelServer.TLS.CertFile,
+		a.Config.TunnelServer.TLS.KeyFile,
+		a.Config.TunnelServer.TLS.ClientAuth,
+		false,
 		true,
 	)
 	if err != nil {

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -118,8 +118,10 @@ func newListenCmd() *cobra.Command {
 					gApp.Config.TLSCa,
 					gApp.Config.TLSCert,
 					gApp.Config.TLSKey,
-					gApp.Config.SkipVerify,
-					false)
+					"request",
+					false,
+					true,
+				)
 				if err != nil {
 					return err
 				}

--- a/config/api_server.go
+++ b/config/api_server.go
@@ -9,6 +9,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -39,11 +40,15 @@ func (c *Config) GetAPIServer() error {
 		c.APIServer.Address = os.ExpandEnv(c.FileConfig.GetString("api"))
 	}
 	c.APIServer.Timeout = c.FileConfig.GetDuration("api-server/timeout")
-	if c.APIServer.TLS != nil {
-		c.APIServer.TLS.SkipVerify = os.ExpandEnv(c.FileConfig.GetString("api-server/skip-verify")) == trueString
-		c.APIServer.TLS.CaFile = os.ExpandEnv(c.FileConfig.GetString("api-server/ca-file"))
-		c.APIServer.TLS.CertFile = os.ExpandEnv(c.FileConfig.GetString("api-server/cert-file"))
-		c.APIServer.TLS.KeyFile = os.ExpandEnv(c.FileConfig.GetString("api-server/key-file"))
+	if c.FileConfig.IsSet("api-server/tls") {
+		c.APIServer.TLS = new(types.TLSConfig)
+		c.APIServer.TLS.CaFile = os.ExpandEnv(c.FileConfig.GetString("api-server/tls/ca-file"))
+		c.APIServer.TLS.CertFile = os.ExpandEnv(c.FileConfig.GetString("api-server/tls/cert-file"))
+		c.APIServer.TLS.KeyFile = os.ExpandEnv(c.FileConfig.GetString("api-server/tls/key-file"))
+		c.APIServer.TLS.ClientAuth = os.ExpandEnv(c.FileConfig.GetString("api-server/tls/client-auth"))
+		if err := c.APIServer.TLS.Validate(); err != nil {
+			return fmt.Errorf("api-server TLS config error: %w", err)
+		}
 	}
 
 	c.APIServer.EnableMetrics = os.ExpandEnv(c.FileConfig.GetString("api-server/enable-metrics")) == trueString

--- a/docs/user_guide/api/api_intro.md
+++ b/docs/user_guide/api/api_intro.md
@@ -43,8 +43,8 @@ api-server:
     #  - request:         The server requests a certificate from the client but does not 
     #                     require the client to send a certificate. 
     #                     If the server sends a certificate, it is not required to be valid.
-    #  - require:         The server requires the client to send a certificate and fails if 
-    #                     the client certificate is not valid.
+    #  - require:         The server requires the client to send a certificate and does not 
+    #                     fail if the client certificate is not valid.
     #  - verify-if-given: The server requests a certificate, 
     #                     does not fail if no certificate is sent. 
     #                     If a certificate is sent it is required to be valid.

--- a/docs/user_guide/api/api_intro.md
+++ b/docs/user_guide/api/api_intro.md
@@ -42,7 +42,7 @@ api-server:
     # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
     #  - request:         The server requests a certificate from the client but does not 
     #                     require the client to send a certificate. 
-    #                     If the server sends a certificate, it is not required to be valid.
+    #                     If the client sends a certificate, it is not required to be valid.
     #  - require:         The server requires the client to send a certificate and does not 
     #                     fail if the client certificate is not valid.
     #  - verify-if-given: The server requests a certificate, 

--- a/docs/user_guide/api/api_intro.md
+++ b/docs/user_guide/api/api_intro.md
@@ -33,19 +33,26 @@ api-server:
   # tls config
   tls:
     # string, path to the CA certificate file,
-    # this will be used to verify the clients certificates when `skip-verify` is false
+    # this certificate is used to verify the clients certificates.
     ca-file:
     # string, server certificate file.
-    # if both `cert-file` and `key-file` are empty, and `skip-verify` is true or `ca-file` is set, 
-    # the server will run with self signed certificates.
     cert-file:
     # string, server key file.
-    # if both `cert-file` and `key-file` are empty, and `skip-verify` is true or `ca-file` is set, 
-    # the server will run with self signed certificates.
     key-file:
-    # boolean, if true, the server will run in secure mode 
-    # but will not verify the client certificate against the available certificate chain.
-    skip-verify: false
+    # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
+    #  - request:         The server requests a certificate from the client but does not 
+    #                     require the client to send a certificate. 
+    #                     If the server sends a certificate, it is not required to be valid.
+    #  - require:         The server requires the client to send a certificate and fails if 
+    #                     the client certificate is not valid.
+    #  - verify-if-given: The server requests a certificate, 
+    #                     does not fail if no certificate is sent. 
+    #                     If a certificate is sent it is required to be valid.
+    #  - require-verify:  The server requires the client to send a valid certificate.
+    #
+    # if no ca-file is present, `client-auth` defaults to ""`
+    # if a ca-file is set, `client-auth` defaults to "require-verify"`
+    client-auth: ""
   # boolean, if true, the server will also handle the path /metrics and serve 
   # gNMIc's enabled prometheus metrics.
   enable-metrics: false

--- a/docs/user_guide/gnmi_server.md
+++ b/docs/user_guide/gnmi_server.md
@@ -168,8 +168,8 @@ gnmi-server:
     #  - request:         The server requests a certificate from the client but does not 
     #                     require the client to send a certificate. 
     #                     If the server sends a certificate, it is not required to be valid.
-    #  - require:         The server requires the client to send a certificate and fails if 
-    #                     the client certificate is not valid.
+    #  - require:         The server requires the client to send a certificate and does not 
+    #                     fail if the client certificate is not valid.
     #  - verify-if-given: The server requests a certificate, 
     #                     does not fail if no certificate is sent. 
     #                     If a certificate is sent it is required to be valid.

--- a/docs/user_guide/gnmi_server.md
+++ b/docs/user_guide/gnmi_server.md
@@ -167,7 +167,7 @@ gnmi-server:
     # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
     #  - request:         The server requests a certificate from the client but does not 
     #                     require the client to send a certificate. 
-    #                     If the server sends a certificate, it is not required to be valid.
+    #                     If the client sends a certificate, it is not required to be valid.
     #  - require:         The server requires the client to send a certificate and does not 
     #                     fail if the client certificate is not valid.
     #  - verify-if-given: The server requests a certificate, 

--- a/docs/user_guide/gnmi_server.md
+++ b/docs/user_guide/gnmi_server.md
@@ -155,15 +155,29 @@ If within a `SubscribeRequest` the received `sample-interval` is zero, the `defa
 gnmi-server:
   # the address the gNMI server will listen to
   address: :57400
-  # if true, the server will not verify the client's certificates
-  skip-verify: false
-  # path to the CA certificate file to be used, irrelevant if `skip-verify` is true
-  ca-file: 
-  # path to the server certificate file
-  cert-file:
-  # path to the server key file
-  key-file:
-  # maximum number of allowed subscriptions
+  # tls config
+  tls:
+    # string, path to the CA certificate file,
+    # this certificate is used to verify the clients certificates.
+    ca-file:
+    # string, server certificate file.
+    cert-file:
+    # string, server key file.
+    key-file:
+    # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
+    #  - request:         The server requests a certificate from the client but does not 
+    #                     require the client to send a certificate. 
+    #                     If the server sends a certificate, it is not required to be valid.
+    #  - require:         The server requires the client to send a certificate and fails if 
+    #                     the client certificate is not valid.
+    #  - verify-if-given: The server requests a certificate, 
+    #                     does not fail if no certificate is sent. 
+    #                     If a certificate is sent it is required to be valid.
+    #  - require-verify:  The server requires the client to send a valid certificate.
+    #
+    # if no ca-file is present, `client-auth` defaults to ""`
+    # if a ca-file is set, `client-auth` defaults to "require-verify"`
+    client-auth: ""
   max-subscriptions: 64
   # maximum number of active Get/Set RPCs
   max-unary-rpc: 64

--- a/docs/user_guide/inputs/stan_input.md
+++ b/docs/user_guide/inputs/stan_input.md
@@ -51,4 +51,3 @@ inputs:
     # Must be configured under root level `outputs` section
     outputs: 
 ```
-

--- a/docs/user_guide/outputs/gnmi_output.md
+++ b/docs/user_guide/outputs/gnmi_output.md
@@ -30,7 +30,7 @@ outputs:
       # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
       #  - request:         The server requests a certificate from the client but does not 
       #                     require the client to send a certificate. 
-      #                     If the server sends a certificate, it is not required to be valid.
+      #                     If the client sends a certificate, it is not required to be valid.
       #  - require:         The server requires the client to send a certificate and does not 
       #                     fail if the client certificate is not valid.
       #  - verify-if-given: The server requests a certificate, 

--- a/docs/user_guide/outputs/gnmi_output.md
+++ b/docs/user_guide/outputs/gnmi_output.md
@@ -18,22 +18,28 @@ outputs:
     max-subscriptions: 64
     # maximum number of ongoing Get/Set RPCs.
     max-unary-rpc: 64
-    # tls config
     tls:
-      # string, path to the CA certificate file,      # string, path to the CA certificate file,
-      # this will be used to verify the clients certificates when `skip-verify` is false
+      # string, path to the CA certificate file,
+      # this certificate is used to verify the clients certificates.
       ca-file:
       # string, server certificate file.
-      # if both `cert-file` and `key-file` are empty, and `skip-verify` is true or `ca-file` is set, 
-      # the server will run with self signed certificates.
       cert-file:
       # string, server key file.
-      # if both `cert-file` and `key-file` are empty, and `skip-verify` is true or `ca-file` is set, 
-      # the server will run with self signed certificates.
       key-file:
-      # boolean, if true, the server will run in secure mode 
-      # but will not verify the client certificate against the available certificate chain.
-      skip-verify: false
+      # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
+      #  - request:         The server requests a certificate from the client but does not 
+      #                     require the client to send a certificate. 
+      #                     If the server sends a certificate, it is not required to be valid.
+      #  - require:         The server requires the client to send a certificate and fails if 
+      #                     the client certificate is not valid.
+      #  - verify-if-given: The server requests a certificate, 
+      #                     does not fail if no certificate is sent. 
+      #                     If a certificate is sent it is required to be valid.
+      #  - require-verify:  The server requires the client to send a valid certificate.
+      #
+      # if no ca-file is present, `client-auth` defaults to ""`
+      # if a ca-file is set, `client-auth` defaults to "require-verify"`
+      client-auth: ""
     # string, a GoTemplate that allow for the customization of the target field in Prefix.Target.
     # it applies only if the returned Prefix.Target is empty.
     # if left empty, it defaults to:

--- a/docs/user_guide/outputs/gnmi_output.md
+++ b/docs/user_guide/outputs/gnmi_output.md
@@ -18,6 +18,7 @@ outputs:
     max-subscriptions: 64
     # maximum number of ongoing Get/Set RPCs.
     max-unary-rpc: 64
+    # tls config
     tls:
       # string, path to the CA certificate file,
       # this certificate is used to verify the clients certificates.
@@ -30,8 +31,8 @@ outputs:
       #  - request:         The server requests a certificate from the client but does not 
       #                     require the client to send a certificate. 
       #                     If the server sends a certificate, it is not required to be valid.
-      #  - require:         The server requires the client to send a certificate and fails if 
-      #                     the client certificate is not valid.
+      #  - require:         The server requires the client to send a certificate and does not 
+      #                     fail if the client certificate is not valid.
       #  - verify-if-given: The server requests a certificate, 
       #                     does not fail if no certificate is sent. 
       #                     If a certificate is sent it is required to be valid.

--- a/docs/user_guide/outputs/prometheus_output.md
+++ b/docs/user_guide/outputs/prometheus_output.md
@@ -23,22 +23,28 @@ outputs:
     export-timestamps: false 
     # a boolean, enables setting string type values as prometheus metric labels.
     strings-as-labels: false
-    # tls config
     tls:
-      # string, path to the CA certificate file,      # string, path to the CA certificate file,
-      # this will be used to verify the clients certificates when `skip-verify` is false
+      # string, path to the CA certificate file,
+      # this certificate is used to verify the clients certificates.
       ca-file:
       # string, server certificate file.
-      # if both `cert-file` and `key-file` are empty, and `skip-verify` is true or `ca-file` is set, 
-      # the server will run with self signed certificates.
       cert-file:
       # string, server key file.
-      # if both `cert-file` and `key-file` are empty, and `skip-verify` is true or `ca-file` is set, 
-      # the server will run with self signed certificates.
       key-file:
-      # boolean, if true, the gNMI server will run in secure mode 
-      # but will not verify the client certificate against the available certificate chain.
-      skip-verify: false
+      # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
+      #  - request:         The server requests a certificate from the client but does not 
+      #                     require the client to send a certificate. 
+      #                     If the server sends a certificate, it is not required to be valid.
+      #  - require:         The server requires the client to send a certificate and fails if 
+      #                     the client certificate is not valid.
+      #  - verify-if-given: The server requests a certificate, 
+      #                     does not fail if no certificate is sent. 
+      #                     If a certificate is sent it is required to be valid.
+      #  - require-verify:  The server requires the client to send a valid certificate.
+      #
+      # if no ca-file is present, `client-auth` defaults to ""`
+      # if a ca-file is set, `client-auth` defaults to "require-verify"`
+      client-auth: ""
     # see https://gnmic.openconfig.net/user_guide/caching/, 
     # if enabled, the received gNMI notifications are stored in a cache.
     # the prometheus metrics are generated at the time a prometheus server sends scrape request.

--- a/docs/user_guide/outputs/prometheus_output.md
+++ b/docs/user_guide/outputs/prometheus_output.md
@@ -35,7 +35,7 @@ outputs:
       # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
       #  - request:         The server requests a certificate from the client but does not 
       #                     require the client to send a certificate. 
-      #                     If the server sends a certificate, it is not required to be valid.
+      #                     If the client sends a certificate, it is not required to be valid.
       #  - require:         The server requires the client to send a certificate and does not 
       #                     fail if the client certificate is not valid.
       #  - verify-if-given: The server requests a certificate, 

--- a/docs/user_guide/outputs/prometheus_output.md
+++ b/docs/user_guide/outputs/prometheus_output.md
@@ -23,6 +23,7 @@ outputs:
     export-timestamps: false 
     # a boolean, enables setting string type values as prometheus metric labels.
     strings-as-labels: false
+    # tls config
     tls:
       # string, path to the CA certificate file,
       # this certificate is used to verify the clients certificates.
@@ -35,8 +36,8 @@ outputs:
       #  - request:         The server requests a certificate from the client but does not 
       #                     require the client to send a certificate. 
       #                     If the server sends a certificate, it is not required to be valid.
-      #  - require:         The server requires the client to send a certificate and fails if 
-      #                     the client certificate is not valid.
+      #  - require:         The server requires the client to send a certificate and does not 
+      #                     fail if the client certificate is not valid.
       #  - verify-if-given: The server requests a certificate, 
       #                     does not fail if no certificate is sent. 
       #                     If a certificate is sent it is required to be valid.

--- a/docs/user_guide/tunnel_server.md
+++ b/docs/user_guide/tunnel_server.md
@@ -108,7 +108,7 @@ tunnel-server:
     # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
     #  - request:         The server requests a certificate from the client but does not 
     #                     require the client to send a certificate. 
-    #                     If the server sends a certificate, it is not required to be valid.
+    #                     If the client sends a certificate, it is not required to be valid.
     #  - require:         The server requires the client to send a certificate and does not 
     #                     fail if the client certificate is not valid.
     #  - verify-if-given: The server requests a certificate, 

--- a/docs/user_guide/tunnel_server.md
+++ b/docs/user_guide/tunnel_server.md
@@ -96,6 +96,7 @@ Similarly, a stream subscription will be stopped when a target deregisters from 
 tunnel-server:
   # the address the tunnel server will listen to
   address:
+  # tls config
   tls:
     # string, path to the CA certificate file,
     # this certificate is used to verify the clients certificates.
@@ -108,8 +109,8 @@ tunnel-server:
     #  - request:         The server requests a certificate from the client but does not 
     #                     require the client to send a certificate. 
     #                     If the server sends a certificate, it is not required to be valid.
-    #  - require:         The server requires the client to send a certificate and fails if 
-    #                     the client certificate is not valid.
+    #  - require:         The server requires the client to send a certificate and does not 
+    #                     fail if the client certificate is not valid.
     #  - verify-if-given: The server requests a certificate, 
     #                     does not fail if no certificate is sent. 
     #                     If a certificate is sent it is required to be valid.

--- a/docs/user_guide/tunnel_server.md
+++ b/docs/user_guide/tunnel_server.md
@@ -96,14 +96,28 @@ Similarly, a stream subscription will be stopped when a target deregisters from 
 tunnel-server:
   # the address the tunnel server will listen to
   address:
-  # if true, the server will not verify the client's certificates
-  skip-verify: false
-  # path to the CA certificate file to be used, irrelevant if `skip-verify` is true
-  ca-file: 
-  # path to the server certificate file
-  cert-file:
-  # path to the server key file
-  key-file:
+  tls:
+    # string, path to the CA certificate file,
+    # this certificate is used to verify the clients certificates.
+    ca-file:
+    # string, server certificate file.
+    cert-file:
+    # string, server key file.
+    key-file:
+    # string, one of `"", "request", "require", "verify-if-given", or "require-verify" 
+    #  - request:         The server requests a certificate from the client but does not 
+    #                     require the client to send a certificate. 
+    #                     If the server sends a certificate, it is not required to be valid.
+    #  - require:         The server requires the client to send a certificate and fails if 
+    #                     the client certificate is not valid.
+    #  - verify-if-given: The server requests a certificate, 
+    #                     does not fail if no certificate is sent. 
+    #                     If a certificate is sent it is required to be valid.
+    #  - require-verify:  The server requires the client to send a valid certificate.
+    #
+    # if no ca-file is present, `client-auth` defaults to ""`
+    # if a ca-file is set, `client-auth` defaults to "require-verify"`
+    client-auth: ""
   # the wait time before triggering unary RPCs or subscribe poll/once
   target-wait-time: 2s
   # enables the collection of Prometheus gRPC server metrics

--- a/inputs/kafka_input/kafka_input.go
+++ b/inputs/kafka_input/kafka_input.go
@@ -358,6 +358,7 @@ func (k *KafkaInput) createConfig() (*sarama.Config, error) {
 			k.Cfg.TLS.CaFile,
 			k.Cfg.TLS.CertFile,
 			k.Cfg.TLS.KeyFile,
+			"",
 			k.Cfg.TLS.SkipVerify,
 			false)
 		if err != nil {

--- a/inputs/nats_input/nats_input.go
+++ b/inputs/nats_input/nats_input.go
@@ -315,7 +315,7 @@ func (n *NatsInput) createNATSConn(c *Config) (*nats.Conn, error) {
 	}
 	if n.Cfg.TLS != nil {
 		tlsConfig, err := utils.NewTLSConfig(
-			n.Cfg.TLS.CaFile, n.Cfg.TLS.CertFile, n.Cfg.TLS.KeyFile, n.Cfg.TLS.SkipVerify,
+			n.Cfg.TLS.CaFile, n.Cfg.TLS.CertFile, n.Cfg.TLS.KeyFile, "", n.Cfg.TLS.SkipVerify,
 			false)
 		if err != nil {
 			return nil, err

--- a/inputs/stan_input/stan_input.go
+++ b/inputs/stan_input/stan_input.go
@@ -246,8 +246,11 @@ func (s *StanInput) createSTANConn(c *Config) (stan.Conn, error) {
 	}
 	if s.Cfg.TLS != nil {
 		tlsConfig, err := utils.NewTLSConfig(
-			s.Cfg.TLS.CaFile, s.Cfg.TLS.CertFile, s.Cfg.TLS.KeyFile, s.Cfg.TLS.SkipVerify,
-			false)
+			s.Cfg.TLS.CaFile, s.Cfg.TLS.CertFile, s.Cfg.TLS.KeyFile,
+			"",
+			s.Cfg.TLS.SkipVerify,
+			false,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/outputs/gnmi_output/gnmi_output.go
+++ b/outputs/gnmi_output/gnmi_output.go
@@ -251,9 +251,12 @@ func (g *gNMIOutput) serverOpts() ([]grpc.ServerOption, error) {
 
 	tlscfg, err := utils.NewTLSConfig(
 		g.cfg.TLS.CaFile,
-		g.cfg.TLS.CertFile, g.cfg.TLS.KeyFile,
-		g.cfg.TLS.SkipVerify,
-		true)
+		g.cfg.TLS.CertFile,
+		g.cfg.TLS.KeyFile,
+		g.cfg.TLS.ClientAuth,
+		false,
+		true,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/outputs/influxdb_output/influxdb_output.go
+++ b/outputs/influxdb_output/influxdb_output.go
@@ -413,7 +413,7 @@ func (i *influxDBOutput) clientOpts() (*influxdb2.Options, error) {
 		SetFlushInterval(uint(i.Cfg.FlushTimer.Milliseconds()))
 	if i.Cfg.TLS != nil {
 		tlsConfig, err := utils.NewTLSConfig(
-			i.Cfg.TLS.CaFile, i.Cfg.TLS.CertFile, i.Cfg.TLS.KeyFile, i.Cfg.TLS.SkipVerify,
+			i.Cfg.TLS.CaFile, i.Cfg.TLS.CertFile, i.Cfg.TLS.KeyFile, "", i.Cfg.TLS.SkipVerify,
 			false)
 		if err != nil {
 			return nil, err

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -409,6 +409,7 @@ func (k *kafkaOutput) createConfig() (*sarama.Config, error) {
 			k.Cfg.TLS.CaFile,
 			k.Cfg.TLS.CertFile,
 			k.Cfg.TLS.KeyFile,
+			"",
 			k.Cfg.TLS.SkipVerify,
 			false)
 		if err != nil {

--- a/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -500,7 +500,11 @@ func (n *jetstreamOutput) createNATSConn(c *config) (*nats.Conn, error) {
 	}
 	if n.Cfg.TLS != nil {
 		tlsConfig, err := utils.NewTLSConfig(
-			n.Cfg.TLS.CaFile, n.Cfg.TLS.CertFile, n.Cfg.TLS.KeyFile, n.Cfg.TLS.SkipVerify,
+			n.Cfg.TLS.CaFile,
+			n.Cfg.TLS.CertFile,
+			n.Cfg.TLS.KeyFile,
+			"",
+			n.Cfg.TLS.SkipVerify,
 			false)
 		if err != nil {
 			return nil, err

--- a/outputs/nats_outputs/nats/nats_output.go
+++ b/outputs/nats_outputs/nats/nats_output.go
@@ -286,7 +286,11 @@ func (n *NatsOutput) createNATSConn(c *Config) (*nats.Conn, error) {
 	}
 	if n.Cfg.TLS != nil {
 		tlsConfig, err := utils.NewTLSConfig(
-			n.Cfg.TLS.CaFile, n.Cfg.TLS.CertFile, n.Cfg.TLS.KeyFile, n.Cfg.TLS.SkipVerify,
+			n.Cfg.TLS.CaFile,
+			n.Cfg.TLS.CertFile,
+			n.Cfg.TLS.KeyFile,
+			"",
+			n.Cfg.TLS.SkipVerify,
 			false)
 		if err != nil {
 			return nil, err

--- a/outputs/prometheus_output/prometheus_output/prometheus_output.go
+++ b/outputs/prometheus_output/prometheus_output/prometheus_output.go
@@ -241,7 +241,14 @@ func (p *prometheusOutput) Init(ctx context.Context, name string, cfg map[string
 		listener, err = net.Listen("tcp", p.Cfg.Listen)
 	default:
 		var tlsConfig *tls.Config
-		tlsConfig, err = utils.NewTLSConfig(p.Cfg.TLS.CaFile, p.Cfg.TLS.CertFile, p.Cfg.TLS.KeyFile, p.Cfg.TLS.SkipVerify, true)
+		tlsConfig, err = utils.NewTLSConfig(
+			p.Cfg.TLS.CaFile,
+			p.Cfg.TLS.CertFile,
+			p.Cfg.TLS.KeyFile,
+			p.Cfg.TLS.ClientAuth,
+			true,
+			true,
+		)
 		if err != nil {
 			return err
 		}

--- a/outputs/prometheus_output/prometheus_write_output/prometheus_write_client.go
+++ b/outputs/prometheus_output/prometheus_write_output/prometheus_write_client.go
@@ -33,8 +33,10 @@ func (p *promWriteOutput) createHTTPClient() error {
 			p.Cfg.TLS.CaFile,
 			p.Cfg.TLS.CertFile,
 			p.Cfg.TLS.KeyFile,
+			"",
 			p.Cfg.TLS.SkipVerify,
-			false)
+			false,
+		)
 		if err != nil {
 			return err
 		}

--- a/types/target.go
+++ b/types/target.go
@@ -82,7 +82,7 @@ func (tc *TargetConfig) NewTLSConfig() (*tls.Config, error) {
 	if tc.TLSKey != nil {
 		key = *tc.TLSKey
 	}
-	tlsConfig, err := utils.NewTLSConfig(ca, cert, key, *tc.SkipVerify, false)
+	tlsConfig, err := utils.NewTLSConfig(ca, cert, key, "", *tc.SkipVerify, false)
 	if err != nil {
 		return nil, err
 	}

--- a/types/tls.go
+++ b/types/tls.go
@@ -1,8 +1,27 @@
 package types
 
+import "fmt"
+
 type TLSConfig struct {
 	CaFile     string `mapstructure:"ca-file,omitempty"`
 	KeyFile    string `mapstructure:"key-file,omitempty"`
 	CertFile   string `mapstructure:"cert-file,omitempty"`
 	SkipVerify bool   `mapstructure:"skip-verify,omitempty"`
+	ClientAuth string `mapstructure:"client-auth,omitempty"`
+}
+
+func (t *TLSConfig) Validate() error {
+	if t == nil {
+		return nil
+	}
+	switch t.ClientAuth {
+	case "", "request":
+	case "require", "verify-if-given", "require-verify":
+		if t.CaFile == "" {
+			return fmt.Errorf("ca-file is required when `client-auth` is %q", t.ClientAuth)
+		}
+	default:
+		return fmt.Errorf("unknown `client-auth` mode: %s", t.ClientAuth)
+	}
+	return nil
 }


### PR DESCRIPTION
This PR adds a configuration attribute to control when and how a server requests and validates a client TLS certificate.
This applies to the api-server, the gnmi-server, the tunnel server and the prometheus output.
The new attribute name is `client-auth` and is set under the TLS config of each of the servers specified above.
`client-auth` has 4 possible values:
- request:
     The server requests a certificate from the client but does not require the client to send a certificate. 
     If the server sends a certificate, it is not required to be valid.
- require: 
     The server requires the client to send a certificate and does not fail if the client certificate is not valid.
- verify-if-given: 
     The server requests a certificate, does not fail if no certificate is sent. If a certificate is sent it is required to be valid.
- require-verify:  
     The server requires the client to send a valid certificate.
