### PR TITLE
Add topic-prefix for kafka output

### DIFF
--- a/docs/user_guide/outputs/kafka_output.md
+++ b/docs/user_guide/outputs/kafka_output.md
@@ -21,9 +21,9 @@ outputs:
     topic: telemetry 
     # Kafka topic prefix
     # If supplied, overrides the `topic` key and outputs to a separate topic per source
-    # named like `topic_<source>`. If `source` contains a port number separated with a colon,
+    # named like `$topic_$subscriptionName_$targetName`. If `source` contains a port number separated with a colon,
     # the colon will be replaced with an underscore due to restrictions on the naming of kafka topics.
-    # ex: topic_device1_6030
+    # ex: telemetry_bgp_neighbor_state_device1_6030
     topic-prefix: telemetry
     # Kafka SASL configuration
     sasl:

--- a/docs/user_guide/outputs/kafka_output.md
+++ b/docs/user_guide/outputs/kafka_output.md
@@ -19,6 +19,12 @@ outputs:
     address: localhost:9092 
     # Kafka topic name
     topic: telemetry 
+    # Kafka topic prefix
+    # If supplied, overrides the `topic` key and outputs to a separate topic per source
+    # named like `topic_<source>`. If `source` contains a port number separated with a colon,
+    # the colon will be replaced with an underscore due to restrictions on the naming of kafka topics.
+    # ex: topic_device1_6030
+    topic-prefix: telemetry
     # Kafka SASL configuration
     sasl:
       # SASL user name
@@ -94,7 +100,7 @@ outputs:
     event-processors: 
 ```
 
-Currently all subscriptions updates (all targets and all subscriptions) are published to the defined topic name
+Currently all subscriptions updates (all targets and all subscriptions) are published to the defined topic name unless the `topic-prefix` configuration option is set.
 
 ### Kafka Security protocol
 

--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -445,9 +445,19 @@ func (k *kafkaOutput) partitionKey(m outputs.Meta) []byte {
 }
 
 func (k *kafkaOutput) selectTopic(m outputs.Meta) string {
+	sb := strings.Builder{}
 	if k.Cfg.TopicPrefix != "" {
-		source := strings.ReplaceAll(m["source"], ":", "_")
-		return fmt.Sprintf("%s_%s", k.Cfg.TopicPrefix, source)
+		sb.WriteString(k.Cfg.TopicPrefix)
+		if subname, ok := m["subscription-name"]; ok {
+			sb.WriteString("_")
+			sb.WriteString(subname)
+		}
+		if s, ok := m["source"]; ok {
+			source := strings.ReplaceAll(s, ":", "_")
+			sb.WriteString("_")
+			sb.WriteString(source)
+		}
+		return sb.String()
 	} else {
 		return k.Cfg.Topic
 	}

--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -74,6 +74,7 @@ type kafkaOutput struct {
 type config struct {
 	Address            string           `mapstructure:"address,omitempty"`
 	Topic              string           `mapstructure:"topic,omitempty"`
+	TopicPrefix        string           `mapstructure:"topic-prefix,omitempty"`
 	Name               string           `mapstructure:"name,omitempty"`
 	SASL               *types.SASL      `mapstructure:"sasl,omitempty"`
 	TLS                *types.TLSConfig `mapstructure:"tls,omitempty"`
@@ -329,8 +330,9 @@ CRPROD:
 					}
 				}
 
+				topic := k.selectTopic(m.GetMeta())
 				msg := &sarama.ProducerMessage{
-					Topic: k.Cfg.Topic,
+					Topic: topic,
 					Value: sarama.ByteEncoder(b),
 				}
 				if k.Cfg.InsertKey {
@@ -343,7 +345,7 @@ CRPROD:
 				_, _, err = producer.SendMessage(msg)
 				if err != nil {
 					if k.Cfg.Debug {
-						k.logger.Printf("%s failed to send a kafka msg to topic '%s': %v", workerLogPrefix, k.Cfg.Topic, err)
+						k.logger.Printf("%s failed to send a kafka msg to topic '%s': %v", workerLogPrefix, topic, err)
 					}
 					if k.Cfg.EnableMetrics {
 						kafkaNumberOfFailSendMsgs.WithLabelValues(config.ClientID, "send_error").Inc()
@@ -440,4 +442,13 @@ func (k *kafkaOutput) partitionKey(m outputs.Meta) []byte {
 	b := new(bytes.Buffer)
 	fmt.Fprintf(b, "%s_%s", m["source"], m["subscription-name"])
 	return b.Bytes()
+}
+
+func (k *kafkaOutput) selectTopic(m outputs.Meta) string {
+	if k.Cfg.TopicPrefix != "" {
+		source := strings.ReplaceAll(m["source"], ":", "_")
+		return fmt.Sprintf("%s_%s", k.Cfg.TopicPrefix, source)
+	} else {
+		return k.Cfg.Topic
+	}
 }

--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -445,20 +445,20 @@ func (k *kafkaOutput) partitionKey(m outputs.Meta) []byte {
 }
 
 func (k *kafkaOutput) selectTopic(m outputs.Meta) string {
-	sb := strings.Builder{}
-	if k.Cfg.TopicPrefix != "" {
-		sb.WriteString(k.Cfg.TopicPrefix)
-		if subname, ok := m["subscription-name"]; ok {
-			sb.WriteString("_")
-			sb.WriteString(subname)
-		}
-		if s, ok := m["source"]; ok {
-			source := strings.ReplaceAll(s, ":", "_")
-			sb.WriteString("_")
-			sb.WriteString(source)
-		}
-		return sb.String()
-	} else {
+	if k.Cfg.TopicPrefix == "" {
 		return k.Cfg.Topic
 	}
+
+	sb := strings.Builder{}
+	sb.WriteString(k.Cfg.TopicPrefix)
+	if subname, ok := m["subscription-name"]; ok {
+		sb.WriteString("_")
+		sb.WriteString(subname)
+	}
+	if s, ok := m["source"]; ok {
+		source := strings.ReplaceAll(s, ":", "_")
+		sb.WriteString("_")
+		sb.WriteString(source)
+	}
+	return sb.String()
 }


### PR DESCRIPTION
This PR adds a `topic-prefix` to the Kafka Output. When present, this prefix will be used to generate a separate Kafka topic per source. The topic name will follow `prefix_<source>`, and if there is a colon separating a port number as part of the source the colon will also be replaced with an underscore like `prefix_<source>_<port>` due to naming restrictions in Kafka topics.

I'm currently using this branch for testing in local development environments and all works as expected.

Let me know if you have any changes you'd like to ensure this keeps with the conventions used throughout the rest of the application, and thanks for the awesome work on gnmic as always!