### PR TITLE
Add shutdown route

### DIFF
--- a/docs/user_guide/api/other.md
+++ b/docs/user_guide/api/other.md
@@ -16,3 +16,14 @@ Health check endpoint for Kubernetes or similar
         "status": "healthy"
     }
     ```
+    
+## /api/v1/admin/shutdown
+
+### `POST /api/v1/admin/shutdown`
+
+Gracefully shut down the application
+
+=== "Request"
+    ```bash
+    curl --request POST gnmic-api-address:port/api/v1/admin/shutdown
+    ```

--- a/pkg/app/api.go
+++ b/pkg/app/api.go
@@ -330,6 +330,11 @@ func (a *App) handleHealthzGet(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
+func (a *App) handleAdminShutdown(w http.ResponseWriter, r *http.Request) {
+	a.Logger.Printf("shutting down due to user request")
+	a.Cfn()
+}
+
 func (a *App) handleClusteringMembersGet(w http.ResponseWriter, r *http.Request) {
 	if a.Config.Clustering == nil {
 		return

--- a/pkg/app/routes.go
+++ b/pkg/app/routes.go
@@ -20,6 +20,7 @@ func (a *App) routes() {
 	a.configRoutes(apiV1)
 	a.targetRoutes(apiV1)
 	a.healthRoutes(apiV1)
+	a.adminRoutes(apiV1)
 }
 
 func (a *App) clusterRoutes(r *mux.Router) {
@@ -63,4 +64,8 @@ func (a *App) targetRoutes(r *mux.Router) {
 
 func (a *App) healthRoutes(r *mux.Router) {
 	r.HandleFunc("/healthz", a.handleHealthzGet).Methods(http.MethodGet)
+}
+
+func (a *App) adminRoutes(r *mux.Router) {
+	r.HandleFunc("/admin/shutdown", a.handleAdminShutdown).Methods(http.MethodPost)
 }


### PR DESCRIPTION
Howdy!

This PR adds a simple route `/api/v1/admin/shutdown` which cancels the `App` main context and shuts down the running `gnmic` server. 

In our environment we run `gnmic` in k8s and have an in-memory datastore. When we detect that this datastore has failed/crashed for some reason we would like a way to signal `gnmic` to restart immediately to trigger resubscription/resync of all paths.

Let me know if you have any feedback on this or have another approach you'd recommend.