### PR TITLE
Fix changelog during release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
       - test
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOVER }}


### PR DESCRIPTION
actions/checkout@v4 defaults to a shallow clone and gorelease is unable to build the full changelog for inclusion into GitHub release tag.