### PR TITLE
Fix sync_response output for ONCE mode subscriptions

### DIFF
--- a/pkg/app/gnmi_client_subscribe.go
+++ b/pkg/app/gnmi_client_subscribe.go
@@ -290,7 +290,8 @@ OUTER:
 				switch rsp.Response.(type) {
 				case *gnmi.SubscribeResponse_SyncResponse:
 					a.Logger.Printf("target %q, subscription %q received sync response", t.Config.Name, sreq.name)
-					continue
+					m := outputs.Meta{"source": t.Config.Name, "format": a.Config.Format, "subscription-name": sreq.name}
+					a.Export(ctx, rsp, m, t.Config.Outputs...)
 				default:
 					m := outputs.Meta{"source": t.Config.Name, "format": a.Config.Format, "subscription-name": sreq.name}
 					a.Export(ctx, rsp, m, t.Config.Outputs...)


### PR DESCRIPTION
https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#35151-once-subscriptions

Current behavior was suppressing `sync_response` output for ONCE mode
subscriptions due to lack of switch/case fallthrough
