### PR TITLE
TargetUpMetric shouldn't show deleted targets

### DIFF
--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -89,7 +89,7 @@ func (a *App) registerTargetMetrics() {
 						ownTargets[strings.TrimPrefix(k, lockedNodesPrefix+"/")] = v
 					}
 				}
-
+				targetUPMetric.Reset()
 				a.configLock.RLock()
 				for _, tc := range a.Config.Targets {
 					a.operLock.RLock()


### PR DESCRIPTION
Fixes: #604 

This resets the TargetUpMetric before creating the metrics so that deleted targets (tested via Consul) don't show as still up.

