### PR TITLE
POC, event processors using go-plugin

### DIFF
--- a/examples/plugin/main.go
+++ b/examples/plugin/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/openconfig/gnmic/pkg/formatters"
+	"github.com/openconfig/gnmic/pkg/formatters/event_plugin"
+
+	"github.com/openconfig/gnmic/pkg/types"
+)
+
+const (
+	processorType = "event-add-device_function"
+	loggingPrefix = "[" + processorType + "] "
+)
+
+type MyEventProcessor struct {
+	Debug bool `mapstructure:"debug,omitempty" json:"debug,omitempty"`
+
+	targetsConfigs        map[string]*types.TargetConfig
+	actionsDefinitions    map[string]map[string]interface{}
+	processorsDefinitions map[string]map[string]any
+	logger                *log.Logger
+}
+
+func (p *MyEventProcessor) Init(cfg interface{}, opts ...formatters.Option) error {
+	err := formatters.DecodeConfig(cfg, p)
+	p.setupLogger()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *MyEventProcessor) Apply(event ...*formatters.EventMsg) []*formatters.EventMsg {
+	for _, e := range event {
+		if e.Tags == nil {
+			e.Tags = make(map[string]string)
+		}
+		e.Tags["device_function"] = "CORE"
+
+	}
+	return event
+}
+
+func (p *MyEventProcessor) WithActions(act map[string]map[string]interface{}) {
+	p.actionsDefinitions = act
+}
+
+func (p *MyEventProcessor) WithTargets(tcs map[string]*types.TargetConfig) {
+	p.targetsConfigs = tcs
+}
+
+func (p *MyEventProcessor) WithProcessors(procs map[string]map[string]any) {
+	p.processorsDefinitions = procs
+}
+
+func (p *MyEventProcessor) WithLogger(l *log.Logger) {
+}
+
+func (p *MyEventProcessor) setupLogger() {
+	if !p.Debug {
+		p.logger = log.New(io.Discard, "", 0)
+	}
+}
+
+func main() {
+	logger := log.New(os.Stderr, "", log.Flags()&^log.Ldate&^log.Ltime&^log.Lmsgprefix)
+	logger.Printf("starting plugin")
+	plug := &MyEventProcessor{logger: logger}
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: plugin.HandshakeConfig{
+			ProtocolVersion:  1,
+			MagicCookieKey:   "GNMIC_PLUGIN",
+			MagicCookieValue: "gnmic",
+		},
+		Plugins: map[string]plugin.Plugin{
+			processorType: &event_plugin.EventProcessorPlugin{Impl: plug},
+		},
+		Logger: nil,
+	})
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -16,6 +16,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/openconfig/gnmic/pkg/formatters/plugin_manager"
+
 	"github.com/openconfig/gnmic/pkg/app"
 	"github.com/openconfig/gnmic/pkg/cmd/capabilities"
 	"github.com/openconfig/gnmic/pkg/cmd/diff"
@@ -110,6 +112,7 @@ func setupCloseHandler(cancelFn context.CancelFunc) {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		sig := <-c
+		plugin_manager.Cleanup()
 		fmt.Printf("\nreceived signal '%s'. terminating...\n", sig.String())
 		cancelFn()
 		os.Exit(0)

--- a/pkg/formatters/all/all.go
+++ b/pkg/formatters/all/all.go
@@ -30,4 +30,5 @@ import (
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_trigger"
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_value_tag"
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_write"
+	_ "github.com/openconfig/gnmic/pkg/formatters/plugin_manager"
 )

--- a/pkg/formatters/event_plugin/plugin.go
+++ b/pkg/formatters/event_plugin/plugin.go
@@ -1,0 +1,20 @@
+package event_plugin
+
+import (
+	"net/rpc"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/openconfig/gnmic/pkg/formatters"
+)
+
+type EventProcessorPlugin struct {
+	Impl formatters.EventProcessor
+}
+
+func (p *EventProcessorPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+	return &EventProcessorRPCServer{Impl: p.Impl}, nil
+}
+
+func (p *EventProcessorPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &EventProcessorRPC{client: c}, nil
+}

--- a/pkg/formatters/event_plugin/rpc.go
+++ b/pkg/formatters/event_plugin/rpc.go
@@ -76,7 +76,7 @@ func (g *EventProcessorRPC) Init(cfg interface{}, opts ...formatters.Option) err
 	}
 	err := g.client.Call("Plugin.Init", &InitArgs{Cfg: cfg}, &InitResponse{})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return nil
 }
@@ -85,7 +85,8 @@ func (g *EventProcessorRPC) Apply(event ...*formatters.EventMsg) []*formatters.E
 	var resp ApplyResponse
 	err := g.client.Call("Plugin.Apply", &ApplyArgs{Events: event}, &resp)
 	if err != nil {
-		panic(err)
+		log.Print("RPC client call error: ", err)
+		return nil
 	}
 	return resp.Events
 }
@@ -93,21 +94,21 @@ func (g *EventProcessorRPC) Apply(event ...*formatters.EventMsg) []*formatters.E
 func (g *EventProcessorRPC) WithActions(act map[string]map[string]interface{}) {
 	err := g.client.Call("Plugin.WithActions", act, &Actionresponse{})
 	if err != nil {
-		panic(err)
+		log.Print("RPC client call error: ", err)
 	}
 }
 
 func (g *EventProcessorRPC) WithTargets(tcs map[string]*types.TargetConfig) {
 	err := g.client.Call("Plugin.WithTargets", tcs, &Targetresponse{})
 	if err != nil {
-		panic(err)
+		log.Print("RPC client call error: ", err)
 	}
 }
 
 func (g *EventProcessorRPC) WithProcessors(procs map[string]map[string]any) {
 	err := g.client.Call("Plugin.WithProcessors", procs, &Proccessorresponse{})
 	if err != nil {
-		panic(err)
+		log.Print("RPC client call error: ", err)
 	}
 }
 

--- a/pkg/formatters/event_plugin/rpc.go
+++ b/pkg/formatters/event_plugin/rpc.go
@@ -1,0 +1,115 @@
+package event_plugin
+
+import (
+	"encoding/gob"
+	"log"
+	"net/rpc"
+
+	"github.com/openconfig/gnmic/pkg/formatters"
+	"github.com/openconfig/gnmic/pkg/types"
+)
+
+type InitArgs struct {
+	Cfg interface{}
+}
+
+type ApplyArgs struct {
+	Events []*formatters.EventMsg
+}
+
+type ApplyResponse struct {
+	Events []*formatters.EventMsg
+}
+
+type (
+	Actionresponse     struct{}
+	InitResponse       struct{}
+	Targetresponse     struct{}
+	Proccessorresponse struct{}
+)
+
+type EventProcessorRPCServer struct {
+	Impl formatters.EventProcessor
+}
+
+func init() {
+	gob.Register(map[string]interface{}{})
+	gob.Register([]interface{}{})
+}
+
+func (s *EventProcessorRPCServer) Init(args *InitArgs, resp *InitResponse) error {
+	return s.Impl.Init(args.Cfg)
+}
+
+func (s *EventProcessorRPCServer) Apply(args *ApplyArgs, resp *ApplyResponse) error {
+	resp.Events = s.Impl.Apply(args.Events...)
+	return nil
+}
+
+func (s *EventProcessorRPCServer) WithActions(args map[string]map[string]interface{}, resp *Actionresponse) error {
+	s.Impl.WithActions(args)
+	return nil
+}
+
+func (s *EventProcessorRPCServer) WithTargets(args map[string]*types.TargetConfig, resp *Targetresponse) error {
+	s.Impl.WithTargets(args)
+	return nil
+}
+
+func (s *EventProcessorRPCServer) WithProcessors(
+	args map[string]map[string]interface{},
+	resp *Proccessorresponse,
+) error {
+	s.Impl.WithProcessors(args)
+	return nil
+}
+
+func (s *EventProcessorRPCServer) WithLogger() error {
+	return nil
+}
+
+type EventProcessorRPC struct{ client *rpc.Client }
+
+func (g *EventProcessorRPC) Init(cfg interface{}, opts ...formatters.Option) error {
+	for _, opt := range opts {
+		opt(g)
+	}
+	err := g.client.Call("Plugin.Init", &InitArgs{Cfg: cfg}, &InitResponse{})
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}
+
+func (g *EventProcessorRPC) Apply(event ...*formatters.EventMsg) []*formatters.EventMsg {
+	var resp ApplyResponse
+	err := g.client.Call("Plugin.Apply", &ApplyArgs{Events: event}, &resp)
+	if err != nil {
+		panic(err)
+	}
+	return resp.Events
+}
+
+func (g *EventProcessorRPC) WithActions(act map[string]map[string]interface{}) {
+	err := g.client.Call("Plugin.WithActions", act, &Actionresponse{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (g *EventProcessorRPC) WithTargets(tcs map[string]*types.TargetConfig) {
+	err := g.client.Call("Plugin.WithTargets", tcs, &Targetresponse{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (g *EventProcessorRPC) WithProcessors(procs map[string]map[string]any) {
+	err := g.client.Call("Plugin.WithProcessors", procs, &Proccessorresponse{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (g *EventProcessorRPC) WithLogger(l *log.Logger) {
+}

--- a/pkg/formatters/plugin_manager/manager.go
+++ b/pkg/formatters/plugin_manager/manager.go
@@ -1,0 +1,83 @@
+package plugin_manager
+
+import (
+	"log"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
+	"github.com/openconfig/gnmic/pkg/formatters"
+	"github.com/openconfig/gnmic/pkg/formatters/event_plugin"
+)
+
+var handshakeConfig = plugin.HandshakeConfig{
+	ProtocolVersion:  1,
+	MagicCookieKey:   "GNMIC_PLUGIN",
+	MagicCookieValue: "gnmic",
+}
+var Plugins []*plugin.Client
+
+type PluginManager struct {
+	pluginMap map[string]plugin.Plugin
+	Debug     bool
+	logger    hclog.Logger
+}
+
+func init() {
+	pm := NewPluginManager()
+	pm.LoadPlugins()
+}
+
+func NewPluginManager() *PluginManager {
+	return &PluginManager{
+		pluginMap: map[string]plugin.Plugin{},
+		logger: hclog.New(
+			&hclog.LoggerOptions{Level: hclog.Trace, TimeFormat: "2006/01/02 15:04:05.999999"},
+		),
+	}
+}
+
+func (p *PluginManager) LoadPlugins() error {
+	pluginPaths, _ := plugin.Discover("*", "./plugins")
+
+	for _, pluginPath := range pluginPaths {
+		fileName := filepath.Base(pluginPath)
+		p.pluginMap[fileName] = &event_plugin.EventProcessorPlugin{}
+	}
+
+	for _, pluginPath := range pluginPaths {
+
+		client := plugin.NewClient(&plugin.ClientConfig{
+			HandshakeConfig: handshakeConfig,
+			Plugins:         p.pluginMap,
+			Cmd:             exec.Command(pluginPath),
+			Logger:          p.logger,
+		})
+
+		Plugins = append(Plugins, client)
+		fileName := filepath.Base(pluginPath)
+
+		rpcClient, err := client.Client()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		raw, err := rpcClient.Dispense(fileName)
+		if err != nil {
+			log.Fatal(err)
+		}
+		eventPlugin := raw.(formatters.EventProcessor)
+
+		formatters.Register(fileName, func() formatters.EventProcessor { return eventPlugin })
+		formatters.EventProcessorTypes = append(formatters.EventProcessorTypes, fileName)
+	}
+
+	return nil
+}
+
+func Cleanup() {
+	for _, client := range Plugins {
+		client.Kill()
+	}
+}


### PR DESCRIPTION
Hi,

I needed a way to dynamically add tags to Prometheus metrics and here is a POC using hashicorp go-plugin to build event processor plugins. In my case I would like to add metadata from our inventory to the metrics, but there could be many other use cases. 

gNMIc loads plugins from './plugins/' and the name of the binary is also the plugin name, it then communicates with the plugin over RPC. Each plugin needs to implement the EventProcessor interface, due to the RPC the logging setup is a bit different in the plugin. 

How to test the POC: Compile the examples/plugin/main.go to ./plugins/event-add-device_function and add 'event-add-device_function' as a processor for an output.


This is my first Golang project and I'm not a developer, but maybe we can get this up to shape and give gNMIc support for plugins together.


A couple of outstanding questions:
- Is there any better way to initialize the plugin_manager, now it uses init() and import in all.go.
- Add support for configuration of the plugin_manager, like debug log true/false and configurable plugin directory.
- Is there a way to send the logger object over RPC?

