### PR TITLE
adds gRPC metadata support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,9 +42,9 @@ require (
 	github.com/openconfig/gnmic/pkg/api v0.1.1
 	github.com/openconfig/gnmic/pkg/cache v0.1.1
 	github.com/openconfig/gnmic/pkg/path v0.1.1
-	github.com/openconfig/gnmic/pkg/target v0.1.1
+	github.com/openconfig/gnmic/pkg/target v0.1.3
 	github.com/openconfig/gnmic/pkg/testutils v0.1.0
-	github.com/openconfig/gnmic/pkg/types v0.1.1
+	github.com/openconfig/gnmic/pkg/types v0.1.2
 	github.com/openconfig/gnmic/pkg/utils v0.1.0
 	github.com/openconfig/goyang v1.4.2
 	github.com/openconfig/ygot v0.29.2

--- a/go.sum
+++ b/go.sum
@@ -960,12 +960,12 @@ github.com/openconfig/gnmic/pkg/cache v0.1.1 h1:cT3swYn6NOmBFELFMJeK3GsWEviRgo9+
 github.com/openconfig/gnmic/pkg/cache v0.1.1/go.mod h1:EQpcUMnkiUUvsSpAux8Jul8Tfkz6XT/wJvXbgohCyr4=
 github.com/openconfig/gnmic/pkg/path v0.1.1 h1:C6vZTC0NsMOGyre7ueXRS8vmYvCW9sdHKQ5cqWYiNPw=
 github.com/openconfig/gnmic/pkg/path v0.1.1/go.mod h1:Z2Ejm3UIO7WDxlXsnJmzE7/lnWe/0neCuXW6QDwmYHQ=
-github.com/openconfig/gnmic/pkg/target v0.1.1 h1:/XA3cFs3FTb2Bli4TdvLYf0b/ifMX1gDOMY+f8LcTr0=
-github.com/openconfig/gnmic/pkg/target v0.1.1/go.mod h1:5NF5rtYCt7e7wygyi5kUUU6YsrFLD62kDB2jaCwFUbk=
+github.com/openconfig/gnmic/pkg/target v0.1.3 h1:dRARtho5wMMnMa4h1LQBNbZTjsb/1kyVS6nXxb6YW+U=
+github.com/openconfig/gnmic/pkg/target v0.1.3/go.mod h1:hNmkYvuYFaUtbFWVm0PuvctJ70ku+fotxZxmkr5oeWM=
 github.com/openconfig/gnmic/pkg/testutils v0.1.0 h1:Mw6LKGqzXQnrI9fCtaCAp3pFDy2B0+rKQFtjCqQWJwM=
 github.com/openconfig/gnmic/pkg/testutils v0.1.0/go.mod h1:/JyhCq6rSbQdmeCbPIQjD8K3ArOqGQZFKUKKUpebonk=
-github.com/openconfig/gnmic/pkg/types v0.1.1 h1:LczdQ/eTsnMkHJvOdu2Q5UpNqdjnzNPsjAL0fhCK410=
-github.com/openconfig/gnmic/pkg/types v0.1.1/go.mod h1:Gwc9suBy/s17bP8BaCrp3dE5E+RkcHqVIkFqdXopog4=
+github.com/openconfig/gnmic/pkg/types v0.1.2 h1:FRjERZrbcuqhwRKHZ7ux4UXr4fc1DlgXvH37Iysu4Co=
+github.com/openconfig/gnmic/pkg/types v0.1.2/go.mod h1:Gwc9suBy/s17bP8BaCrp3dE5E+RkcHqVIkFqdXopog4=
 github.com/openconfig/gnmic/pkg/utils v0.1.0 h1:MqRhW8oJdPpBb1UprbnpDxciBJVjl/Gw97xuNoBG3Vs=
 github.com/openconfig/gnmic/pkg/utils v0.1.0/go.mod h1:DQm/e8cdRwdmUORjODWteDU0HG0CWNYBAhLWqnPQegE=
 github.com/openconfig/goyang v0.0.0-20200115183954-d0a48929f0ea/go.mod h1:dhXaV0JgHJzdrHi2l+w0fZrwArtXL7jEFoiqLEdmkvU=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -204,7 +204,7 @@ func (a *App) InitGlobalFlags() {
 	a.RootCmd.PersistentFlags().BoolVarP(&a.Config.GlobalFlags.UseTunnelServer, "use-tunnel-server", "", false, "use tunnel server to dial targets")
 	a.RootCmd.PersistentFlags().StringVarP(&a.Config.GlobalFlags.AuthScheme, "auth-scheme", "", "", "authentication scheme to use for the target's username/password")
 	a.RootCmd.PersistentFlags().BoolVarP(&a.Config.GlobalFlags.CalculateLatency, "calculate-latency", "", false, "calculate the delta between each message timestamp and the receive timestamp. JSON format only")
-
+	a.RootCmd.PersistentFlags().StringToStringP("metadata", "H", a.Config.GlobalFlags.Metadata, "add metadata to gRPC requests (`key=value`)")
 	a.RootCmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
 		a.Config.FileConfig.BindPFlag(flag.Name, flag)
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,8 @@ type GlobalFlags struct {
 	UseTunnelServer  bool          `mapstructure:"use-tunnel-server,omitempty" json:"use-tunnel-server,omitempty" yaml:"use-tunnel-server,omitempty"`
 	AuthScheme       string        `mapstructure:"auth-scheme,omitempty" json:"auth-scheme,omitempty" yaml:"auth-scheme,omitempty"`
 	CalculateLatency bool          `mapstructure:"calculate-latency,omitempty" json:"calculate-latency,omitempty" yaml:"calculate-latency,omitempty"`
+
+	Metadata map[string]string `mapstructure:"metadata,omitempty" json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 type LocalFlags struct {

--- a/pkg/config/targets.go
+++ b/pkg/config/targets.go
@@ -11,6 +11,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"sort"
@@ -214,6 +215,10 @@ func (c *Config) SetTargetConfigDefaults(tc *types.TargetConfig) error {
 	}
 	if tc.BufferSize == 0 {
 		tc.BufferSize = defaultTargetBufferSize
+	}
+	if tc.Metadata == nil && c.Metadata != nil {
+		tc.Metadata = make(map[string]string)
+		maps.Copy(tc.Metadata, c.Metadata)
 	}
 	return nil
 }

--- a/pkg/config/targets_test.go
+++ b/pkg/config/targets_test.go
@@ -78,11 +78,16 @@ targets:
 	},
 	"from_both_targets_and_main_section": {
 		in: []byte(`
+metadata:
+  key1: val1
+  key2: val2
 username: admin
 password: admin
 skip-verify: true
 targets:
   10.1.1.1:57400:  
+    metadata:
+      override1: val2
 `),
 		out: map[string]*types.TargetConfig{
 			"10.1.1.1:57400": {
@@ -98,12 +103,18 @@ targets:
 				SkipVerify:   pointer.ToBool(true),
 				Gzip:         pointer.ToBool(false),
 				BufferSize:   uint(100),
+				Metadata: map[string]string{
+					"override1": "val2",
+				},
 			},
 		},
 		outErr: nil,
 	},
 	"multiple_targets": {
 		in: []byte(`
+metadata:
+  key1: val1
+  key2: val2
 targets:
   10.1.1.1:57400:
     username: admin
@@ -126,6 +137,10 @@ targets:
 				SkipVerify:   pointer.ToBool(false),
 				Gzip:         pointer.ToBool(false),
 				BufferSize:   uint(100),
+				Metadata: map[string]string{
+					"key1": "val1",
+					"key2": "val2",
+				},
 			},
 			"10.1.1.2:57400": {
 				Address:      "10.1.1.2:57400",
@@ -140,6 +155,10 @@ targets:
 				SkipVerify:   pointer.ToBool(false),
 				Gzip:         pointer.ToBool(false),
 				BufferSize:   uint(100),
+				Metadata: map[string]string{
+					"key1": "val1",
+					"key2": "val2",
+				},
 			},
 		},
 		outErr: nil,


### PR DESCRIPTION
This diff adds support for sending gRPC metadata (aka headers). This is useful for situations where an application implementing the gNMI gRPC server wants additional information about the caller that cannot be transmitted using the constructs in the RPC itself.

Tests are included that exercise this functionality.