### PR TITLE
Removed file content trimming on reading for the update-file/replace-file/union-replace-file arguments

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -687,7 +687,7 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 			}
 			updOpt = api.Update(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(updateData, " \r\n\t")), c.Encoding),
+				api.Value(string(updateData), c.Encoding),
 			)
 
 		} else {
@@ -709,7 +709,7 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 			}
 			replaceOpt = api.Replace(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(replaceData, " \r\n\t")), c.Encoding),
+				api.Value(string(replaceData), c.Encoding),
 			)
 
 		} else {
@@ -731,7 +731,7 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 			}
 			unionReplaceOpt = api.UnionReplace(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(replaceData, " \r\n\t")), c.Encoding),
+				api.Value(string(replaceData), c.Encoding),
 			)
 
 		} else {


### PR DESCRIPTION
Firstly, the trimming of data is already done in the the `value` function in `pkg/api/gnmi_msgs.go`.

Secondly, we can send CLI commands using the `--update-path cli: --update-file <path-to-file>` args (replace and union-replace as well) by keeping CLI commands in the input file. The files are always trimmed when read. This causes an issue if the encoding is ASCII and the router expects the CLI command to terminate with a '\n'.

Using the `--update-cli-file` arg does solve this issue (since the file isn't trimmed in this case) but it locks the origin into 'cli'. From a testing perspective, I want to try 'xr_cli' or 'junos_cli'. I would also like to test negative cases where origin is not cli. Also, `union-replace-cli` is not a flag that exists, hence this change.