### PR TITLE
feat: support env vars from loaders

### DIFF
--- a/pkg/app/loaders.go
+++ b/pkg/app/loaders.go
@@ -72,7 +72,7 @@ START:
 			limiter = time.NewTicker(a.Config.LocalFlags.SubscribeBackoff)
 		}
 		for _, add := range targetOp.Add {
-			err = a.Config.SetTargetConfigDefaultsExpandEnv(add)
+			err = targetsDefaultsFunc(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue
@@ -118,11 +118,18 @@ func (a *App) startLoaderProxy(ctx context.Context) {
 START:
 	a.Logger.Printf("initializing loader type %q", ldTypeS)
 
+	var targetsDefaultsFunc func(tc *types.TargetConfig) error
+	if expandEnv, ok := a.Config.Loader["expand-env"].(bool); ok && expandEnv {
+		targetsDefaultsFunc = a.Config.SetTargetConfigDefaultsExpandEnv
+	} else {
+		targetsDefaultsFunc = a.Config.SetTargetConfigDefaults
+	}
+
 	ld := loaders.Loaders[ldTypeS]()
 	err := ld.Init(ctx, a.Config.Loader, a.Logger,
 		loaders.WithRegistry(a.reg),
 		loaders.WithActions(a.Config.Actions),
-		loaders.WithTargetsDefaults(a.Config.SetTargetConfigDefaultsExpandEnv),
+		loaders.WithTargetsDefaults(targetsDefaultsFunc),
 	)
 	if err != nil {
 		a.Logger.Printf("failed to init loader type %q: %v", ldTypeS, err)
@@ -148,7 +155,7 @@ START:
 			a.operLock.Unlock()
 		}
 		for _, add := range targetOp.Add {
-			err = a.Config.SetTargetConfigDefaultsExpandEnv(add)
+			err = targetsDefaultsFunc(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue

--- a/pkg/app/loaders.go
+++ b/pkg/app/loaders.go
@@ -37,7 +37,7 @@ START:
 	err := ld.Init(ctx, a.Config.Loader, a.Logger,
 		loaders.WithRegistry(a.reg),
 		loaders.WithActions(a.Config.Actions),
-		loaders.WithTargetsDefaults(a.Config.SetTargetLoaderConfigDefaults),
+		loaders.WithTargetsDefaults(a.Config.SetTargetConfigDefaultsExpandEnv),
 	)
 	if err != nil {
 		a.Logger.Printf("failed to init loader type %q: %v", ldTypeS, err)
@@ -66,7 +66,7 @@ START:
 			limiter = time.NewTicker(a.Config.LocalFlags.SubscribeBackoff)
 		}
 		for _, add := range targetOp.Add {
-			err = a.Config.SetTargetLoaderConfigDefaults(add)
+			err = a.Config.SetTargetConfigDefaultsExpandEnv(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue
@@ -116,7 +116,7 @@ START:
 	err := ld.Init(ctx, a.Config.Loader, a.Logger,
 		loaders.WithRegistry(a.reg),
 		loaders.WithActions(a.Config.Actions),
-		loaders.WithTargetsDefaults(a.Config.SetTargetLoaderConfigDefaults),
+		loaders.WithTargetsDefaults(a.Config.SetTargetConfigDefaultsExpandEnv),
 	)
 	if err != nil {
 		a.Logger.Printf("failed to init loader type %q: %v", ldTypeS, err)
@@ -142,7 +142,7 @@ START:
 			a.operLock.Unlock()
 		}
 		for _, add := range targetOp.Add {
-			err = a.Config.SetTargetLoaderConfigDefaults(add)
+			err = a.Config.SetTargetConfigDefaultsExpandEnv(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue

--- a/pkg/app/loaders.go
+++ b/pkg/app/loaders.go
@@ -33,17 +33,17 @@ func (a *App) startLoader(ctx context.Context) {
 	ldTypeS := a.Config.Loader["type"].(string)
 START:
 	a.Logger.Printf("initializing loader type %q", ldTypeS)
-	var targetsDefaultsFunc func(tc *types.TargetConfig) error
+	var fnTargetsDefaults func(tc *types.TargetConfig) error
 	if expandEnv, ok := a.Config.Loader["expand-env"].(bool); ok && expandEnv {
-		targetsDefaultsFunc = a.Config.SetTargetConfigDefaultsExpandEnv
+		fnTargetsDefaults = a.Config.SetTargetConfigDefaultsExpandEnv
 	} else {
-		targetsDefaultsFunc = a.Config.SetTargetConfigDefaults
+		fnTargetsDefaults = a.Config.SetTargetConfigDefaults
 	}
 	ld := loaders.Loaders[ldTypeS]()
 	err := ld.Init(ctx, a.Config.Loader, a.Logger,
 		loaders.WithRegistry(a.reg),
 		loaders.WithActions(a.Config.Actions),
-		loaders.WithTargetsDefaults(targetsDefaultsFunc),
+		loaders.WithTargetsDefaults(fnTargetsDefaults),
 	)
 	if err != nil {
 		a.Logger.Printf("failed to init loader type %q: %v", ldTypeS, err)
@@ -72,7 +72,7 @@ START:
 			limiter = time.NewTicker(a.Config.LocalFlags.SubscribeBackoff)
 		}
 		for _, add := range targetOp.Add {
-			err = targetsDefaultsFunc(add)
+			err = fnTargetsDefaults(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue
@@ -118,18 +118,18 @@ func (a *App) startLoaderProxy(ctx context.Context) {
 START:
 	a.Logger.Printf("initializing loader type %q", ldTypeS)
 
-	var targetsDefaultsFunc func(tc *types.TargetConfig) error
+	var fnTargetsDefaults func(tc *types.TargetConfig) error
 	if expandEnv, ok := a.Config.Loader["expand-env"].(bool); ok && expandEnv {
-		targetsDefaultsFunc = a.Config.SetTargetConfigDefaultsExpandEnv
+		fnTargetsDefaults = a.Config.SetTargetConfigDefaultsExpandEnv
 	} else {
-		targetsDefaultsFunc = a.Config.SetTargetConfigDefaults
+		fnTargetsDefaults = a.Config.SetTargetConfigDefaults
 	}
 
 	ld := loaders.Loaders[ldTypeS]()
 	err := ld.Init(ctx, a.Config.Loader, a.Logger,
 		loaders.WithRegistry(a.reg),
 		loaders.WithActions(a.Config.Actions),
-		loaders.WithTargetsDefaults(targetsDefaultsFunc),
+		loaders.WithTargetsDefaults(fnTargetsDefaults),
 	)
 	if err != nil {
 		a.Logger.Printf("failed to init loader type %q: %v", ldTypeS, err)
@@ -155,7 +155,7 @@ START:
 			a.operLock.Unlock()
 		}
 		for _, add := range targetOp.Add {
-			err = targetsDefaultsFunc(add)
+			err = fnTargetsDefaults(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue

--- a/pkg/app/loaders.go
+++ b/pkg/app/loaders.go
@@ -37,7 +37,7 @@ START:
 	err := ld.Init(ctx, a.Config.Loader, a.Logger,
 		loaders.WithRegistry(a.reg),
 		loaders.WithActions(a.Config.Actions),
-		loaders.WithTargetsDefaults(a.Config.SetTargetConfigDefaults),
+		loaders.WithTargetsDefaults(a.Config.SetTargetLoaderConfigDefaults),
 	)
 	if err != nil {
 		a.Logger.Printf("failed to init loader type %q: %v", ldTypeS, err)
@@ -66,7 +66,7 @@ START:
 			limiter = time.NewTicker(a.Config.LocalFlags.SubscribeBackoff)
 		}
 		for _, add := range targetOp.Add {
-			err = a.Config.SetTargetConfigDefaults(add)
+			err = a.Config.SetTargetLoaderConfigDefaults(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue
@@ -116,7 +116,7 @@ START:
 	err := ld.Init(ctx, a.Config.Loader, a.Logger,
 		loaders.WithRegistry(a.reg),
 		loaders.WithActions(a.Config.Actions),
-		loaders.WithTargetsDefaults(a.Config.SetTargetConfigDefaults),
+		loaders.WithTargetsDefaults(a.Config.SetTargetLoaderConfigDefaults),
 	)
 	if err != nil {
 		a.Logger.Printf("failed to init loader type %q: %v", ldTypeS, err)
@@ -142,7 +142,7 @@ START:
 			a.operLock.Unlock()
 		}
 		for _, add := range targetOp.Add {
-			err = a.Config.SetTargetConfigDefaults(add)
+			err = a.Config.SetTargetLoaderConfigDefaults(add)
 			if err != nil {
 				a.Logger.Printf("failed parsing new target configuration %#v: %v", add, err)
 				continue

--- a/pkg/config/targets.go
+++ b/pkg/config/targets.go
@@ -135,7 +135,7 @@ func (c *Config) GetTargets() (map[string]*types.TargetConfig, error) {
 	return c.Targets, nil
 }
 
-func (c *Config) SetTargetLoaderConfigDefaults(tc *types.TargetConfig) error {
+func (c *Config) SetTargetConfigDefaultsExpandEnv(tc *types.TargetConfig) error {
 	er := c.SetTargetConfigDefaults(tc)
 	if er != nil {
 		return er

--- a/pkg/config/targets.go
+++ b/pkg/config/targets.go
@@ -135,6 +135,17 @@ func (c *Config) GetTargets() (map[string]*types.TargetConfig, error) {
 	return c.Targets, nil
 }
 
+func (c *Config) SetTargetLoaderConfigDefaults(tc *types.TargetConfig) error {
+	er := c.SetTargetConfigDefaults(tc)
+	if er != nil {
+		return er
+	}
+	// we can also expand cert paths if needed
+	expandTargetEnv(tc)
+
+	return nil
+}
+
 func (c *Config) SetTargetConfigDefaults(tc *types.TargetConfig) error {
 	defGrpcPort := c.FileConfig.GetString("port")
 	if !strings.HasPrefix(tc.Address, "unix://") {

--- a/pkg/config/targets_test.go
+++ b/pkg/config/targets_test.go
@@ -416,7 +416,7 @@ func TestSetTargetLoaderConfigDefaults(t *testing.T) {
 				break
 			}
 			cfg := New()
-			err = cfg.SetTargetLoaderConfigDefaults(input)
+			err = cfg.SetTargetConfigDefaultsExpandEnv(input)
 			if err != nil {
 				t.Logf("SetTargetLoaderConfigDefaults error: %v", err)
 				t.Fail()

--- a/pkg/config/targets_test.go
+++ b/pkg/config/targets_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/AlekSi/pointer"
+	"gopkg.in/yaml.v2"
 
 	"github.com/openconfig/gnmic/pkg/api/types"
 )
@@ -351,6 +352,78 @@ func TestGetTargets(t *testing.T) {
 			}
 			if !reflect.DeepEqual(outs, data.out) {
 				t.Log("maps not equal")
+				t.Fail()
+			}
+		})
+	}
+}
+
+var setTargetLoaderConfigDefaultsTest = map[string]struct {
+	envs   []string
+	in     []byte
+	out    *types.TargetConfig
+	outErr error
+}{
+	"from_address": {
+		envs: []string{
+			"username=user1",
+			"pass=pass1",
+		},
+		in: []byte(`
+test1:
+    name: test1.123
+    address: test1.123:9339
+    username: ${username}
+    password: ${pass}
+    subscriptions:
+        - drivenets-sample
+`),
+		out: &types.TargetConfig{
+			Address:       "test1.123:9339",
+			Name:          "test1.123",
+			Password:      pointer.ToString("pass1"),
+			Username:      pointer.ToString("user1"),
+			Token:         pointer.ToString(""),
+			TLSCert:       pointer.ToString(""),
+			TLSKey:        pointer.ToString(""),
+			LogTLSSecret:  pointer.ToBool(false),
+			Insecure:      pointer.ToBool(false),
+			SkipVerify:    pointer.ToBool(false),
+			Gzip:          pointer.ToBool(false),
+			BufferSize:    uint(100),
+			Subscriptions: []string{"drivenets-sample"},
+		},
+		outErr: nil,
+	},
+}
+
+func TestSetTargetLoaderConfigDefaults(t *testing.T) {
+	for name, data := range setTargetLoaderConfigDefaultsTest {
+		t.Run(name, func(t *testing.T) {
+			for _, e := range data.envs {
+				p := strings.SplitN(e, "=", 2)
+				os.Setenv(p[0], p[1])
+			}
+			var inputMap map[string]*types.TargetConfig
+			err := yaml.Unmarshal(data.in, &inputMap)
+			if err != nil {
+				t.Logf("failed to unmarshal input: %v", err)
+				t.Fail()
+			}
+			var input *types.TargetConfig
+			for _, v := range inputMap {
+				input = v
+				break
+			}
+			cfg := New()
+			err = cfg.SetTargetLoaderConfigDefaults(input)
+			if err != nil {
+				t.Logf("SetTargetLoaderConfigDefaults error: %v", err)
+				t.Fail()
+			}
+			if !reflect.DeepEqual(input, data.out) {
+				t.Logf("expected: %+v", data.out)
+				t.Logf("got: %+v", input)
 				t.Fail()
 			}
 		})


### PR DESCRIPTION
By this change, I can collect multiple devices with different creds on the same instance
I will create all the secrets as env like

```
ven1_user='user1'
ven1_pass='test1'
ven2_user='user2'
ven2_pass='test2'
```

Now SD can load targets and instruct with creds to use
```

target1:
    name: target1.domain.net
    address: target1.domain.net:9339
    username: ${ven1_user}
    password: ${ven1_pass}
    subscriptions:
        - ven-sample

```

OR Let me know if this has to be enabled based on a config vars under loader

i can do something like this as well

```
var targetsDefaultsFunc func(tc *types.TargetConfig) error
if expandEnv, ok := a.Config.Loader["expandEnv"].(bool); ok && expandEnv {
targetsDefaultsFunc = a.Config.SetTargetConfigDefaultsExpandEnv
} else {
targetsDefaultsFunc = a.Config.SetTargetConfigDefaults
}
ld := loaders.Loaders[ldTypeS]()
	err := ld.Init(ctx, a.Config.Loader, a.Logger,
		loaders.WithRegistry(a.reg),
		loaders.WithActions(a.Config.Actions),
		loaders.WithTargetsDefaults(targetsDefaultsFunc),
	)

```