### PR TITLE
Memory leak with failing subscription

### DIFF
--- a/pkg/api/target/subscribe.go
+++ b/pkg/api/target/subscribe.go
@@ -44,7 +44,6 @@ SUBSC_NODELAY:
 		return
 	default:
 		nctx, cancel = context.WithCancel(ctx)
-		defer cancel()
 		nctx = t.appendRequestMetadata(nctx)
 		subscribeClient, err = t.Client.Subscribe(nctx, t.callOpts()...)
 		if err != nil {
@@ -98,6 +97,7 @@ SUBSC_NODELAY:
 				Err:              err,
 			}
 			if errors.Is(err, io.EOF) {
+				cancel()
 				return
 			}
 			t.errors <- &TargetError{
@@ -107,6 +107,7 @@ SUBSC_NODELAY:
 			cancel()
 			goto SUBSC
 		}
+		cancel()
 		return
 	case gnmi.SubscriptionList_POLL:
 		go t.listenPolls(nctx)
@@ -120,6 +121,7 @@ SUBSC_NODELAY:
 			goto SUBSC
 		}
 	}
+	cancel()
 }
 
 func (t *Target) SubscribeStreamChan(ctx context.Context, req *gnmi.SubscribeRequest, subscriptionName string) (chan *gnmi.SubscribeResponse, chan error) {


### PR DESCRIPTION
When a subscription fails, for instance because the path does not exists on the target, there is a memory leak in the cancel() function reference that is kept alive indefinitely by the defer, as the function is never exited.

See the attached pprof of memory allocations before and after the fix on the same setup.

A simple fix is to not defer and explicitly call cancel() every time the function can be exited. The proper fix would probably be to rewrite the function in a defer-style, avoiding mixing it with gotos. (for instance with a loop and an anonymous function inside which we can defer without risk)
I'm eager to discuss this possibility :-)

![pprof_leak](https://github.com/user-attachments/assets/5dbb4f64-c39d-4eda-b807-83008d974755)
![pprof_leak_fixed](https://github.com/user-attachments/assets/a8b187b8-123a-4208-8a86-e8a68fc4f1ef)
