### PR TITLE
Fix bug corrupting Prometheus timeseries __name__ label

### DIFF
--- a/outputs/prometheus_output/prometheus_common.go
+++ b/outputs/prometheus_output/prometheus_common.go
@@ -143,14 +143,17 @@ func (m *MetricBuilder) TimeSeriesFromEvent(ev *formatters.EventMsg) []*NamedTim
 			fv = 1.0
 		}
 		tsName := m.MetricName(ev.Name, k)
+		tsLabelsWithName := make([]prompb.Label, 0, len(tsLabels)+1)
+		tsLabelsWithName = append(tsLabelsWithName, tsLabels...)
+		tsLabelsWithName = append(tsLabelsWithName,
+			prompb.Label{
+				Name:  labels.MetricName,
+				Value: tsName,
+			})
 		nts := &NamedTimeSeries{
 			Name: tsName,
 			TS: &prompb.TimeSeries{
-				Labels: append(tsLabels,
-					prompb.Label{
-						Name:  labels.MetricName,
-						Value: m.MetricName(ev.Name, k),
-					}),
+				Labels: tsLabelsWithName,
 				Samples: []prompb.Sample{
 					{
 						Value:     fv,

--- a/outputs/prometheus_output/prometheus_common_test.go
+++ b/outputs/prometheus_output/prometheus_common_test.go
@@ -10,6 +10,9 @@ package prometheus_output
 
 import (
 	"testing"
+
+	"github.com/openconfig/gnmic/formatters"
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 var metricNameSet = map[string]struct {
@@ -67,6 +70,31 @@ var metricNameSet = map[string]struct {
 		valueName: "value-name2",
 		want:      "sub_name_value_name2",
 	},
+}
+
+func TestTimeSeriesFromEvent(t *testing.T) {
+	metricBuilder := &MetricBuilder{StringsAsLabels: true}
+	event := &formatters.EventMsg{
+		Name:      "eventName",
+		Timestamp: 12345,
+		Tags: map[string]string{
+			"tagName": "tagVal",
+		},
+		Values: map[string]interface{}{
+			"strName1": "strVal1",
+			"strName2": "strVal2",
+			"intName1": 1,
+			"intName2": 2,
+		},
+		Deletes: []string{},
+	}
+	for _, nts := range metricBuilder.TimeSeriesFromEvent(event) {
+		for _, label := range nts.TS.Labels {
+			if label.Name == labels.MetricName && label.Value != nts.Name {
+				t.Errorf("__name__ label wrong, expected '%s', got '%s'", nts.Name, label.Value)
+			}
+		}
+	}
 }
 
 func TestMetricName(t *testing.T) {


### PR DESCRIPTION
I have also been experiencing issues like the ones described in #259 and #169 where Prometheus outputs are sometimes dropped or incorrect.

I believe this is due to a bug with how the `__name__` label gets added to the list of labels when constructing a timeseries. The `__name__` label is appended without a copy or assignment, meaning it will overwrite whatever was appended previously, so long as there is space remaining in the array. If GetLabels returns a slice with length == capacity, the bug does not seem to occur because append forces a copy.

A consequence of this bug is that a value can get written to the wrong timeseries.

I've written a test that reproduces this behavior. The test fails without the fix and passes with the fix.

I don't write a lot of Go, so let me know if I've gotten anything wrong here or there's a better way to solve this. I stumbled upon this issue while investigating incorrect gNMIC Prometheus writes that I was observing.