### PR TITLE
Handle target changes in loaders

### DIFF
--- a/pkg/app/loaders.go
+++ b/pkg/app/loaders.go
@@ -45,6 +45,7 @@ START:
 	}
 	a.Logger.Printf("starting loader type %q", ldTypeS)
 	for targetOp := range ld.Start(ctx) {
+		// do deletes first, since target change equates to delete+add
 		for _, del := range targetOp.Del {
 			// not clustered, delete local target
 			if !a.inCluster() {
@@ -113,6 +114,7 @@ START:
 	}
 	a.Logger.Printf("starting loader type %q", ldTypeS)
 	for targetOp := range ld.Start(ctx) {
+		// do deletes first since target change is delete+add
 		for _, del := range targetOp.Del {
 			// clustered, delete target in all instances of the cluster
 			a.configLock.Lock()

--- a/pkg/loaders/consul_loader/consul_loader.go
+++ b/pkg/loaders/consul_loader/consul_loader.go
@@ -434,11 +434,12 @@ func (c *consulLoader) updateTargets(ctx context.Context, srvName string, tcs ma
 	if _, ok := c.lastTargets[srvName]; !ok {
 		c.lastTargets[srvName] = make(map[string]*types.TargetConfig)
 	}
-	for _, add := range targetOp.Add {
-		c.lastTargets[srvName][add.Name] = add
-	}
+	// do delete first since change is delete+add
 	for _, del := range targetOp.Del {
 		delete(c.lastTargets[srvName], del)
+	}
+	for _, add := range targetOp.Add {
+		c.lastTargets[srvName][add.Name] = add
 	}
 	c.m.Unlock()
 

--- a/pkg/loaders/docker_loader/docker_loader.go
+++ b/pkg/loaders/docker_loader/docker_loader.go
@@ -520,11 +520,12 @@ func (d *dockerLoader) updateTargets(ctx context.Context, tcs map[string]*types.
 		return
 	}
 	d.m.Lock()
-	for _, add := range targetOp.Add {
-		d.lastTargets[add.Name] = add
-	}
+	// do deletes first since change is delete+add
 	for _, del := range targetOp.Del {
 		delete(d.lastTargets, del)
+	}
+	for _, add := range targetOp.Add {
+		d.lastTargets[add.Name] = add
 	}
 	d.m.Unlock()
 	opChan <- targetOp

--- a/pkg/loaders/file_loader/file_loader.go
+++ b/pkg/loaders/file_loader/file_loader.go
@@ -291,11 +291,12 @@ func (f *fileLoader) updateTargets(ctx context.Context, tcs map[string]*types.Ta
 		return
 	}
 	f.m.Lock()
-	for _, add := range targetOp.Add {
-		f.lastTargets[add.Name] = add
-	}
+	// do delete first since change is delete+add
 	for _, del := range targetOp.Del {
 		delete(f.lastTargets, del)
+	}
+	for _, add := range targetOp.Add {
+		f.lastTargets[add.Name] = add
 	}
 	f.m.Unlock()
 	opChan <- targetOp

--- a/pkg/loaders/loaders_test.go
+++ b/pkg/loaders/loaders_test.go
@@ -149,6 +149,24 @@ var testSet = map[string]struct {
 			Del: []string{"target1"},
 		},
 	},
+	"t10-target-change": {
+		m1: map[string]*types.TargetConfig{
+			"target1": {Address: "ip1"},
+			"target2": {Address: "ip2"},
+		},
+		m2: map[string]*types.TargetConfig{
+			"target1": {Address: "ip1"},
+			"target2": {Address: "ip2new"},
+		},
+		output: &TargetOperation{
+			Add: map[string]*types.TargetConfig{
+				"target2": {
+					Address: "ip2new",
+				},
+			},
+			Del: []string{"target2"},
+		},
+	},
 }
 
 func TestGetInstancesTagsMatches(t *testing.T) {


### PR DESCRIPTION
When a target config changes,
generate a delete and a add action
so that the subscription can be restarted
to apply the new parameters.

https://github.com/openconfig/gnmic/issues/563