### PR TITLE
api support to update target subscriptions directly

### DIFF
--- a/docs/user_guide/api/targets.md
+++ b/docs/user_guide/api/targets.md
@@ -220,7 +220,6 @@ Returns an empty body if successful.
     ```json
     {
         "errors": [
-            "subscriptions not found",
             "subscription $subscription does not exist"
         ]
     }

--- a/docs/user_guide/api/targets.md
+++ b/docs/user_guide/api/targets.md
@@ -194,3 +194,42 @@ Returns an empty body if successful.
         ]
     }
     ```
+    
+## `PATCH /api/v1/targets/{id}/subscriptions`
+
+Updates existing subscriptions for the target ID
+    
+Returns an empty body if successful.
+
+=== "Request"
+    ```bash
+    curl --request PATCH gnmic-api-address:port/api/v1/targets/192.168.1.131:57400/subscriptions -d '{"subscriptions": ["sub1", "sub2"]}'
+    ```
+=== "200 OK"
+    ```json
+    ```
+=== "404 Not found"
+    ```json
+    {
+        "errors": [
+            "target $target not found"
+        ]
+    }
+    ```
+=== "400 Bad Request"
+    ```json
+    {
+        "errors": [
+            "subscriptions not found",
+            "subscription $subscription does not exist"
+        ]
+    }
+    ```
+=== "500 Internal Server Error"
+    ```json
+    {
+        "errors": [
+            "Error Text"
+        ]
+    }
+    ```

--- a/pkg/app/routes.go
+++ b/pkg/app/routes.go
@@ -36,6 +36,7 @@ func (a *App) configRoutes(r *mux.Router) {
 	r.HandleFunc("/config/targets/{id}", a.handleConfigTargetsGet).Methods(http.MethodGet)
 	r.HandleFunc("/config/targets", a.handleConfigTargetsPost).Methods(http.MethodPost)
 	r.HandleFunc("/config/targets/{id}", a.handleConfigTargetsDelete).Methods(http.MethodDelete)
+	r.HandleFunc("/config/targets/{id}/subscriptions", a.handleConfigTargetsSubscriptions).Methods(http.MethodPatch)
 	// config/subscriptions
 	r.HandleFunc("/config/subscriptions", a.handleConfigSubscriptions).Methods(http.MethodGet)
 	// config/outputs

--- a/pkg/app/target.go
+++ b/pkg/app/target.go
@@ -100,6 +100,7 @@ func (a *App) UpdateTargetSubscription(ctx context.Context, name string, subs []
 	a.configLock.Lock()
 	for _, subName := range subs {
 		if _, ok := a.Config.Subscriptions[subName]; !ok {
+			a.configLock.Unlock()
 			return fmt.Errorf("subscription %q does not exist", subName)
 		}
 	}


### PR DESCRIPTION
This PR introduces a new API endpoint `/config/targets/:id/subscriptions` designed to allow users to directly update the subscription list for a specific target without the need to delete and re-add the target.

The use case for this endpoint allows us to build an initial target list with a single subscription for system information (i.e. `eos_native:/Eos/image` for EOS or `/system/information/version` for SRL) that we can update with subscriptions for specific paths that vary across vendor versions to accommodate breaking changes in models.
