### PR TITLE
feat: Templated names and tags for Consul targets

### DIFF
--- a/docs/user_guide/targets/target_discovery/consul_discovery.md
+++ b/docs/user_guide/targets/target_discovery/consul_discovery.md
@@ -25,9 +25,9 @@ loader:
 
 ### Templating with Consul
 
-It is possible to set the target name to something other than the Consul Service ID using the `target-name` field under the service. The target name can be customized using [Go Templates](https://golang.org/pkg/text/template/).
+It is possible to set the target name to something other than the Consul Service ID using the `name` field under the config. The target name can be customized using [Go Templates](https://golang.org/pkg/text/template/).
 
-In addition to setting the target name, it is also possible to add extra `target-tags` to the targets that use the same configuration as the target name.
+In addition to setting the target name, it is also possible to use Go Templates on `event-tags` as well.
 
 The templates use the Service under Consul, so access to things like `ID`, `Tags`, `Meta`, etc. are all available.
 
@@ -36,11 +36,13 @@ loader:
   type: consul
   services:
     - name: cluster1-gnmi-server
-      target-name: "{{.Meta.fancy-target-name}}"
-      target-tags:
-        location: "{{.Meta.site_name}}"
-        model: "{{.Meta.device_type}}"
-        tag-1: "{{.Meta.tag_1}}"
+      config:
+        name: "{{.Meta.device}}"
+        event-tags:
+            location: "{{.Meta.site_name}}"
+            model: "{{.Meta.device_type}}"
+            tag-1: "{{.Meta.tag_1}}"
+            boring-static-tag: "hello"
 ```
 
 ### Configuration
@@ -67,12 +69,6 @@ loader:
   services:
       # name of the Consul service
     - name:
-      # templated name of the target
-      target-name:
-      # a mapping of Consul templated tags to add to all events from this taget.
-      # each key/value pair in this mapping will be added to metadata on all events.
-      # the templated value will be converted based on the Consul data for the target.
-      target-tags:
       # a list of strings to further filter the service instances
       tags: 
       # configuration map to apply to target discovered from this service

--- a/docs/user_guide/targets/target_discovery/consul_discovery.md
+++ b/docs/user_guide/targets/target_discovery/consul_discovery.md
@@ -23,6 +23,26 @@ loader:
         password: admin
 ```
 
+### Templating with Consul
+
+It is possible to set the target name to something other than the Consul Service ID using the `target-name` field under the service. The target name can be customized using [Go Templates](https://golang.org/pkg/text/template/).
+
+In addition to setting the target name, it is also possible to add extra `target-tags` to the targets that use the same configuration as the target name.
+
+The templates use the Service under Consul, so access to things like `ID`, `Tags`, `Meta`, etc. are all available.
+
+```yaml
+loader:
+  type: consul
+  services:
+    - name: cluster1-gnmi-server
+      target-name: "{{.Meta.fancy-target-name}}"
+      target-tags:
+        location: "{{.Meta.site_name}}"
+        model: "{{.Meta.device_type}}"
+        tag-1: "{{.Meta.tag_1}}"
+```
+
 ### Configuration
 
 ```yaml
@@ -47,6 +67,12 @@ loader:
   services:
       # name of the Consul service
     - name:
+      # templated name of the target
+      target-name:
+      # a mapping of Consul templated tags to add to all events from this taget.
+      # each key/value pair in this mapping will be added to metadata on all events.
+      # the templated value will be converted based on the Consul data for the target.
+      target-tags:
       # a list of strings to further filter the service instances
       tags: 
       # configuration map to apply to target discovered from this service

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -50,7 +50,6 @@ func (c *Config) GetLoader() error {
 					}
 					return os.ExpandEnv(v)
 				})
-				fmt.Printf("LOADER: %+v\n", c.Loader)
 				return nil
 			}
 		}

--- a/pkg/loaders/consul_loader/consul_loader.go
+++ b/pkg/loaders/consul_loader/consul_loader.go
@@ -411,11 +411,8 @@ SRV:
 			tc.Address = se.Node.Address
 		}
 		tc.Address = net.JoinHostPort(tc.Address, strconv.Itoa(se.Service.Port))
-
-		c.logger.Println(se.Service.Tags)
 		
 		var buffer bytes.Buffer
-		buffer.Reset()
 
 		if sd.TargetName != "" {
 			nameTemplate, err := template.New("targetName").Option("missingkey=zero").Parse(sd.TargetName)
@@ -423,7 +420,8 @@ SRV:
 				c.logger.Println("Could not parse nameTemplate")
 			}
 			sd.targetNameTemplate = nameTemplate
-
+			
+			buffer.Reset()
 			err = sd.targetNameTemplate.Execute(&buffer, se.Service)
 			if err != nil {
 				c.logger.Println("Could not execute nameTemplate")


### PR DESCRIPTION
This adds the ability to use Go Templates on Consul targets to set both the name of the target as well as event-tags. The primary driving force for this comes from Telegraf's [Prometheus Input Plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/prometheus) which also has Consul support and allows for using Go templates to set the name/tags as well.

As an example, you are now able to do something like:

```yaml
loader:
    type: consul
    address: consul:8500
    datacenter: "dc99"
    services:
        - name: gnmic-sros
          target-name: "{{.Meta.device}}"
          target-tags:
              region: "{{.Meta.region}}"
              geo: "{{.Meta.geo}}"
              test: "{{.Meta.test}}"
```

This also removes a debugging statement in `pkg/config/loader.go` that could potentially expose passwords in log messages