### PR TITLE
[DRAFT] feat: custom tags support

### DIFF
--- a/pkg/formatters/json.go
+++ b/pkg/formatters/json.go
@@ -122,12 +122,23 @@ func (o *MarshalOptions) formatSubscribeResponse(m *gnmi.SubscribeResponse, meta
 		msg.Target = mr.Update.Prefix.GetTarget()
 		if s, ok := meta["source"]; ok {
 			msg.Source = s
+			delete(meta, "source")
 		}
 		if s, ok := meta["system-name"]; ok {
 			msg.SystemName = s
+			delete(meta, "system-name")
 		}
 		if s, ok := meta["subscription-name"]; ok {
 			msg.SubscriptionName = s
+			delete(meta, "subscription-name")
+		}
+		delete(meta, "format")
+		// add remaining meta as tags
+		if len(meta) > 0 {
+			msg.Tags = make(map[string]interface{}, len(meta))
+			for k, v := range meta {
+				msg.Tags[k] = v
+			}
 		}
 		for i, upd := range mr.Update.Update {
 			if upd.Path == nil {

--- a/pkg/formatters/msg.go
+++ b/pkg/formatters/msg.go
@@ -37,6 +37,7 @@ type notificationRspMsg struct {
 	Updates          []update               `json:"updates,omitempty"`
 	Deletes          []string               `json:"deletes,omitempty"`
 	Extensions       []*gnmi_ext.Extension  `json:"extensions,omitempty"`
+	Tags             map[string]interface{} `json:"tags,omitempty"`
 }
 type update struct {
 	Path   string


### PR DESCRIPTION
Allow custom tags to be emitted for final metrics. This will allow us to do a lot of filtering easily on the Prometheus or Grafana side.

Creating this as a draft pr to get opinions from repo maintainers. will make the changes after review.

@karimra can you please comment on this

e.g

**Targetconfig**

```yaml
test:
  name: test-dev
  address: "[2001:558:1002:809e:12e1::]:9339"
  event-tags:
    type: poc
    ppod: test1
```

**output**:

```json
{
  "source": "test",
  "subscription-name": "test_0_1",
  "timestamp": 1755150808,
  "time": "1970-01-01T05:30:01.755150808+05:30",
  "target": "test-dev",
  "updates": [
    {
      "Path": "test-ec-info[gcp-channel=0][gcp-rf-port=2][measurement-type=FREQ_DOMAIN_COEF][np-index=0]",
      "values": {
        "test-ec-info": {
          "data-len": 960,
          "ec-test-base-freq": 108000,
          "ec-test-capture-time": 0,
          "ec-test-data": "00000000",
          "test-channel": 50,
          "gcp-test-port": 2,
          "measurement-type": "FREQ",
          "test-index": 0
        }
      }
    }
  ],
  "tags": {
    "ppod": "test1",
    "type": "poc"
  }
}
`````