### PR TITLE
Sort prometheus labels in accordance with the prometheus spec

### DIFF
--- a/pkg/outputs/prometheus_output/prometheus_common.go
+++ b/pkg/outputs/prometheus_output/prometheus_common.go
@@ -9,10 +9,12 @@
 package prometheus_output
 
 import (
+	"cmp"
 	"errors"
 	"math"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -152,6 +154,13 @@ func (m *MetricBuilder) TimeSeriesFromEvent(ev *formatters.EventMsg) []*NamedTim
 				Name:  labels.MetricName,
 				Value: tsName,
 			})
+
+		// The prometheus spec requires label names to be sorted
+		// https://prometheus.io/docs/concepts/remote_write_spec/
+		slices.SortFunc(tsLabelsWithName, func(a prompb.Label, b prompb.Label) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
+
 		nts := &NamedTimeSeries{
 			Name: tsName,
 			TS: &prompb.TimeSeries{


### PR DESCRIPTION
Currently, the gnmic prometheus output does not sort labels lexicographically before sending them out the door.

This is required by the prometheus [remote write spec](https://prometheus.io/docs/concepts/remote_write_spec/):

> MUST have label names sorted in lexicographical order.

It's unclear how all implementations of prometheus remote write targets handle the unsorted labels. In at least some, it can lead to issues with correctness or sharding efficiency.

I have made the fix and added a test.