### PR TITLE
Only fetch kafka metadata for relevant topics

### DIFF
--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -419,6 +419,7 @@ func (k *kafkaOutput) createConfig() (*sarama.Config, error) {
 	cfg.Producer.RequiredAcks = sarama.WaitForAll
 	cfg.Producer.Return.Successes = true
 	cfg.Producer.Timeout = k.Cfg.Timeout
+	cfg.Metadata.Full = false
 
 	switch k.Cfg.CompressionCodec {
 	case "gzip":


### PR DESCRIPTION
By default, sarama fetches "full" kafka metadata, meaning it fetches metadata about every kafka topic in the cluster, even unrelated ones. There's not really any reason for this. Sarama only describes it as [simpler](https://github.com/IBM/sarama/blob/4d31d23ca31a68788d4249cfc8f44e619cea2d3a/config.go#L157)

On large kafka clusters with many thousands of topics, this can cause significant performance problems for the brokers.

This PR overrides the sarama default, configuring it to only fetch metadata for relevant topics. I'm happy to add this as a config option to gnmic if you prefer, but I think it's reasonable to just override the default, given there's not reallly any advantage to doing the full fetch, and I think this is unlikely to break any existing workflows.