### PR TITLE
Added a no-trim flag for SET operations

### DIFF
--- a/pkg/app/set.go
+++ b/pkg/app/set.go
@@ -133,6 +133,7 @@ func (a *App) InitSetFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&a.Config.LocalFlags.SetRequestVars, "request-vars", "", "", "set request variables file")
 	cmd.Flags().BoolVarP(&a.Config.LocalFlags.SetDryRun, "dry-run", "", false, "prints the set request without initiating a gRPC connection")
 	cmd.Flags().StringArrayVarP(&a.Config.LocalFlags.SetRequestProtoFile, "proto-file", "", []string{}, "set request from prototext file")
+	cmd.Flags().BoolVarP(&a.Config.LocalFlags.SetNoTrim, "no-trim", "", false, "won't trim the input files")
 	//
 	cmd.Flags().StringArrayVarP(&a.Config.LocalFlags.SetReplaceCli, "replace-cli", "", []string{}, "a cli command to be sent as a set replace request")
 	cmd.Flags().StringVarP(&a.Config.LocalFlags.SetReplaceCliFile, "replace-cli-file", "", "", "path to a file containing a list of commands that will be sent as a set replace request")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,7 @@ type LocalFlags struct {
 	SetRequestVars            string        `mapstructure:"set-request-vars,omitempty" json:"set-request-vars,omitempty" yaml:"set-request-vars,omitempty"`
 	SetRequestProtoFile       []string      `mapstructure:"set-proto-request-file,omitempty" yaml:"set-proto-request-file,omitempty" json:"set-proto-request-file,omitempty"`
 	SetDryRun                 bool          `mapstructure:"set-dry-run,omitempty" json:"set-dry-run,omitempty" yaml:"set-dry-run,omitempty"`
+	SetNoTrim                 bool          `mapstructure:"set-no-trim,omitempty" json:"set-no-trim,omitempty" yaml:"set-no-trim,omitempty"`
 	SetReplaceCli             []string      `mapstructure:"set-replace-cli,omitempty" yaml:"set-replace-cli,omitempty" json:"set-replace-cli,omitempty"`
 	SetReplaceCliFile         string        `mapstructure:"set-replace-cli-file,omitempty" yaml:"set-replace-cli-file,omitempty" json:"set-replace-cli-file,omitempty"`
 	SetUpdateCli              []string      `mapstructure:"set-update-cli,omitempty" yaml:"set-update-cli,omitempty" json:"set-update-cli,omitempty"`
@@ -685,9 +686,13 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				c.logger.Printf("error reading data from file '%s': %v", c.LocalFlags.SetUpdateFile[i], err)
 				return nil, err
 			}
+			trimChars := " \r\n\t"
+			if c.LocalFlags.SetNoTrim {
+				trimChars = ""
+			}
 			updOpt = api.Update(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(updateData, " \r\n\t")), c.Encoding),
+				api.Value(string(bytes.Trim(updateData, trimChars)), c.Encoding),
 			)
 
 		} else {
@@ -707,9 +712,13 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				c.logger.Printf("error reading data from file '%s': %v", c.LocalFlags.SetReplaceFile[i], err)
 				return nil, err
 			}
+			trimChars := " \r\n\t"
+			if c.LocalFlags.SetNoTrim {
+				trimChars = ""
+			}
 			replaceOpt = api.Replace(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(replaceData, " \r\n\t")), c.Encoding),
+				api.Value(string(bytes.Trim(replaceData, trimChars)), c.Encoding),
 			)
 
 		} else {
@@ -729,9 +738,13 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				c.logger.Printf("error reading data from file '%s': %v", c.LocalFlags.SetUnionReplaceFile[i], err)
 				return nil, err
 			}
+			trimChars := " \r\n\t"
+			if c.LocalFlags.SetNoTrim {
+				trimChars = ""
+			}
 			unionReplaceOpt = api.UnionReplace(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(replaceData, " \r\n\t")), c.Encoding),
+				api.Value(string(bytes.Trim(replaceData, trimChars)), c.Encoding),
 			)
 
 		} else {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ const (
 	configName      = ".gnmic"
 	configLogPrefix = "[config] "
 	envPrefix       = "GNMIC"
+	trimChars       = " \r\n\t"
 )
 
 var ErrInvalidConfig = errors.New("invalid configuration")
@@ -686,13 +687,13 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				c.logger.Printf("error reading data from file '%s': %v", c.LocalFlags.SetUpdateFile[i], err)
 				return nil, err
 			}
-			trimChars := " \r\n\t"
-			if c.LocalFlags.SetNoTrim {
-				trimChars = ""
+			trim := ""
+			if !c.LocalFlags.SetNoTrim {
+				trim = trimChars
 			}
 			updOpt = api.Update(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(updateData, trimChars)), c.Encoding),
+				api.Value(string(bytes.Trim(updateData, trim)), c.Encoding),
 			)
 
 		} else {
@@ -712,13 +713,13 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				c.logger.Printf("error reading data from file '%s': %v", c.LocalFlags.SetReplaceFile[i], err)
 				return nil, err
 			}
-			trimChars := " \r\n\t"
-			if c.LocalFlags.SetNoTrim {
-				trimChars = ""
+			trim := ""
+			if !c.LocalFlags.SetNoTrim {
+				trim = trimChars
 			}
 			replaceOpt = api.Replace(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(replaceData, trimChars)), c.Encoding),
+				api.Value(string(bytes.Trim(replaceData, trim)), c.Encoding),
 			)
 
 		} else {
@@ -738,13 +739,13 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				c.logger.Printf("error reading data from file '%s': %v", c.LocalFlags.SetUnionReplaceFile[i], err)
 				return nil, err
 			}
-			trimChars := " \r\n\t"
-			if c.LocalFlags.SetNoTrim {
-				trimChars = ""
+			trim := ""
+			if !c.LocalFlags.SetNoTrim {
+				trim = trimChars
 			}
 			unionReplaceOpt = api.UnionReplace(
 				api.Path(strings.TrimSpace(p)),
-				api.Value(string(bytes.Trim(replaceData, trimChars)), c.Encoding),
+				api.Value(string(bytes.Trim(replaceData, trim)), c.Encoding),
 			)
 
 		} else {


### PR DESCRIPTION
We can send CLI commands using the `--update-path cli: --update-file <path-to-file>` args (replace and union-replace as well) by keeping CLI commands in the input file. The files are always trimmed when read. This causes an issue if the encoding is ASCII and the router expects the CLI command to terminate with a '\n'.

Using the `--update-cli-file` arg does solve this issue (since the file isn't trimmed in this case) but it locks the origin into 'cli'. From a testing perspective, I want to try 'xr_cli' or 'junos_cli'. I would also like to test negative cases where origin is not cli. Also, `union-replace-cli` is not a flag that exists, hence this change.