### PR TITLE
Add logs on starlark failed processing with debug enabled

### DIFF
--- a/formatters/event_starlark/event_starlark.go
+++ b/formatters/event_starlark/event_starlark.go
@@ -149,7 +149,11 @@ func (p *starlarkProc) Apply(es ...*formatters.EventMsg) []*formatters.EventMsg 
 	}
 	r, err := starlark.Call(p.thread, p.applyFn, sevs, nil)
 	if err != nil {
-		p.logger.Printf("failed to run script: %v", err)
+		if p.Debug {
+			p.logger.Printf("failed to run script with input %v: %v", sevs, err)
+		} else {
+			p.logger.Printf("failed to run script: %v", err)
+		}
 		return es
 	}
 	if p.Debug {


### PR DESCRIPTION
When the starlark processor fails, it can be hard
to know where the issue is comming from
since multiple processing can happen at the same time the logs may be interleaved.

Adding the value that causes the error enables easier troubleshooting of the starlark code