### PR TITLE
Add a config option for kafka producer flush frequency

### DIFF
--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -85,6 +85,7 @@ type config struct {
 	MaxRetry           int              `mapstructure:"max-retry,omitempty"`
 	Timeout            time.Duration    `mapstructure:"timeout,omitempty"`
 	RecoveryWaitTime   time.Duration    `mapstructure:"recovery-wait-time,omitempty"`
+	FlushFrequency     time.Duration    `mapstructure:"flush-frequency,omitempty"`
 	SyncProducer       bool             `mapstructure:"sync-producer,omitempty"`
 	RequiredAcks       string           `mapstructure:"required-acks,omitempty"`
 	Format             string           `mapstructure:"format,omitempty"`
@@ -546,6 +547,7 @@ func (k *kafkaOutput) createConfig() (*sarama.Config, error) {
 	cfg.Producer.Retry.Max = k.cfg.MaxRetry
 	cfg.Producer.Return.Successes = true
 	cfg.Producer.Timeout = k.cfg.Timeout
+	cfg.Producer.Flush.Frequency = k.cfg.FlushFrequency
 	switch k.cfg.RequiredAcks {
 	case requiredAcksNoResponse:
 	case requiredAcksWaitForLocal:


### PR DESCRIPTION
Sarama exposes [a config option](https://github.com/IBM/sarama/blob/4ad35041300e1c15ba58b630745ac8eb05f30c10/config.go#L253) for the best effort frequency of flushes.

This option tells the library to hold kafka messages for up to this amount of time with the goal of better client-side compression and batching. This can lead to peformance improvements in both gnmic and on the kafka broker.

By default, sarama sets this value to 0 which indicates that it should flush as frequently as possible. This PR preserves that behavior while adding a knob to increase the frequency.