### PR TITLE
Make the output/input fail when processor fails

### DIFF
--- a/pkg/app/inputs.go
+++ b/pkg/app/inputs.go
@@ -29,7 +29,12 @@ func (a *App) InitInput(ctx context.Context, name string, tcs map[string]*types.
 				go func() {
 					err := in.Start(ctx, name, cfg,
 						inputs.WithLogger(a.Logger),
-						inputs.WithEventProcessors(a.Config.Processors, a.Logger, a.Config.Targets),
+						inputs.WithEventProcessors(
+							a.Config.Processors,
+							a.Logger,
+							a.Config.Targets,
+							a.Config.Actions,
+						),
 						inputs.WithName(a.Config.InstanceName),
 						inputs.WithOutputs(a.Outputs),
 					)

--- a/pkg/inputs/input.go
+++ b/pkg/inputs/input.go
@@ -10,10 +10,8 @@ package inputs
 
 import (
 	"context"
-	"fmt"
 	"log"
 
-	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/outputs"
 	"github.com/openconfig/gnmic/pkg/types"
 )
@@ -23,7 +21,7 @@ type Input interface {
 	Close() error
 	SetLogger(*log.Logger)
 	SetOutputs(map[string]outputs.Output)
-	SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig) error
+	SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig, map[string]map[string]interface{}) error
 	SetName(string)
 }
 
@@ -64,36 +62,8 @@ func WithName(name string) Option {
 	}
 }
 
-func WithEventProcessors(eps map[string]map[string]interface{}, log *log.Logger, tcs map[string]*types.TargetConfig) Option {
+func WithEventProcessors(eps map[string]map[string]interface{}, log *log.Logger, tcs map[string]*types.TargetConfig, acts map[string]map[string]interface{}) Option {
 	return func(i Input) error {
-		return i.SetEventProcessors(eps, log, tcs)
+		return i.SetEventProcessors(eps, log, tcs, acts)
 	}
-}
-
-func MakeEventProcessors(
-	logger *log.Logger,
-	processorNames []string,
-	ps map[string]map[string]interface{},
-	tcs map[string]*types.TargetConfig,
-) ([]formatters.EventProcessor, error) {
-	evps := make([]formatters.EventProcessor, len(processorNames))
-	for i, epName := range processorNames {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType], formatters.WithLogger(logger), formatters.WithTargets(tcs))
-				if err != nil {
-					return nil, fmt.Errorf("failed initializing event processor %q of type=%q: %w", epName, epType, err)
-				}
-				evps[i] = ep
-				logger.Printf("added event processor %q of type=%q to kafka input", epName, epType)
-			}
-		}
-	}
-	return evps, nil
 }

--- a/pkg/inputs/input.go
+++ b/pkg/inputs/input.go
@@ -10,8 +10,10 @@ package inputs
 
 import (
 	"context"
+	"fmt"
 	"log"
 
+	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/outputs"
 	"github.com/openconfig/gnmic/pkg/types"
 )
@@ -21,7 +23,7 @@ type Input interface {
 	Close() error
 	SetLogger(*log.Logger)
 	SetOutputs(map[string]outputs.Output)
-	SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig)
+	SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig) error
 	SetName(string)
 }
 
@@ -39,28 +41,59 @@ func Register(name string, initFn Initializer) {
 	Inputs[name] = initFn
 }
 
-type Option func(Input)
+type Option func(Input) error
 
 func WithLogger(logger *log.Logger) Option {
-	return func(i Input) {
+	return func(i Input) error {
 		i.SetLogger(logger)
+		return nil
 	}
 }
 
 func WithOutputs(outs map[string]outputs.Output) Option {
-	return func(i Input) {
+	return func(i Input) error {
 		i.SetOutputs(outs)
+		return nil
 	}
 }
 
 func WithName(name string) Option {
-	return func(i Input) {
+	return func(i Input) error {
 		i.SetName(name)
+		return nil
 	}
 }
 
 func WithEventProcessors(eps map[string]map[string]interface{}, log *log.Logger, tcs map[string]*types.TargetConfig) Option {
-	return func(i Input) {
-		i.SetEventProcessors(eps, log, tcs)
+	return func(i Input) error {
+		return i.SetEventProcessors(eps, log, tcs)
 	}
+}
+
+func MakeEventProcessors(
+	logger *log.Logger,
+	processorNames []string,
+	ps map[string]map[string]interface{},
+	tcs map[string]*types.TargetConfig,
+) ([]formatters.EventProcessor, error) {
+	evps := make([]formatters.EventProcessor, len(processorNames))
+	for i, epName := range processorNames {
+		if epCfg, ok := ps[epName]; ok {
+			epType := ""
+			for k := range epCfg {
+				epType = k
+				break
+			}
+			if in, ok := formatters.EventProcessors[epType]; ok {
+				ep := in()
+				err := ep.Init(epCfg[epType], formatters.WithLogger(logger), formatters.WithTargets(tcs))
+				if err != nil {
+					return nil, fmt.Errorf("failed initializing event processor %q of type=%q: %w", epName, epType, err)
+				}
+				evps[i] = ep
+				logger.Printf("added event processor %q of type=%q to kafka input", epName, epType)
+			}
+		}
+	}
+	return evps, nil
 }

--- a/pkg/inputs/kafka_input/kafka_input.go
+++ b/pkg/inputs/kafka_input/kafka_input.go
@@ -100,7 +100,9 @@ func (k *KafkaInput) Start(ctx context.Context, name string, cfg map[string]inte
 		k.Cfg.Name = name
 	}
 	for _, opt := range opts {
-		opt(k)
+		if err := opt(k); err != nil {
+			return err
+		}
 	}
 	err = k.setDefaults()
 	if err != nil {
@@ -258,26 +260,18 @@ func (k *KafkaInput) SetName(name string) {
 	k.Cfg.Name = sb.String()
 }
 
-func (k *KafkaInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig) {
-	for _, epName := range k.Cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType], formatters.WithLogger(logger), formatters.WithTargets(tcs))
-				if err != nil {
-					k.logger.Printf("failed initializing event processor %q of type=%q: %v", epName, epType, err)
-					continue
-				}
-				k.evps = append(k.evps, ep)
-				k.logger.Printf("added event processor %q of type=%q to kafka input", epName, epType)
-			}
-		}
+func (k *KafkaInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig) error {
+	var err error
+	k.evps, err = inputs.MakeEventProcessors(
+		logger,
+		k.Cfg.EventProcessors,
+		ps,
+		tcs,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 // helper funcs

--- a/pkg/inputs/kafka_input/kafka_input.go
+++ b/pkg/inputs/kafka_input/kafka_input.go
@@ -20,11 +20,10 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/Shopify/sarama"
 	"github.com/damiannolan/sasl/oauthbearer"
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/inputs"
@@ -260,13 +259,14 @@ func (k *KafkaInput) SetName(name string) {
 	k.Cfg.Name = sb.String()
 }
 
-func (k *KafkaInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig) error {
+func (k *KafkaInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig, acts map[string]map[string]interface{}) error {
 	var err error
-	k.evps, err = inputs.MakeEventProcessors(
+	k.evps, err = formatters.MakeEventProcessors(
 		logger,
 		k.Cfg.EventProcessors,
 		ps,
 		tcs,
+		acts,
 	)
 	if err != nil {
 		return err

--- a/pkg/inputs/nats_input/nats_input.go
+++ b/pkg/inputs/nats_input/nats_input.go
@@ -242,13 +242,14 @@ func (n *NatsInput) SetName(name string) {
 	n.Cfg.Name = sb.String()
 }
 
-func (n *NatsInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig) error {
+func (n *NatsInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig, acts map[string]map[string]interface{}) error {
 	var err error
-	n.evps, err = inputs.MakeEventProcessors(
+	n.evps, err = formatters.MakeEventProcessors(
 		logger,
 		n.Cfg.EventProcessors,
 		ps,
 		tcs,
+		acts,
 	)
 	if err != nil {
 		return err

--- a/pkg/inputs/nats_input/nats_input.go
+++ b/pkg/inputs/nats_input/nats_input.go
@@ -91,7 +91,9 @@ func (n *NatsInput) Start(ctx context.Context, name string, cfg map[string]inter
 		n.Cfg.Name = name
 	}
 	for _, opt := range opts {
-		opt(n)
+		if err := opt(n); err != nil {
+			return err
+		}
 	}
 	err = n.setDefaults()
 	if err != nil {
@@ -240,26 +242,18 @@ func (n *NatsInput) SetName(name string) {
 	n.Cfg.Name = sb.String()
 }
 
-func (n *NatsInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig) {
-	for _, epName := range n.Cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType], formatters.WithLogger(logger), formatters.WithTargets(tcs))
-				if err != nil {
-					n.logger.Printf("failed initializing event processor %q of type=%q: %v", epName, epType, err)
-					continue
-				}
-				n.evps = append(n.evps, ep)
-				n.logger.Printf("added event processor %q of type=%q to nats input", epName, epType)
-			}
-		}
+func (n *NatsInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig) error {
+	var err error
+	n.evps, err = inputs.MakeEventProcessors(
+		logger,
+		n.Cfg.EventProcessors,
+		ps,
+		tcs,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 // helper functions

--- a/pkg/inputs/stan_input/stan_input.go
+++ b/pkg/inputs/stan_input/stan_input.go
@@ -19,10 +19,10 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/proto"
-
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/stan.go"
+
 	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/inputs"
 	"github.com/openconfig/gnmic/pkg/outputs"
@@ -179,13 +179,14 @@ func (s *StanInput) SetName(name string) {
 	s.Cfg.Name = sb.String()
 }
 
-func (s *StanInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig) error {
+func (s *StanInput) SetEventProcessors(ps map[string]map[string]interface{}, logger *log.Logger, tcs map[string]*types.TargetConfig, acts map[string]map[string]interface{}) error {
 	var err error
-	s.evps, err = inputs.MakeEventProcessors(
+	s.evps, err = formatters.MakeEventProcessors(
 		logger,
 		s.Cfg.EventProcessors,
 		ps,
 		tcs,
+		acts,
 	)
 	if err != nil {
 		return err

--- a/pkg/outputs/asciigraph_output/asciigraph.go
+++ b/pkg/outputs/asciigraph_output/asciigraph.go
@@ -24,12 +24,11 @@ import (
 	"text/template"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/guptarohit/asciigraph"
 	"github.com/nsf/termbox-go"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/gtemplate"
@@ -136,7 +135,7 @@ func (a *asciigraphOutput) SetEventProcessors(ps map[string]map[string]interface
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	a.evps, err = outputs.MakeEventProcessors(
+	a.evps, err = formatters.MakeEventProcessors(
 		logger,
 		a.cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/file/file_output.go
+++ b/pkg/outputs/file/file_output.go
@@ -93,7 +93,7 @@ func (f *File) SetEventProcessors(ps map[string]map[string]interface{},
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	f.evps, err = outputs.MakeEventProcessors(
+	f.evps, err = formatters.MakeEventProcessors(
 		logger,
 		f.cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/file/file_output.go
+++ b/pkg/outputs/file/file_output.go
@@ -91,34 +91,19 @@ func (f *File) String() string {
 func (f *File) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range f.cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType],
-					formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts),
-				)
-				if err != nil {
-					f.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				f.evps = append(f.evps, ep)
-				f.logger.Printf("added event processor '%s' of type=%s to file output", epName, epType)
-				continue
-			}
-			f.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		f.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	f.evps, err = outputs.MakeEventProcessors(
+		logger,
+		f.cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 func (f *File) SetLogger(logger *log.Logger) {
@@ -138,7 +123,9 @@ func (f *File) Init(ctx context.Context, name string, cfg map[string]interface{}
 	f.logger.SetPrefix(fmt.Sprintf(loggingPrefix, name))
 
 	for _, opt := range opts {
-		opt(f)
+		if err := opt(f); err != nil {
+			return err
+		}
 	}
 	if f.cfg.Format == "proto" {
 		return fmt.Errorf("proto format not supported in output type 'file'")

--- a/pkg/outputs/gnmi_output/gnmi_output.go
+++ b/pkg/outputs/gnmi_output/gnmi_output.go
@@ -83,7 +83,9 @@ func (g *gNMIOutput) Init(ctx context.Context, name string, cfg map[string]inter
 	g.srv = g.newServer()
 
 	for _, opt := range opts {
-		opt(g)
+		if err := opt(g); err != nil {
+			return err
+		}
 	}
 
 	err = g.setDefaults()
@@ -171,7 +173,8 @@ func (g *gNMIOutput) SetLogger(logger *log.Logger) {
 	}
 }
 
-func (g *gNMIOutput) SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig, map[string]map[string]interface{}) {
+func (g *gNMIOutput) SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig, map[string]map[string]interface{}) error {
+	return nil
 }
 
 func (g *gNMIOutput) SetName(string) {}

--- a/pkg/outputs/influxdb_output/influxdb_output.go
+++ b/pkg/outputs/influxdb_output/influxdb_output.go
@@ -116,33 +116,19 @@ func (i *influxDBOutput) SetLogger(logger *log.Logger) {
 func (i *influxDBOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range i.Cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType],
-					formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts))
-				if err != nil {
-					i.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				i.evps = append(i.evps, ep)
-				i.logger.Printf("added event processor '%s' of type=%s to influxdb output", epName, epType)
-				continue
-			}
-			i.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		i.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	i.evps, err = outputs.MakeEventProcessors(
+		logger,
+		i.Cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 func (i *influxDBOutput) Init(ctx context.Context, name string, cfg map[string]interface{}, opts ...outputs.Option) error {
@@ -153,7 +139,9 @@ func (i *influxDBOutput) Init(ctx context.Context, name string, cfg map[string]i
 	i.logger.SetPrefix(fmt.Sprintf(loggingPrefix, name))
 
 	for _, opt := range opts {
-		opt(i)
+		if err := opt(i); err != nil {
+			return err
+		}
 	}
 	i.setDefaults()
 

--- a/pkg/outputs/influxdb_output/influxdb_output.go
+++ b/pkg/outputs/influxdb_output/influxdb_output.go
@@ -118,7 +118,7 @@ func (i *influxDBOutput) SetEventProcessors(ps map[string]map[string]interface{}
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	i.evps, err = outputs.MakeEventProcessors(
+	i.evps, err = formatters.MakeEventProcessors(
 		logger,
 		i.Cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -116,7 +116,7 @@ func (k *kafkaOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	k.evps, err = outputs.MakeEventProcessors(
+	k.evps, err = formatters.MakeEventProcessors(
 		logger,
 		k.Cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -127,7 +127,9 @@ func (n *jetstreamOutput) Init(ctx context.Context, name string, cfg map[string]
 	n.logger.SetPrefix(fmt.Sprintf(loggingPrefix, n.Cfg.Name))
 
 	for _, opt := range opts {
-		opt(n)
+		if err := opt(n); err != nil {
+			return err
+		}
 	}
 	err = n.setDefaults()
 	if err != nil {
@@ -290,33 +292,19 @@ func (n *jetstreamOutput) SetLogger(logger *log.Logger) {
 func (n *jetstreamOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range n.Cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType],
-					formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts))
-				if err != nil {
-					n.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				n.evps = append(n.evps, ep)
-				n.logger.Printf("added event processor '%s' of type=%s to jetstream output", epName, epType)
-				continue
-			}
-			n.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		n.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	n.evps, err = outputs.MakeEventProcessors(
+		logger,
+		n.Cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 func (n *jetstreamOutput) SetName(name string) {

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -294,7 +294,7 @@ func (n *jetstreamOutput) SetEventProcessors(ps map[string]map[string]interface{
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	n.evps, err = outputs.MakeEventProcessors(
+	n.evps, err = formatters.MakeEventProcessors(
 		logger,
 		n.Cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/nats_outputs/nats/nats_output.go
+++ b/pkg/outputs/nats_outputs/nats/nats_output.go
@@ -112,7 +112,7 @@ func (n *NatsOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	n.evps, err = outputs.MakeEventProcessors(
+	n.evps, err = formatters.MakeEventProcessors(
 		logger,
 		n.Cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/nats_outputs/nats/nats_output.go
+++ b/pkg/outputs/nats_outputs/nats/nats_output.go
@@ -110,33 +110,19 @@ func (n *NatsOutput) SetLogger(logger *log.Logger) {
 func (n *NatsOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range n.Cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType],
-					formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts))
-				if err != nil {
-					n.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				n.evps = append(n.evps, ep)
-				n.logger.Printf("added event processor '%s' of type=%s to nats output", epName, epType)
-				continue
-			}
-			n.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		n.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	n.evps, err = outputs.MakeEventProcessors(
+		logger,
+		n.Cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 // Init //
@@ -151,7 +137,9 @@ func (n *NatsOutput) Init(ctx context.Context, name string, cfg map[string]inter
 	n.logger.SetPrefix(fmt.Sprintf(loggingPrefix, n.Cfg.Name))
 
 	for _, opt := range opts {
-		opt(n)
+		if err := opt(n); err != nil {
+			return err
+		}
 	}
 	err = n.setDefaults()
 	if err != nil {

--- a/pkg/outputs/nats_outputs/stan/stan_output.go
+++ b/pkg/outputs/nats_outputs/stan/stan_output.go
@@ -113,7 +113,7 @@ func (s *StanOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	s.evps, err = outputs.MakeEventProcessors(
+	s.evps, err = formatters.MakeEventProcessors(
 		logger,
 		s.Cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/options.go
+++ b/pkg/outputs/options.go
@@ -15,11 +15,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type Option func(Output)
+type Option func(Output) error
 
 func WithLogger(logger *log.Logger) Option {
-	return func(o Output) {
+	return func(o Output) error {
 		o.SetLogger(logger)
+		return nil
 	}
 }
 
@@ -27,31 +28,35 @@ func WithEventProcessors(eps map[string]map[string]interface{},
 	log *log.Logger,
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) Option {
-	return func(o Output) {
-		o.SetEventProcessors(eps, log, tcs, acts)
+	return func(o Output) error {
+		return  o.SetEventProcessors(eps, log, tcs, acts)
 	}
 }
 
 func WithRegistry(reg *prometheus.Registry) Option {
-	return func(o Output) {
+	return func(o Output) error {
 		o.RegisterMetrics(reg)
+		return nil
 	}
 }
 
 func WithName(name string) Option {
-	return func(o Output) {
+	return func(o Output) error {
 		o.SetName(name)
+		return nil
 	}
 }
 
 func WithClusterName(name string) Option {
-	return func(o Output) {
+	return func(o Output) error {
 		o.SetClusterName(name)
+		return nil
 	}
 }
 
 func WithTargetsConfig(tcs map[string]*types.TargetConfig) Option {
-	return func(o Output) {
+	return func(o Output) error {
 		o.SetTargetsConfig(tcs)
+		return nil
 	}
 }

--- a/pkg/outputs/output.go
+++ b/pkg/outputs/output.go
@@ -17,12 +17,11 @@ import (
 	"strings"
 	"text/template"
 
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
-
 	"github.com/mitchellh/mapstructure"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/openconfig/gnmic/pkg/formatters"
 	_ "github.com/openconfig/gnmic/pkg/formatters/all"
@@ -213,41 +212,4 @@ func marshalSplit(pmsg protoreflect.ProtoMessage, meta map[string]string, mo *fo
 	default:
 		return nil, fmt.Errorf("unexpected message type: %T", msg)
 	}
-}
-
-
-func MakeEventProcessors(
-	logger *log.Logger,
-	processorNames []string,
-	ps map[string]map[string]interface{},
-	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{},
-) ([]formatters.EventProcessor, error) {
-	evps := make([]formatters.EventProcessor, len(processorNames))
-	for i, epName := range processorNames {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType],
-					formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts),
-				)
-				if err != nil {
-					return nil, fmt.Errorf("failed initializing event processor '%s' of type='%s': %w", epName, epType, err)
-				}
-				evps[i] = ep
-				logger.Printf("added event processor '%s' of type=%s to file output", epName, epType)
-				continue
-			}
-			return nil, fmt.Errorf("%q event processor has an unknown type=%q", epName, epType)
-		}
-		return nil, fmt.Errorf("%q event processor not found!", epName)
-	}
-	return evps, nil
 }

--- a/pkg/outputs/output.go
+++ b/pkg/outputs/output.go
@@ -39,7 +39,7 @@ type Output interface {
 	String() string
 
 	SetLogger(*log.Logger)
-	SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig, map[string]map[string]interface{})
+	SetEventProcessors(map[string]map[string]interface{}, *log.Logger, map[string]*types.TargetConfig, map[string]map[string]interface{}) error
 	SetName(string)
 	SetClusterName(string)
 	SetTargetsConfig(map[string]*types.TargetConfig)
@@ -213,4 +213,41 @@ func marshalSplit(pmsg protoreflect.ProtoMessage, meta map[string]string, mo *fo
 	default:
 		return nil, fmt.Errorf("unexpected message type: %T", msg)
 	}
+}
+
+
+func MakeEventProcessors(
+	logger *log.Logger,
+	processorNames []string,
+	ps map[string]map[string]interface{},
+	tcs map[string]*types.TargetConfig,
+	acts map[string]map[string]interface{},
+) ([]formatters.EventProcessor, error) {
+	evps := make([]formatters.EventProcessor, len(processorNames))
+	for i, epName := range processorNames {
+		if epCfg, ok := ps[epName]; ok {
+			epType := ""
+			for k := range epCfg {
+				epType = k
+				break
+			}
+			if in, ok := formatters.EventProcessors[epType]; ok {
+				ep := in()
+				err := ep.Init(epCfg[epType],
+					formatters.WithLogger(logger),
+					formatters.WithTargets(tcs),
+					formatters.WithActions(acts),
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed initializing event processor '%s' of type='%s': %w", epName, epType, err)
+				}
+				evps[i] = ep
+				logger.Printf("added event processor '%s' of type=%s to file output", epName, epType)
+				continue
+			}
+			return nil, fmt.Errorf("%q event processor has an unknown type=%q", epName, epType)
+		}
+		return nil, fmt.Errorf("%q event processor not found!", epName)
+	}
+	return evps, nil
 }

--- a/pkg/outputs/prometheus_output/prometheus_output/prometheus_output.go
+++ b/pkg/outputs/prometheus_output/prometheus_output/prometheus_output.go
@@ -149,7 +149,7 @@ func (p *prometheusOutput) SetEventProcessors(ps map[string]map[string]interface
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	p.evps, err = outputs.MakeEventProcessors(
+	p.evps, err = formatters.MakeEventProcessors(
 		logger,
 		p.cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/prometheus_output/prometheus_output/prometheus_output.go
+++ b/pkg/outputs/prometheus_output/prometheus_output/prometheus_output.go
@@ -147,34 +147,19 @@ func (p *prometheusOutput) SetLogger(logger *log.Logger) {
 func (p *prometheusOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range p.cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(
-					epCfg[epType],
-					formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts))
-				if err != nil {
-					p.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				p.evps = append(p.evps, ep)
-				p.logger.Printf("added event processor '%s' of type=%s to prometheus output", epName, epType)
-				continue
-			}
-			p.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		p.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	p.evps, err = outputs.MakeEventProcessors(
+		logger,
+		p.cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 func (p *prometheusOutput) Init(ctx context.Context, name string, cfg map[string]interface{}, opts ...outputs.Option) error {
@@ -189,7 +174,9 @@ func (p *prometheusOutput) Init(ctx context.Context, name string, cfg map[string
 	p.logger.SetPrefix(fmt.Sprintf(loggingPrefix, p.cfg.Name))
 
 	for _, opt := range opts {
-		opt(p)
+		if err := opt(p); err != nil {
+			return err
+		}
 	}
 	if p.cfg.TargetTemplate == "" {
 		p.targetTpl = outputs.DefaultTargetTemplate

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
@@ -263,7 +263,7 @@ func (p *promWriteOutput) SetEventProcessors(ps map[string]map[string]interface{
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	p.evps, err = outputs.MakeEventProcessors(
+	p.evps, err = formatters.MakeEventProcessors(
 		logger,
 		p.cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/snmp_output/snmp_output.go
+++ b/pkg/outputs/snmp_output/snmp_output.go
@@ -108,32 +108,19 @@ func (s *snmpOutput) SetLogger(logger *log.Logger) {
 func (s *snmpOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range s.cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType], formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts))
-				if err != nil {
-					s.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				s.evps = append(s.evps, ep)
-				s.logger.Printf("added event processor '%s' of type=%s to udp output", epName, epType)
-				continue
-			}
-			s.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		s.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	s.evps, err = outputs.MakeEventProcessors(
+		logger,
+		s.cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 func (s *snmpOutput) Init(ctx context.Context, name string, cfg map[string]interface{}, opts ...outputs.Option) error {
@@ -145,7 +132,9 @@ func (s *snmpOutput) Init(ctx context.Context, name string, cfg map[string]inter
 	s.logger.SetPrefix(fmt.Sprintf(loggingPrefix, name))
 
 	for _, opt := range opts {
-		opt(s)
+		if err := opt(s); err != nil {
+			return err
+		}
 	}
 
 	s.setDefaults()

--- a/pkg/outputs/snmp_output/snmp_output.go
+++ b/pkg/outputs/snmp_output/snmp_output.go
@@ -110,7 +110,7 @@ func (s *snmpOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	s.evps, err = outputs.MakeEventProcessors(
+	s.evps, err = formatters.MakeEventProcessors(
 		logger,
 		s.cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/tcp_output/tcp_output.go
+++ b/pkg/outputs/tcp_output/tcp_output.go
@@ -85,30 +85,19 @@ func (t *tcpOutput) SetLogger(logger *log.Logger) {
 func (t *tcpOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range t.cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType], formatters.WithLogger(logger), formatters.WithTargets(tcs))
-				if err != nil {
-					t.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				t.evps = append(t.evps, ep)
-				t.logger.Printf("added event processor '%s' of type=%s to tcp output", epName, epType)
-				continue
-			}
-			t.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		t.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	t.evps, err = outputs.MakeEventProcessors(
+		logger,
+		t.cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 func (t *tcpOutput) Init(ctx context.Context, name string, cfg map[string]interface{}, opts ...outputs.Option) error {
@@ -119,7 +108,9 @@ func (t *tcpOutput) Init(ctx context.Context, name string, cfg map[string]interf
 	t.logger.SetPrefix(fmt.Sprintf(loggingPrefix, name))
 
 	for _, opt := range opts {
-		opt(t)
+		if err := opt(t); err != nil {
+			return err
+		}
 	}
 	_, _, err = net.SplitHostPort(t.cfg.Address)
 	if err != nil {

--- a/pkg/outputs/tcp_output/tcp_output.go
+++ b/pkg/outputs/tcp_output/tcp_output.go
@@ -87,7 +87,7 @@ func (t *tcpOutput) SetEventProcessors(ps map[string]map[string]interface{},
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	t.evps, err = outputs.MakeEventProcessors(
+	t.evps, err = formatters.MakeEventProcessors(
 		logger,
 		t.cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/udp_output/udp_output.go
+++ b/pkg/outputs/udp_output/udp_output.go
@@ -83,7 +83,7 @@ func (u *UDPSock) SetEventProcessors(ps map[string]map[string]interface{},
 	tcs map[string]*types.TargetConfig,
 	acts map[string]map[string]interface{}) error {
 	var err error
-	u.evps, err = outputs.MakeEventProcessors(
+	u.evps, err = formatters.MakeEventProcessors(
 		logger,
 		u.Cfg.EventProcessors,
 		ps,

--- a/pkg/outputs/udp_output/udp_output.go
+++ b/pkg/outputs/udp_output/udp_output.go
@@ -81,32 +81,19 @@ func (u *UDPSock) SetLogger(logger *log.Logger) {
 func (u *UDPSock) SetEventProcessors(ps map[string]map[string]interface{},
 	logger *log.Logger,
 	tcs map[string]*types.TargetConfig,
-	acts map[string]map[string]interface{}) {
-	for _, epName := range u.Cfg.EventProcessors {
-		if epCfg, ok := ps[epName]; ok {
-			epType := ""
-			for k := range epCfg {
-				epType = k
-				break
-			}
-			if in, ok := formatters.EventProcessors[epType]; ok {
-				ep := in()
-				err := ep.Init(epCfg[epType], formatters.WithLogger(logger),
-					formatters.WithTargets(tcs),
-					formatters.WithActions(acts))
-				if err != nil {
-					u.logger.Printf("failed initializing event processor '%s' of type='%s': %v", epName, epType, err)
-					continue
-				}
-				u.evps = append(u.evps, ep)
-				u.logger.Printf("added event processor '%s' of type=%s to udp output", epName, epType)
-				continue
-			}
-			u.logger.Printf("%q event processor has an unknown type=%q", epName, epType)
-			continue
-		}
-		u.logger.Printf("%q event processor not found!", epName)
+	acts map[string]map[string]interface{}) error {
+	var err error
+	u.evps, err = outputs.MakeEventProcessors(
+		logger,
+		u.Cfg.EventProcessors,
+		ps,
+		tcs,
+		acts,
+	)
+	if err != nil {
+		return err
 	}
+	return nil
 }
 
 func (u *UDPSock) Init(ctx context.Context, name string, cfg map[string]interface{}, opts ...outputs.Option) error {
@@ -117,7 +104,9 @@ func (u *UDPSock) Init(ctx context.Context, name string, cfg map[string]interfac
 	u.logger.SetPrefix(fmt.Sprintf(loggingPrefix, name))
 
 	for _, opt := range opts {
-		opt(u)
+		if err := opt(u); err != nil {
+			return err
+		}
 	}
 	_, _, err = net.SplitHostPort(u.Cfg.Address)
 	if err != nil {


### PR DESCRIPTION
In the case where the event processor fails to initialise (could be for example a bad processor config, file not found, starlark syntax error), the previous behaviour was to ignore the processor.

However an event-processor can be crucial to the event processing and ignoring it could lead to garbage in the downstream metrics platform. It could lead for example to cardinality explosion.

This changes makes the input or output component fail if any processor in the chain fails to initilise.