### PR TITLE
Implement WriteEvent on file output so that it can be used by 'inputs' components

### DIFF
--- a/outputs/output.go
+++ b/outputs/output.go
@@ -140,11 +140,11 @@ var (
 		template.New("target-template").
 			Funcs(TemplateFuncs).
 			Parse(defaultTargetTemplateString))
-)
 
-var TemplateFuncs = template.FuncMap{
-	"host": utils.GetHost,
-}
+	TemplateFuncs = template.FuncMap{
+		"host": utils.GetHost,
+	}
+)
 
 const (
 	defaultTargetTemplateString = `


### PR DESCRIPTION
WriteEvent is used by the "inputs" components to output their data.

Without this implementation,
things like
```
inputs:
  nats-replay:
    type: nats
    address: nats-server:4222
    subject: replay
    debug: true
    buffer-size: 1
    outputs:
      - file-dump

outputs:
  file-dump:
    type: file
    format: event
    debug: true
    split-events: true
    filename: /output.json
    concurrency-limit: 1
```

wont actually output anything to the file.