### PR TITLE
Set minimal version for Go to 1.21.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/openconfig/gnmic
 
-go 1.21.9
+go 1.21.1
+
+toolchain go1.21.9
 
 replace github.com/openconfig/gnmic/pkg/api v0.1.5 => ./pkg/api
 

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openconfig/gnmic/pkg/api
 
-go 1.21.9
+go 1.21.1
 
 require (
 	github.com/AlekSi/pointer v1.2.0

--- a/pkg/cache/go.mod
+++ b/pkg/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/openconfig/gnmic/pkg/cache
 
-go 1.21.9
+go 1.21.1
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5


### PR DESCRIPTION
And set toolchain to 1.21.9. The "go" keyword in go.mod should be used to specify the minimal version of Go required to compile the package. The "toolchain" keyword is a suggestion of toolchain to use (and for the main module, by default, it has the same effect as the "go" keyword).