### PR TITLE
Add support for (optional) organization & version for model selection in Get request

### DIFF
--- a/pkg/app/get.go
+++ b/pkg/app/get.go
@@ -155,8 +155,25 @@ func (a *App) filterModels(ctx context.Context, tc *types.TargetConfig, modelsNa
 	var found bool
 	for _, m := range modelsNames {
 		found = false
+
+		modelName := m
+		var organization *string
+		var version *string
+
+		if strings.Contains(modelName, "/") {
+			parts := strings.SplitN(modelName, "/", 2)
+			organization = &parts[0]
+			modelName = parts[1]
+		}
+
+		if strings.Contains(modelName, ":") {
+			parts := strings.SplitN(modelName, ":", 2)
+			modelName = parts[0]
+			version = &parts[1]
+		}
+
 		for _, tModel := range supModels {
-			if m == tModel.Name {
+			if modelName == tModel.Name && (organization == nil || *organization == tModel.Organization) && (version == nil || *version == tModel.Version) {
 				supportedModels[m] = tModel
 				found = true
 				break


### PR DESCRIPTION
Currently you can only specify a (comma separated) list of names for the models that should be used when performing a get request. Open execution the first model with the same name (provided by a `capabilities` request) is used, regardless of version and organization.

This pull requests adds the possibility to further select the right models for a `get` request by _optionally_ specifying the organization (by *prepending* `<organization>/`) _or_ the required version (by *appending* `:<version>`). The current functionality is **not** changed but rather extended.