### PR TITLE
add subject.target.subscription format for Jetstream

### DIFF
--- a/docs/user_guide/outputs/jetstream_output.md
+++ b/docs/user_guide/outputs/jetstream_output.md
@@ -59,9 +59,14 @@ outputs:
     #       The path is built by joining the gNMI path pathElements and Keys with a dot (.).
     #       e.g: /interface[name=ethernet-1/1]/statistics/in-octets
     #       -->  interface.{name=ethernet-1/1}.statistics.in-octets 
+    # `subject.target.subscription`:
+    #       updates from each subscription, target will be written with a prefix of the `subject`
+    #       to subject $subject.$target_name.$subscription_name
     subject-format: static 
     # If a subject-format is `static`, gnmic will publish all subscriptions updates 
     # to a single subject configured under this field. Defaults to 'telemetry'
+    # If a subject-format is `subject.target.subscription`, gnmic will publish subscripion
+    # updates prefixed with this subject.
     subject: telemetry
     # tls config
     tls:

--- a/docs/user_guide/outputs/jetstream_output.md
+++ b/docs/user_guide/outputs/jetstream_output.md
@@ -59,13 +59,14 @@ outputs:
     #       The path is built by joining the gNMI path pathElements and Keys with a dot (.).
     #       e.g: /interface[name=ethernet-1/1]/statistics/in-octets
     #       -->  interface.{name=ethernet-1/1}.statistics.in-octets 
-    # `subject.target.subscription`:
+    # `target.subscription`:
     #       updates from each subscription, target will be written with a prefix of the `subject`
-    #       to subject $subject.$target_name.$subscription_name
+    #       to subject $subject.$target_name.$subscription_name if `subject` is present. If not,
+    #       it will write to $target_name.$subscription_name.
     subject-format: static 
     # If a subject-format is `static`, gnmic will publish all subscriptions updates 
     # to a single subject configured under this field. Defaults to 'telemetry'
-    # If a subject-format is `subject.target.subscription`, gnmic will publish subscripion
+    # If a subject-format is `target.subscription`, gnmic will publish subscripion
     # updates prefixed with this subject.
     subject: telemetry
     # tls config

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -61,6 +61,7 @@ type subjectFormat string
 
 const (
 	subjectFormat_Static                = "static"
+	subjectFormat_SubjectTargetSub      = "subject.target.subscription"
 	subjectFormat_SubTarget             = "subscription.target"
 	subjectFormat_SubTargetPath         = "subscription.target.path"
 	subjectFormat_SubTargetPathWithKeys = "subscription.target.pathKeys"
@@ -187,6 +188,7 @@ func (n *jetstreamOutput) setDefaults() error {
 	}
 	switch n.Cfg.SubjectFormat {
 	case subjectFormat_Static,
+		subjectFormat_SubjectTargetSub,
 		subjectFormat_SubTarget,
 		subjectFormat_SubTargetPath,
 		subjectFormat_SubTargetPathWithKeys:
@@ -380,7 +382,7 @@ CRCONN:
 			}
 			var rs []proto.Message
 			switch n.Cfg.SubjectFormat {
-			case subjectFormat_Static, subjectFormat_SubTarget:
+			case subjectFormat_Static, subjectFormat_SubjectTargetSub, subjectFormat_SubTarget:
 				rs = []proto.Message{pmsg}
 			case subjectFormat_SubTargetPath, subjectFormat_SubTargetPathWithKeys:
 				switch rsp := pmsg.(type) {
@@ -527,6 +529,17 @@ func (n *jetstreamOutput) subjectName(m proto.Message, meta outputs.Meta) (strin
 	switch n.Cfg.SubjectFormat {
 	case subjectFormat_Static:
 		sb.WriteString(n.Cfg.Subject)
+	case subjectFormat_SubjectTargetSub:
+		sb.WriteString(n.Cfg.Subject)
+		sb.WriteString(".")
+		err := n.targetTpl.Execute(sb, meta)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(".")
+		if sub, ok := meta["subscription-name"]; ok {
+			sb.WriteString(sub)
+		}
 	case subjectFormat_SubTarget:
 		if sub, ok := meta["subscription-name"]; ok {
 			sb.WriteString(sub)

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -61,7 +61,7 @@ type subjectFormat string
 
 const (
 	subjectFormat_Static                = "static"
-	subjectFormat_SubjectTargetSub      = "subject.target.subscription"
+	subjectFormat_TargetSub             = "target.subscription"
 	subjectFormat_SubTarget             = "subscription.target"
 	subjectFormat_SubTargetPath         = "subscription.target.path"
 	subjectFormat_SubTargetPathWithKeys = "subscription.target.pathKeys"
@@ -188,7 +188,7 @@ func (n *jetstreamOutput) setDefaults() error {
 	}
 	switch n.Cfg.SubjectFormat {
 	case subjectFormat_Static,
-		subjectFormat_SubjectTargetSub,
+		subjectFormat_TargetSub,
 		subjectFormat_SubTarget,
 		subjectFormat_SubTargetPath,
 		subjectFormat_SubTargetPathWithKeys:
@@ -382,7 +382,7 @@ CRCONN:
 			}
 			var rs []proto.Message
 			switch n.Cfg.SubjectFormat {
-			case subjectFormat_Static, subjectFormat_SubjectTargetSub, subjectFormat_SubTarget:
+			case subjectFormat_Static, subjectFormat_TargetSub, subjectFormat_SubTarget:
 				rs = []proto.Message{pmsg}
 			case subjectFormat_SubTargetPath, subjectFormat_SubTargetPathWithKeys:
 				switch rsp := pmsg.(type) {
@@ -529,7 +529,7 @@ func (n *jetstreamOutput) subjectName(m proto.Message, meta outputs.Meta) (strin
 	switch n.Cfg.SubjectFormat {
 	case subjectFormat_Static:
 		sb.WriteString(n.Cfg.Subject)
-	case subjectFormat_SubjectTargetSub:
+	case subjectFormat_TargetSub:
 		if n.Cfg.Subject != "" {
 			sb.WriteString(n.Cfg.Subject)
 			sb.WriteString(".")

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -530,8 +530,10 @@ func (n *jetstreamOutput) subjectName(m proto.Message, meta outputs.Meta) (strin
 	case subjectFormat_Static:
 		sb.WriteString(n.Cfg.Subject)
 	case subjectFormat_SubjectTargetSub:
-		sb.WriteString(n.Cfg.Subject)
-		sb.WriteString(".")
+		if n.Cfg.Subject != "" {
+			sb.WriteString(n.Cfg.Subject)
+			sb.WriteString(".")
+		}
 		err := n.targetTpl.Execute(sb, meta)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This PR adds an additional `subject` formatting option for Jetstream. It uses the existing `subject` key in the config and orders the subject like: `$subject.$target_name.$subscription_name`.

I'm using this in development already with no issues. 