### PR TITLE
Add a metric for failed subscriptions

### DIFF
--- a/pkg/app/api.go
+++ b/pkg/app/api.go
@@ -49,6 +49,7 @@ func (a *App) newAPIServer() (*http.Server, error) {
 		a.reg.MustRegister(collectors.NewGoCollector())
 		a.reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 		a.reg.MustRegister(subscribeResponseReceivedCounter)
+		a.reg.MustRegister(subscribeResponseFailedCounter)
 		go a.startClusterMetrics()
 	}
 	s := &http.Server{

--- a/pkg/app/collector.go
+++ b/pkg/app/collector.go
@@ -118,7 +118,8 @@ func (a *App) StartCollector(ctx context.Context) {
 				case tErr := <-errChan:
 					if errors.Is(tErr.Err, io.EOF) {
 						a.Logger.Printf("target %q: subscription %s closed stream(EOF)", t.Config.Name, tErr.SubscriptionName)
-					} else {
+						} else {
+						subscribeResponseFailedCounter.WithLabelValues(t.Config.Name, tErr.SubscriptionName).Inc()
 						a.Logger.Printf("target %q: subscription %s rcv error: %v", t.Config.Name, tErr.SubscriptionName, tErr.Err)
 					}
 					if remainingOnceSubscriptions > 0 {

--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -28,6 +28,13 @@ var subscribeResponseReceivedCounter = prometheus.NewCounterVec(prometheus.Count
 	Help:      "Total number of received subscribe response messages",
 }, []string{"source", "subscription"})
 
+var subscribeResponseFailedCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "gnmic",
+	Subsystem: "subscribe",
+	Name:      "number_of_failed_subscribe_request_messages_total",
+	Help:      "Total number of failed subscribe requests",
+}, []string{"source", "subscription"})
+
 // cluster
 var clusterNumberOfLockedTargets = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: "gnmic",


### PR DESCRIPTION
This adds a way to monitor failed subscription response received, it makes it easier to identified missconfigured devices or subscriptions.

Maybe we should include the error in the label as well ?