### PR TITLE
Added BufferSize to Jetsream and NATS outputs

### DIFF
--- a/docs/user_guide/outputs/jetstream_output.md
+++ b/docs/user_guide/outputs/jetstream_output.md
@@ -123,6 +123,10 @@ outputs:
     # boolean, enables extra logging for the nats output
     debug: false
     # boolean, enables the collection and export (via prometheus) of output specific metrics
+    # integer, sets the size of the local buffer where received
+    # NATS messages are stored before being sent to outputs.
+    # This value is set per worker. Defaults to 100 messages
+    buffer-size: 100
     enable-metrics: false 
     # list of processors to apply to the message before writing
     event-processors: 

--- a/docs/user_guide/outputs/jetstream_output.md
+++ b/docs/user_guide/outputs/jetstream_output.md
@@ -122,11 +122,11 @@ outputs:
     write-timeout: 5s 
     # boolean, enables extra logging for the nats output
     debug: false
-    # boolean, enables the collection and export (via prometheus) of output specific metrics
     # integer, sets the size of the local buffer where received
     # NATS messages are stored before being sent to outputs.
-    # This value is set per worker. Defaults to 100 messages
-    buffer-size: 100
+    # This value is set per worker. Defaults to 0 messages
+    buffer-size: 0
+    # boolean, enables the collection and export (via prometheus) of output specific metrics
     enable-metrics: false 
     # list of processors to apply to the message before writing
     event-processors: 

--- a/docs/user_guide/outputs/nats_output.md
+++ b/docs/user_guide/outputs/nats_output.md
@@ -72,11 +72,11 @@ outputs:
     write-timeout: 5s 
     # boolean, enables extra logging for the nats output
     debug: false
-    # boolean, enables the collection and export (via prometheus) of output specific metrics
     # integer, sets the size of the local buffer where received
     # NATS messages are stored before being sent to outputs.
-    # This value is set per worker. Defaults to 100 messages
-    buffer-size: 100
+    # This value is set per worker. Defaults to 0 messages
+    buffer-size: 0
+    # boolean, enables the collection and export (via prometheus) of output specific metrics
     enable-metrics: false 
     # list of processors to apply on the message before writing
     event-processors: 

--- a/docs/user_guide/outputs/nats_output.md
+++ b/docs/user_guide/outputs/nats_output.md
@@ -73,6 +73,10 @@ outputs:
     # boolean, enables extra logging for the nats output
     debug: false
     # boolean, enables the collection and export (via prometheus) of output specific metrics
+    # integer, sets the size of the local buffer where received
+    # NATS messages are stored before being sent to outputs.
+    # This value is set per worker. Defaults to 100 messages
+    buffer-size: 100
     enable-metrics: false 
     # list of processors to apply on the message before writing
     event-processors: 

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -87,6 +87,7 @@ type config struct {
 	NumWorkers         int                 `mapstructure:"num-workers,omitempty" json:"num-workers,omitempty"`
 	WriteTimeout       time.Duration       `mapstructure:"write-timeout,omitempty" json:"write-timeout,omitempty"`
 	Debug              bool                `mapstructure:"debug,omitempty" json:"debug,omitempty"`
+	BufferSize         int                 `mapstructure:"buffer-size,omitempty"`
 	EnableMetrics      bool                `mapstructure:"enable-metrics,omitempty" json:"enable-metrics,omitempty"`
 	EventProcessors    []string            `mapstructure:"event-processors,omitempty" json:"event-processors,omitempty"`
 }
@@ -136,7 +137,7 @@ func (n *jetstreamOutput) Init(ctx context.Context, name string, cfg map[string]
 		return err
 	}
 
-	n.msgChan = make(chan *outputs.ProtoMsg)
+	n.msgChan = make(chan *outputs.ProtoMsg, uint(n.Cfg.BufferSize))
 	initMetrics()
 	n.mo = &formatters.MarshalOptions{
 		Format:     n.Cfg.Format,

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -137,7 +137,7 @@ func (n *jetstreamOutput) Init(ctx context.Context, name string, cfg map[string]
 		return err
 	}
 
-	n.msgChan = make(chan *outputs.ProtoMsg, uint(n.Cfg.BufferSize))
+	n.msgChan = make(chan *outputs.ProtoMsg, n.Cfg.BufferSize)
 	initMetrics()
 	n.mo = &formatters.MarshalOptions{
 		Format:     n.Cfg.Format,

--- a/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
+++ b/pkg/outputs/nats_outputs/jetstream/jetstream_output.go
@@ -87,7 +87,7 @@ type config struct {
 	NumWorkers         int                 `mapstructure:"num-workers,omitempty" json:"num-workers,omitempty"`
 	WriteTimeout       time.Duration       `mapstructure:"write-timeout,omitempty" json:"write-timeout,omitempty"`
 	Debug              bool                `mapstructure:"debug,omitempty" json:"debug,omitempty"`
-	BufferSize         int                 `mapstructure:"buffer-size,omitempty"`
+	BufferSize         uint                `mapstructure:"buffer-size,omitempty"`
 	EnableMetrics      bool                `mapstructure:"enable-metrics,omitempty" json:"enable-metrics,omitempty"`
 	EventProcessors    []string            `mapstructure:"event-processors,omitempty" json:"event-processors,omitempty"`
 }

--- a/pkg/outputs/nats_outputs/nats/nats_output.go
+++ b/pkg/outputs/nats_outputs/nats/nats_output.go
@@ -87,6 +87,7 @@ type Config struct {
 	NumWorkers         int              `mapstructure:"num-workers,omitempty"`
 	WriteTimeout       time.Duration    `mapstructure:"write-timeout,omitempty"`
 	Debug              bool             `mapstructure:"debug,omitempty"`
+	BufferSize         int              `mapstructure:"buffer-size,omitempty"`
 	EnableMetrics      bool             `mapstructure:"enable-metrics,omitempty"`
 	EventProcessors    []string         `mapstructure:"event-processors,omitempty"`
 }
@@ -145,7 +146,7 @@ func (n *NatsOutput) Init(ctx context.Context, name string, cfg map[string]inter
 		return err
 	}
 
-	n.msgChan = make(chan *outputs.ProtoMsg)
+	n.msgChan = make(chan *outputs.ProtoMsg, uint(n.Cfg.BufferSize))
 	initMetrics()
 	n.mo = &formatters.MarshalOptions{
 		Format:     n.Cfg.Format,

--- a/pkg/outputs/nats_outputs/nats/nats_output.go
+++ b/pkg/outputs/nats_outputs/nats/nats_output.go
@@ -87,7 +87,7 @@ type Config struct {
 	NumWorkers         int              `mapstructure:"num-workers,omitempty"`
 	WriteTimeout       time.Duration    `mapstructure:"write-timeout,omitempty"`
 	Debug              bool             `mapstructure:"debug,omitempty"`
-	BufferSize         int              `mapstructure:"buffer-size,omitempty"`
+	BufferSize         uint             `mapstructure:"buffer-size,omitempty"`
 	EnableMetrics      bool             `mapstructure:"enable-metrics,omitempty"`
 	EventProcessors    []string         `mapstructure:"event-processors,omitempty"`
 }

--- a/pkg/outputs/nats_outputs/nats/nats_output.go
+++ b/pkg/outputs/nats_outputs/nats/nats_output.go
@@ -146,7 +146,7 @@ func (n *NatsOutput) Init(ctx context.Context, name string, cfg map[string]inter
 		return err
 	}
 
-	n.msgChan = make(chan *outputs.ProtoMsg, uint(n.Cfg.BufferSize))
+	n.msgChan = make(chan *outputs.ProtoMsg, n.Cfg.BufferSize)
 	initMetrics()
 	n.mo = &formatters.MarshalOptions{
 		Format:     n.Cfg.Format,


### PR DESCRIPTION
## Primer
This is a follow-up to [THIS](https://github.com/openconfig/gnmic/issues/342) issue.  We would like to set the `buffer-size` field in the JetStream config output when the Go channel is created but this option is not currently available.   We noticed this isn't available in the NATs output either so we added it as well.

## Change
- [x] added BufferSize as a Config field for NATs and JetStream outputs
- [x] added  the BufferSize option to the Go channel when created
- [x] updated the user documents

