### PR TITLE
Change ipv4_subnet to ipv4-subnet

### DIFF
--- a/examples/deployments/1.single-instance/10.prometheus-with-cache/containerlab/prometheus.clab.yaml
+++ b/examples/deployments/1.single-instance/10.prometheus-with-cache/containerlab/prometheus.clab.yaml
@@ -9,7 +9,7 @@
 name: lab110
 
 mgmt:
-  ipv4_subnet: 192.168.1.0/24
+  ipv4-subnet: 192.168.1.0/24
 
 topology:
   defaults:
@@ -26,7 +26,7 @@ topology:
     leaf2:
     leaf3:
     leaf4:
-    
+
     gnmic:
       kind: linux
       image: gnmic:0.0.0
@@ -35,16 +35,16 @@ topology:
         - /var/run/docker.sock:/var/run/docker.sock
       ports:
         - 7890:7890
-      cmd: '--config /app/gnmic.yaml --log subscribe'
-    
+      cmd: "--config /app/gnmic.yaml --log subscribe"
+
     consul-agent:
       kind: linux
       image: consul:latest
       ports:
         - 8500:8500
         - 8600:8600/udp
-      cmd: 'agent -server -ui -bind=127.0.0.1 -node=server-1 -bootstrap-expect=1 -client=0.0.0.0'
-    
+      cmd: "agent -server -ui -bind=127.0.0.1 -node=server-1 -bootstrap-expect=1 -client=0.0.0.0"
+
     prometheus:
       kind: linux
       image: prom/prometheus:latest
@@ -86,4 +86,3 @@ topology:
     - endpoints: ["spine2:e1-2", "leaf2:e1-2"]
     - endpoints: ["spine2:e1-3", "leaf3:e1-2"]
     - endpoints: ["spine2:e1-4", "leaf4:e1-2"]
-

--- a/examples/deployments/1.single-instance/4.prometheus-output/containerlab/prometheus.clab.yaml
+++ b/examples/deployments/1.single-instance/4.prometheus-output/containerlab/prometheus.clab.yaml
@@ -9,7 +9,7 @@
 name: lab14
 
 mgmt:
-  ipv4_subnet: 192.168.1.0/24
+  ipv4-subnet: 192.168.1.0/24
 
 topology:
   defaults:
@@ -33,16 +33,16 @@ topology:
       binds:
         - ./gnmic.yaml:/app/gnmic.yaml:ro
         - /var/run/docker.sock:/var/run/docker.sock
-      cmd: '--config /app/gnmic.yaml --log subscribe'
-    
+      cmd: "--config /app/gnmic.yaml --log subscribe"
+
     consul-agent:
       kind: linux
       image: consul:latest
       ports:
         - 8500:8500
         - 8600:8600/udp
-      cmd: 'agent -server -ui -bind=127.0.0.1 -node=server-1 -bootstrap-expect=1 -client=0.0.0.0'
-    
+      cmd: "agent -server -ui -bind=127.0.0.1 -node=server-1 -bootstrap-expect=1 -client=0.0.0.0"
+
     prometheus:
       kind: linux
       image: prom/prometheus:latest
@@ -65,7 +65,7 @@ topology:
         #- grafana/dashboards/:/var/lib/grafana/dashboards
       ports:
         - 3000:3000
-        
+
   links:
     # spine1 links
     - endpoints: ["spine1:e1-1", "leaf1:e1-1"]
@@ -77,4 +77,3 @@ topology:
     - endpoints: ["spine2:e1-2", "leaf2:e1-2"]
     - endpoints: ["spine2:e1-3", "leaf3:e1-2"]
     - endpoints: ["spine2:e1-4", "leaf4:e1-2"]
-

--- a/examples/deployments/1.single-instance/6.prometheus-write-output/containerlab/prom_write.clab.yaml
+++ b/examples/deployments/1.single-instance/6.prometheus-write-output/containerlab/prom_write.clab.yaml
@@ -10,7 +10,7 @@ name: lab16
 
 mgmt:
   bridge: prom
-  ipv4_subnet: 172.19.19.0/24
+  ipv4-subnet: 172.19.19.0/24
 
 topology:
   defaults:
@@ -28,23 +28,22 @@ topology:
     leaf3:
     leaf4:
 
-
     gnmic:
       kind: linux
       image: ghcr.io/openconfig/gnmic:latest
       binds:
         - ./gnmic.yaml:/app/gnmic.yaml:ro
         - /var/run/docker.sock:/var/run/docker.sock
-      cmd: '--config /app/gnmic.yaml --log subscribe'
-      
+      cmd: "--config /app/gnmic.yaml --log subscribe"
+
     consul-agent:
       kind: linux
       image: consul:latest
       ports:
         - 8500:8500
         - 8600:8600/udp
-      cmd: 'agent -server -ui -bind=127.0.0.1 -node=server-1 -bootstrap-expect=1 -client=0.0.0.0'
-      
+      cmd: "agent -server -ui -bind=127.0.0.1 -node=server-1 -bootstrap-expect=1 -client=0.0.0.0"
+
     prometheus:
       kind: linux
       image: prom/prometheus:latest
@@ -68,7 +67,7 @@ topology:
         # - grafana/dashboards/:/var/lib/grafana/dashboards
       ports:
         - 3000:3000
-                 
+
   links:
     # spine1 links
     - endpoints: ["spine1:e1-1", "leaf1:e1-1"]
@@ -80,4 +79,3 @@ topology:
     - endpoints: ["spine2:e1-2", "leaf2:e1-2"]
     - endpoints: ["spine2:e1-3", "leaf3:e1-2"]
     - endpoints: ["spine2:e1-4", "leaf4:e1-2"]
-

--- a/examples/deployments/1.single-instance/7.cortex-output/containerlab/cortexmetrics.clab.yaml
+++ b/examples/deployments/1.single-instance/7.cortex-output/containerlab/cortexmetrics.clab.yaml
@@ -10,7 +10,7 @@ name: lab17
 
 mgmt:
   bridge: cortex
-  ipv4_subnet: 172.19.19.0/24
+  ipv4-subnet: 172.19.19.0/24
 
 topology:
   defaults:
@@ -34,8 +34,8 @@ topology:
       binds:
         - ./gnmic.yaml:/app/gnmic.yaml:ro
         - /var/run/docker.sock:/var/run/docker.sock
-      cmd: '--config /app/gnmic.yaml --log subscribe'
-    
+      cmd: "--config /app/gnmic.yaml --log subscribe"
+
     cortex:
       kind: linux
       image: quay.io/cortexproject/cortex:latest
@@ -45,7 +45,7 @@ topology:
         - ./cortex/single-process-config-blocks.yaml:/etc/single-process-config-blocks.yaml:ro
       cmd: |
         -config.file=/etc/single-process-config-blocks.yaml
-    
+
     grafana:
       kind: linux
       image: grafana/grafana:latest
@@ -54,7 +54,7 @@ topology:
         # - grafana/dashboards/:/var/lib/grafana/dashboards
       ports:
         - 3000:3000
-                 
+
   links:
     # spine1 links
     - endpoints: ["spine1:e1-1", "leaf1:e1-1"]
@@ -66,4 +66,3 @@ topology:
     - endpoints: ["spine2:e1-2", "leaf2:e1-2"]
     - endpoints: ["spine2:e1-3", "leaf3:e1-2"]
     - endpoints: ["spine2:e1-4", "leaf4:e1-2"]
-

--- a/examples/deployments/1.single-instance/8.victoria-metrics-output/containerlab/victoriametrics.clab.yaml
+++ b/examples/deployments/1.single-instance/8.victoria-metrics-output/containerlab/victoriametrics.clab.yaml
@@ -10,7 +10,7 @@ name: lab18
 
 mgmt:
   bridge: victoria
-  ipv4_subnet: 172.19.19.0/24
+  ipv4-subnet: 172.19.19.0/24
 
 topology:
   defaults:
@@ -34,14 +34,14 @@ topology:
       binds:
         - ./gnmic.yaml:/app/gnmic.yaml:ro
         - /var/run/docker.sock:/var/run/docker.sock
-      cmd: '--config /app/gnmic.yaml --log subscribe'
-    
+      cmd: "--config /app/gnmic.yaml --log subscribe"
+
     victoria:
       kind: linux
       image: victoriametrics/victoria-metrics:latest
       ports:
         - 8428:8428
-    
+
     grafana:
       kind: linux
       image: grafana/grafana:latest
@@ -50,7 +50,7 @@ topology:
         # - grafana/dashboards/:/var/lib/grafana/dashboards
       ports:
         - 3000:3000
-                 
+
   links:
     # spine1 links
     - endpoints: ["spine1:e1-1", "leaf1:e1-1"]
@@ -62,4 +62,3 @@ topology:
     - endpoints: ["spine2:e1-2", "leaf2:e1-2"]
     - endpoints: ["spine2:e1-3", "leaf3:e1-2"]
     - endpoints: ["spine2:e1-4", "leaf4:e1-2"]
-


### PR DESCRIPTION
Hi @karimra 
In clab 0.41.0 a breaking change was introduced - https://containerlab.dev/rn/0.41/#parameters-renaming

Across gnmic code-base only ipv4_subnet field was used, this PR changes it to `ipv4-subnet`. Other modifications are done by YAML formatter...