### PR TITLE
fix: kafka output error metric missing label

### DIFF
--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -48,6 +48,8 @@ const (
 	requiredAcksNoResponse   = "no-response"
 	requiredAcksWaitForLocal = "wait-for-local"
 	requiredAcksWaitForAll   = "wait-for-all"
+
+	reasonUnknown = "unknown"
 )
 
 func init() {
@@ -274,7 +276,7 @@ func (k *kafkaOutput) Write(ctx context.Context, rsp proto.Message, meta outputs
 			k.logger.Printf("writing expired after %s, Kafka output might not be initialized", k.cfg.Timeout)
 		}
 		if k.cfg.EnableMetrics {
-			kafkaNumberOfFailSendMsgs.WithLabelValues(k.cfg.Name, "timeout").Inc()
+			kafkaNumberOfFailSendMsgs.WithLabelValues(k.cfg.Name, "timeout", reasonUnknown).Inc()
 		}
 		return
 	}
@@ -480,7 +482,7 @@ CRPROD:
 						k.logger.Printf("%s failed to send a kafka msg to topic '%s': %v", workerLogPrefix, topic, err)
 					}
 					if k.cfg.EnableMetrics {
-						kafkaNumberOfFailSendMsgs.WithLabelValues(config.ClientID, "send_error").Inc()
+						kafkaNumberOfFailSendMsgs.WithLabelValues(config.ClientID, "send_error", reasonUnknown).Inc()
 					}
 					producer.Close()
 					time.Sleep(k.cfg.RecoveryWaitTime)

--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -480,7 +480,7 @@ CRPROD:
 						k.logger.Printf("%s failed to send a kafka msg to topic '%s': %v", workerLogPrefix, topic, err)
 					}
 					if k.cfg.EnableMetrics {
-						kafkaNumberOfFailSendMsgs.WithLabelValues(config.ClientID, config.ClientID, "send_error").Inc()
+						kafkaNumberOfFailSendMsgs.WithLabelValues(k.cfg.Name, config.ClientID, "send_error").Inc()
 					}
 					producer.Close()
 					time.Sleep(k.cfg.RecoveryWaitTime)

--- a/pkg/outputs/kafka_output/kafka_output.go
+++ b/pkg/outputs/kafka_output/kafka_output.go
@@ -48,8 +48,6 @@ const (
 	requiredAcksNoResponse   = "no-response"
 	requiredAcksWaitForLocal = "wait-for-local"
 	requiredAcksWaitForAll   = "wait-for-all"
-
-	reasonUnknown = "unknown"
 )
 
 func init() {
@@ -276,7 +274,7 @@ func (k *kafkaOutput) Write(ctx context.Context, rsp proto.Message, meta outputs
 			k.logger.Printf("writing expired after %s, Kafka output might not be initialized", k.cfg.Timeout)
 		}
 		if k.cfg.EnableMetrics {
-			kafkaNumberOfFailSendMsgs.WithLabelValues(k.cfg.Name, "timeout", reasonUnknown).Inc()
+			kafkaNumberOfFailSendMsgs.WithLabelValues(k.cfg.Name, k.cfg.Name, "timeout").Inc()
 		}
 		return
 	}
@@ -482,7 +480,7 @@ CRPROD:
 						k.logger.Printf("%s failed to send a kafka msg to topic '%s': %v", workerLogPrefix, topic, err)
 					}
 					if k.cfg.EnableMetrics {
-						kafkaNumberOfFailSendMsgs.WithLabelValues(config.ClientID, "send_error", reasonUnknown).Inc()
+						kafkaNumberOfFailSendMsgs.WithLabelValues(config.ClientID, config.ClientID, "send_error").Inc()
 					}
 					producer.Close()
 					time.Sleep(k.cfg.RecoveryWaitTime)


### PR DESCRIPTION
this inconsistency in labels leads to panics,  so simply hacking them with a reason as `unknown` where we can't get reason
```
2025/09/06 00:40:02.642215 [gnmic] target "xxxxxxx": subscription test-sample rcv error: failed to create a subscribe client, target='xxxxxxx', retry in 10000000000. err=rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp xxxx:9339: connect: no route to host"
panic: inconsistent label cardinality: expected 3 label values but got 2 in []string{"kafka-kafka-prod", "timeout"}

goroutine 2258 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).WithLabelValues(0x4001489ea8?, {0x4001489ed8?, 0x12a05f200?, 0x1?})
	/go/pkg/mod/github.com/prometheus/client_golang@v1.20.5/prometheus/counter.go:284 +0x68
github.com/openconfig/gnmic/pkg/outputs/kafka_output.(*kafkaOutput).Write(0x400061c620, {0x4303d98, 0x400079f5e0}, {0x42c6ba0, 0x4003de8d70}, 0x4001c30900)
```