### PR TITLE
fix: Make logging healthz route optional

### DIFF
--- a/docs/user_guide/api/api_intro.md
+++ b/docs/user_guide/api/api_intro.md
@@ -58,6 +58,8 @@ api-server:
   enable-metrics: false
   # boolean, enables extra debug log printing
   debug: false
+  # boolean, disables creating log messages when accessing the `healthz` path
+  healthz-disable-logging: false
 ```
 
 ## API Endpoints

--- a/pkg/app/api.go
+++ b/pkg/app/api.go
@@ -506,8 +506,10 @@ func headersMiddleware(next http.Handler) http.Handler {
 }
 
 func (a *App) loggingMiddleware(next http.Handler) http.Handler {
-	next = handlers.LoggingHandler(a.Logger.Writer(), next)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if (!a.Config.APIServer.HealthzDisableLogging && r.URL.Path == "/api/v1/healthz") || r.URL.Path != "/api/v1/healthz" {
+			next = handlers.LoggingHandler(a.Logger.Writer(), next)
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/config/api_server.go
+++ b/pkg/config/api_server.go
@@ -28,6 +28,7 @@ type APIServer struct {
 	TLS           *types.TLSConfig `mapstructure:"tls,omitempty" json:"tls,omitempty"`
 	EnableMetrics bool             `mapstructure:"enable-metrics,omitempty" json:"enable-metrics,omitempty"`
 	Debug         bool             `mapstructure:"debug,omitempty" json:"debug,omitempty"`
+	HealthzDisableLogging bool     	   `mapstructure:"healthz-disable-logging,omitempty" json:"healthz-disable-logging,omitempty"`
 }
 
 func (c *Config) GetAPIServer() error {
@@ -53,6 +54,7 @@ func (c *Config) GetAPIServer() error {
 
 	c.APIServer.EnableMetrics = os.ExpandEnv(c.FileConfig.GetString("api-server/enable-metrics")) == trueString
 	c.APIServer.Debug = os.ExpandEnv(c.FileConfig.GetString("api-server/debug")) == trueString
+	c.APIServer.HealthzDisableLogging = os.ExpandEnv(c.FileConfig.GetString("api-server/healthz-disable-logging")) == trueString
 	c.setAPIServerDefaults()
 	return nil
 }


### PR DESCRIPTION
When using the `/api/v1/healthz` endpoint to check on the status of the container, it generates a lot of log messages that don't add any value. This provides a configuration option (`healthz-disable-logging`) that will not create log messages when there is an HTTP GET to that path