### PR TITLE
Fix 348 - Fix broken Consul docs links

### DIFF
--- a/docs/deployments/clusters/containerlab/cluster_with_gnmi_server_and_prometheus_output.md
+++ b/docs/deployments/clusters/containerlab/cluster_with_gnmi_server_and_prometheus_output.md
@@ -8,7 +8,7 @@ This deployment example includes:
 - A [Grafana](https://grafana.com/docs/) Server
 - A [Consul](https://www.consul.io/docs/intro) Server
 
-The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/introhttps://www.consul.io/docs/intro)
+The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/intro)
 
 All members of the cluster expose a gNMI Server that the single gNMIc instance will use to aggregate the collected data.
 

--- a/docs/deployments/clusters/containerlab/cluster_with_nats_input_and_prometheus_output.md
+++ b/docs/deployments/clusters/containerlab/cluster_with_nats_input_and_prometheus_output.md
@@ -12,7 +12,7 @@ This deployment example includes a:
 - A [Grafana](https://grafana.com/docs/) Server
 - A [Consul](https://www.consul.io/docs/intro) Server
 
-The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/introhttps://www.consul.io/docs/intro)
+The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/intro)
 
 Each `gnmic` instance outputs the streamed gNMI data to NATS, and reads back all the data from the same NATS server (including its own),
 

--- a/docs/deployments/clusters/containerlab/cluster_with_prometheus_output.md
+++ b/docs/deployments/clusters/containerlab/cluster_with_prometheus_output.md
@@ -7,7 +7,7 @@ This deployment example includes:
 - A [Grafana](https://grafana.com/docs/) Server
 - A [Consul](https://www.consul.io/docs/intro) Server
 
-The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/introhttps://www.consul.io/docs/intro)
+The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/intro)
 
 `gnmic` will also register its Prometheus output service in `Consul` so that Prometheus can discover which Prometheus servers are available to be scraped.
 

--- a/docs/deployments/clusters/docker-compose/cluster_with_influxdb_output.md
+++ b/docs/deployments/clusters/docker-compose/cluster_with_influxdb_output.md
@@ -5,7 +5,7 @@ This deployment example includes:
 - A 3 instances [`gnmic` cluster](../../../user_guide/HA.md),
 - A single [InfluxDB output](../../../user_guide/outputs/influxdb_output.md)
 
-The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/introhttps://www.consul.io/docs/intro)
+The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/intro)
 
 <div class="mxgraph" style="max-width:100%;border:1px solid transparent;margin:0 auto; display:block;" data-mxgraph="{&quot;page&quot;:12,&quot;zoom&quot;:1.4,&quot;highlight&quot;:&quot;#0000ff&quot;,&quot;nav&quot;:true,&quot;check-visible-state&quot;:true,&quot;resize&quot;:true,&quot;url&quot;:&quot;https://raw.githubusercontent.com/openconfig/gnmic/diagrams/diagrams/cluster_influxdb.drawio&quot;}"></div>
 

--- a/docs/deployments/clusters/docker-compose/cluster_with_nats_input_and_prometheus_output.md
+++ b/docs/deployments/clusters/docker-compose/cluster_with_nats_input_and_prometheus_output.md
@@ -10,7 +10,7 @@ This deployment example includes a:
 - A NATS [input](../../../user_guide/inputs/nats_input.md) and [output](../../../user_guide/outputs/nats_output.md) 
 - A [Prometheus output](../../../user_guide/outputs/prometheus_output.md)
 
-The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/introhttps://www.consul.io/docs/intro)
+The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/intro)
 
 Each `gnmic` instance outputs the streamed gNMI data to NATS, and reads back all the data from the same NATS server (including its own),
 

--- a/docs/deployments/clusters/docker-compose/cluster_with_prometheus_output.md
+++ b/docs/deployments/clusters/docker-compose/cluster_with_prometheus_output.md
@@ -5,7 +5,7 @@ This deployment example includes:
 - A 3 instances [`gnmic` cluster](../../../user_guide/HA.md),
 - A single [Prometheus output](../../../user_guide/outputs/prometheus_output.md)
 
-The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/introhttps://www.consul.io/docs/intro)
+The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/intro)
 
 `gnmic` will also register its Prometheus output service in `Consul` so that Prometheus can discover which Prometheus servers are available to be scraped
 

--- a/docs/deployments/clusters/kubernetes/cluster_with_prometheus_output.md
+++ b/docs/deployments/clusters/kubernetes/cluster_with_prometheus_output.md
@@ -5,7 +5,7 @@ This deployment example includes:
 - A 3 instances [`gnmic` cluster](../../../user_guide/HA.md),
 - A single [Prometheus output](../../../user_guide/outputs/prometheus_output.md)
 
-The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/introhttps://www.consul.io/docs/intro)
+The leader election and target distribution is done with the help of a [Consul server](https://www.consul.io/docs/intro)
 
 `gnmic` can be discovered by `Prometheus` using Kubernetes service discovery. Kubernetes uses a [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) with a StatefulSet to disable the internal load balancing across multiple pods of the same StatefulSet and allow `Prometheus` to discover all instances of `gnmic`.
 


### PR DESCRIPTION
Fixes #348 - multiple pages in the `deployments` docs section link to the Consul documentation, but the links are broken.