### PR TITLE
Support health check API

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -288,7 +288,14 @@ func (a *App) handleClusteringGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleHealthzGet(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("I'm healthy!\n"))
+	s := map[string]string{"status": "healthy",}
+	b, err := json.Marshal(s)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(APIErrors{Errors: []string{err.Error()}})
+		return
+	}
+	w.Write(b)
 }
 
 func (a *App) handleClusteringMembersGet(w http.ResponseWriter, r *http.Request) {

--- a/app/api.go
+++ b/app/api.go
@@ -287,6 +287,10 @@ func (a *App) handleClusteringGet(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
+func (a *App) handleHealthzGet(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("I'm healthy!\n"))
+}
+
 func (a *App) handleClusteringMembersGet(w http.ResponseWriter, r *http.Request) {
 	if a.Config.Clustering == nil {
 		return

--- a/app/routes.go
+++ b/app/routes.go
@@ -19,7 +19,7 @@ func (a *App) routes() {
 	a.clusterRoutes(apiV1)
 	a.configRoutes(apiV1)
 	a.targetRoutes(apiV1)
-
+	a.healthRoutes(apiV1)
 }
 
 func (a *App) clusterRoutes(r *mux.Router) {
@@ -58,4 +58,8 @@ func (a *App) targetRoutes(r *mux.Router) {
 	r.HandleFunc("/targets/{id}", a.handleTargetsGet).Methods(http.MethodGet)
 	r.HandleFunc("/targets/{id}", a.handleTargetsPost).Methods(http.MethodPost)
 	r.HandleFunc("/targets/{id}", a.handleTargetsDelete).Methods(http.MethodDelete)
+}
+
+func (a *App) healthRoutes(r *mux.Router) {
+	r.HandleFunc("/healthz", a.handleHealthzGet).Methods(http.MethodGet)
 }


### PR DESCRIPTION
gnmic API server currently doesn’t include support for the http health check requests in k8s. This PR addresses this issue by exposing a health check endpoint and adding a handler for http health check requests.