### PR TITLE
add support for rotating file outputs

### DIFF
--- a/docs/user_guide/outputs/file_output.md
+++ b/docs/user_guide/outputs/file_output.md
@@ -10,8 +10,8 @@ outputs:
     # filename to write telemetry data to.
     # will be ignored if `file-type` is set
     filename: /path/to/filename
-    # file-type, stdout or stderr
-    # overwrites `filename` if stdout or stderr
+    # file-type, stdout or stderr.
+    # overwrites `filename`
     file-type: # stdout or stderr
     # string, message formatting, json, protojson, prototext, event
     format: 

--- a/docs/user_guide/outputs/file_output.md
+++ b/docs/user_guide/outputs/file_output.md
@@ -10,9 +10,9 @@ outputs:
     # filename to write telemetry data to.
     # will be ignored if `file-type` is set
     filename: /path/to/filename
-    # file-type, stdout or stderr.
-    # overwrites `filename`
-    file-type: # stdout or stderr
+    # file-type, stdout, stderr, or rotating.
+    # overwrites `filename` if stdout or stderr
+    file-type: # stdout, stderr, or rotating
     # string, message formatting, json, protojson, prototext, event
     format: 
     # string, one of `overwrite`, `if-not-present`, ``
@@ -54,10 +54,20 @@ outputs:
     enable-metrics: false
      # list of processors to apply on the message before writing
     event-processors:
+    # file rotation configuration
+    #   all fields are required if enabling file rotation
+    rotation:
+      max-size: 100 # size in megabytes
+      max-age: 30 # max age in days
+      max-backups: 3 # maximum number of old files to store, not counting the current file
+      compress: false # whether or not to enable compression
+      
 ```
 
-The file output can be used to write to file on the disk, to stdout or to stderr.
+The file output can be used to write to file on the disk, to stdout or to stderr. Also includes support for rotating files to control disk utilization and maximum age.
 
 For a disk file, a file name is required.
 
 For stdout or stderr, only file-type is required.
+
+For rotation, all fields (other than `compress`) are required.

--- a/docs/user_guide/outputs/file_output.md
+++ b/docs/user_guide/outputs/file_output.md
@@ -55,7 +55,6 @@ outputs:
      # list of processors to apply on the message before writing
     event-processors:
     # file rotation configuration
-    #   all fields are required if enabling file rotation
     rotation:
       max-size: 100 # size in megabytes
       max-age: 30 # max age in days
@@ -69,5 +68,3 @@ The file output can be used to write to file on the disk, to stdout or to stderr
 For a disk file, a file name is required.
 
 For stdout or stderr, only file-type is required.
-
-For rotation, all fields (other than `compress`) are required.

--- a/docs/user_guide/outputs/file_output.md
+++ b/docs/user_guide/outputs/file_output.md
@@ -10,9 +10,9 @@ outputs:
     # filename to write telemetry data to.
     # will be ignored if `file-type` is set
     filename: /path/to/filename
-    # file-type, stdout, stderr, or rotating.
+    # file-type, stdout or stderr
     # overwrites `filename` if stdout or stderr
-    file-type: # stdout, stderr, or rotating
+    file-type: # stdout or stderr
     # string, message formatting, json, protojson, prototext, event
     format: 
     # string, one of `overwrite`, `if-not-present`, ``
@@ -63,7 +63,7 @@ outputs:
       
 ```
 
-The file output can be used to write to file on the disk, to stdout or to stderr. Also includes support for rotating files to control disk utilization and maximum age.
+The file output can be used to write to file on the disk, to stdout or to stderr. Also includes support for rotating files to control disk utilization and maximum age using the `rotation` configuration section.
 
 For a disk file, a file name is required.
 

--- a/pkg/outputs/file/file_output.go
+++ b/pkg/outputs/file/file_output.go
@@ -157,7 +157,7 @@ func (f *File) Init(ctx context.Context, name string, cfg map[string]interface{}
 			return err
 		}
 
-		f.file = newRotatingFile(f.cfg.FileName, f.cfg.Rotation.Compress, f.cfg.Rotation.MaxSize, f.cfg.Rotation.MaxBackups, f.cfg.Rotation.MaxAge)
+		f.file = newRotatingFile(f.cfg)
 	default:
 	CRFILE:
 		f.file, err = os.OpenFile(f.cfg.FileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)

--- a/pkg/outputs/file/file_output.go
+++ b/pkg/outputs/file/file_output.go
@@ -78,7 +78,7 @@ type Config struct {
 	EnableMetrics      bool           `mapstructure:"enable-metrics,omitempty"`
 	Debug              bool           `mapstructure:"debug,omitempty"`
 	CalculateLatency   bool           `mapstructure:"calculate-latency,omitempty"`
-	Rotation           RotationConfig `mapstructure:"rotation,omitempty"`
+	Rotation           rotationConfig `mapstructure:"rotation,omitempty"`
 }
 
 type file interface {
@@ -150,13 +150,6 @@ func (f *File) Init(ctx context.Context, name string, cfg map[string]interface{}
 	case "stderr":
 		f.file = os.Stderr
 	case "rotating":
-		err := f.cfg.Rotation.validateConfig()
-		if err != nil {
-			f.logger.Printf("failed to validate rotating configuration: %v", err)
-
-			return err
-		}
-
 		f.file = newRotatingFile(f.cfg)
 	default:
 	CRFILE:

--- a/pkg/outputs/file/rotating_file.go
+++ b/pkg/outputs/file/rotating_file.go
@@ -36,13 +36,13 @@ type rotatingFile struct {
 }
 
 // newRotatingFile initialize the lumberjack instance
-func newRotatingFile(filename string, compress bool, maxSize, maxBackups, maxAge int) *rotatingFile {
+func newRotatingFile(cfg *Config) *rotatingFile {
 	lj := lumberjack.Logger{
-		Filename:   filename,
-		MaxSize:    maxSize,
-		MaxBackups: maxBackups,
-		MaxAge:     maxAge,
-		Compress:   compress,
+		Filename:   cfg.FileName,
+		MaxSize:    cfg.Rotation.MaxSize,
+		MaxBackups: cfg.Rotation.MaxBackups,
+		MaxAge:     cfg.Rotation.MaxAge,
+		Compress:   cfg.Rotation.Compress,
 	}
 
 	return &rotatingFile{l: &lj}

--- a/pkg/outputs/file/rotating_file.go
+++ b/pkg/outputs/file/rotating_file.go
@@ -1,34 +1,28 @@
 package file
 
 import (
-	"fmt"
-
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // RotationConfig manages configuration around file rotation
-type RotationConfig struct {
+type rotationConfig struct {
 	MaxSize    int  `mapstructure:"max-size,omitempty"`
 	MaxBackups int  `mapstructure:"max-backups,omitempty"`
 	MaxAge     int  `mapstructure:"max-age,omitempty"`
 	Compress   bool `mapstructure:"compress,omitempty"`
 }
 
-// validateConfig ensures all parameters are supplied
-func (rc *RotationConfig) validateConfig() error {
-	if rc.MaxSize == 0 {
-		return fmt.Errorf("Rotation.MaxSize is required if using type 'rotating'")
+func (r *rotationConfig) SetDefaults() {
+	if r.MaxSize == 0 {
+		r.MaxSize = 100
+	}
+	if r.MaxBackups == 0 {
+		r.MaxBackups = 3
 	}
 
-	if rc.MaxBackups == 0 {
-		return fmt.Errorf("Rotation.MaxBackups is required if using type 'rotating'")
+	if r.MaxAge == 0 {
+		r.MaxAge = 30
 	}
-
-	if rc.MaxAge == 0 {
-		return fmt.Errorf("Rotation.MaxAge is required if using type 'rotating'")
-	}
-
-	return nil
 }
 
 type rotatingFile struct {
@@ -37,6 +31,8 @@ type rotatingFile struct {
 
 // newRotatingFile initialize the lumberjack instance
 func newRotatingFile(cfg *Config) *rotatingFile {
+	cfg.Rotation.SetDefaults()
+
 	lj := lumberjack.Logger{
 		Filename:   cfg.FileName,
 		MaxSize:    cfg.Rotation.MaxSize,

--- a/pkg/outputs/file/rotating_file.go
+++ b/pkg/outputs/file/rotating_file.go
@@ -1,0 +1,64 @@
+package file
+
+import (
+	"fmt"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// RotationConfig manages configuration around file rotation
+type RotationConfig struct {
+	MaxSize    int  `mapstructure:"max-size,omitempty"`
+	MaxBackups int  `mapstructure:"max-backups,omitempty"`
+	MaxAge     int  `mapstructure:"max-age,omitempty"`
+	Compress   bool `mapstructure:"compress,omitempty"`
+}
+
+// validateConfig ensures all parameters are supplied
+func (rc *RotationConfig) validateConfig() error {
+	if rc.MaxSize == 0 {
+		return fmt.Errorf("Rotation.MaxSize is required if using type 'rotating'")
+	}
+
+	if rc.MaxBackups == 0 {
+		return fmt.Errorf("Rotation.MaxBackups is required if using type 'rotating'")
+	}
+
+	if rc.MaxAge == 0 {
+		return fmt.Errorf("Rotation.MaxAge is required if using type 'rotating'")
+	}
+
+	return nil
+}
+
+type rotatingFile struct {
+	l *lumberjack.Logger
+}
+
+// newRotatingFile initialize the lumberjack instance
+func newRotatingFile(filename string, compress bool, maxSize, maxBackups, maxAge int) *rotatingFile {
+	lj := lumberjack.Logger{
+		Filename:   filename,
+		MaxSize:    maxSize,
+		MaxBackups: maxBackups,
+		MaxAge:     maxAge,
+		Compress:   compress,
+	}
+
+	return &rotatingFile{l: &lj}
+}
+
+// Close closes the file
+func (r *rotatingFile) Close() error {
+	return r.l.Close()
+}
+
+// Name returns the name of the file
+func (r *rotatingFile) Name() string {
+	return r.l.Filename
+}
+
+// Write implements io.Writer
+func (r *rotatingFile) Write(b []byte) (int, error) {
+	return r.l.Write(b)
+}


### PR DESCRIPTION
This PR adds support for rotating file outputs, similar to log rotation. In our internal use of gnmic I have written some scripts to replay production events logged from the `file` output into a development environment so that we can reproduce bugs and do some load testing. Whenever I needed a production dump I would restart gnmic with a file output enabled for an hour or so and then grab the file and roll back to our previous configuration.

This option enables us to limit the disk space and just keep the last 3x 100MB files available on our k8s nodes should we need to grab them to replay or troubleshoot. No behavior is changed if not using the `rotating` file-type.

You can specify the file-type as `rotating` and then supply the following configuration to configure the rotation parameters:
```yaml
    rotation:
      max-size: 100 # size in megabytes
      max-age: 30 # max age in days
      max-backups: 3 # maximum number of old files to store, not counting the current file
      compress: false # whether or not to enable compression
```

This uses the `lumberjack` package in Go to handle the rotation when enabled. 

To support this I've converted the `File.file` from an `*os.File` to a new `file` interface that is satisfied by the new `rotatingFile` struct. This allowed me to add the new behavior without modifying any of the existing logic.

Let me know if you have any comments or concerns about this!