### PR TITLE
feat: enhance target up metric

### DIFF
--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -114,13 +114,16 @@ func (a *App) registerTargetMetrics() {
 							targetUPMetric.WithLabelValues(tc.Name).Set(1)
 							targetConnStateMetric.WithLabelValues(tc.Name).Set(1)
 						case "CONNECTING":
+							targetUPMetric.WithLabelValues(tc.Name).Set(0)
 							targetConnStateMetric.WithLabelValues(tc.Name).Set(2)
 						case "READY":
 							targetUPMetric.WithLabelValues(tc.Name).Set(1)
 							targetConnStateMetric.WithLabelValues(tc.Name).Set(3)
 						case "TRANSIENT_FAILURE":
+							targetUPMetric.WithLabelValues(tc.Name).Set(0)
 							targetConnStateMetric.WithLabelValues(tc.Name).Set(4)
 						case "SHUTDOWN":
+							targetUPMetric.WithLabelValues(tc.Name).Set(0)
 							targetConnStateMetric.WithLabelValues(tc.Name).Set(5)
 						default:
 							targetUPMetric.WithLabelValues(tc.Name).Set(0)

--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -97,8 +97,16 @@ func (a *App) registerTargetMetrics() {
 					a.operLock.RUnlock()
 					if ok {
 						switch t.ConnState() {
-						case "IDLE", "READY":
+						case "READY":
 							targetUPMetric.WithLabelValues(tc.Name).Set(1)
+						case "IDLE":
+							targetUPMetric.WithLabelValues(tc.Name).Set(2)
+						case "CONNECTING":
+							targetUPMetric.WithLabelValues(tc.Name).Set(3)
+						case "TRANSIENT_FAILURE":
+							targetUPMetric.WithLabelValues(tc.Name).Set(4)
+						case "SHUTDOWN":
+							targetUPMetric.WithLabelValues(tc.Name).Set(5)
 						default:
 							targetUPMetric.WithLabelValues(tc.Name).Set(0)
 						}

--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -44,6 +44,13 @@ var targetUPMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help:      "Has value 1 if the gNMI connection to the target is established; otherwise, 0.",
 }, []string{"name"})
 
+var targetConnStateMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "gnmic",
+	Subsystem: "target",
+	Name:      "connection_state",
+	Help:      "The current gRPC connection state to the target. The value can be one of the following: 0(INVALID_STATE), 1 (IDLE), 2 (CONNECTING), 3 (READY), 4 (TRANSIENT_FAILURE), or 5 (SHUTDOWN).",
+}, []string{"name"})
+
 // cluster
 var clusterNumberOfLockedTargets = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: "gnmic",
@@ -63,9 +70,14 @@ func (a *App) registerTargetMetrics() {
 	if err != nil {
 		a.Logger.Printf("failed to register target metric: %v", err)
 	}
+	err = a.reg.Register(targetConnStateMetric)
+	if err != nil {
+		a.Logger.Printf("failed to register target connection state metric: %v", err)
+	}
 	a.configLock.RLock()
 	for _, t := range a.Config.Targets {
 		targetUPMetric.WithLabelValues(t.Name).Set(0)
+		targetConnStateMetric.WithLabelValues(t.Name).Set(0)
 	}
 	a.configLock.RUnlock()
 	go func() {
@@ -90,6 +102,7 @@ func (a *App) registerTargetMetrics() {
 					}
 				}
 				targetUPMetric.Reset()
+				targetConnStateMetric.Reset()
 				a.configLock.RLock()
 				for _, tc := range a.Config.Targets {
 					a.operLock.RLock()
@@ -97,26 +110,31 @@ func (a *App) registerTargetMetrics() {
 					a.operLock.RUnlock()
 					if ok {
 						switch t.ConnState() {
+						case "IDLE":
+							targetUPMetric.WithLabelValues(tc.Name).Set(1)
+							targetConnStateMetric.WithLabelValues(tc.Name).Set(1)
+						case "CONNECTING":
+							targetConnStateMetric.WithLabelValues(tc.Name).Set(2)
 						case "READY":
 							targetUPMetric.WithLabelValues(tc.Name).Set(1)
-						case "IDLE":
-							targetUPMetric.WithLabelValues(tc.Name).Set(2)
-						case "CONNECTING":
-							targetUPMetric.WithLabelValues(tc.Name).Set(3)
+							targetConnStateMetric.WithLabelValues(tc.Name).Set(3)
 						case "TRANSIENT_FAILURE":
-							targetUPMetric.WithLabelValues(tc.Name).Set(4)
+							targetConnStateMetric.WithLabelValues(tc.Name).Set(4)
 						case "SHUTDOWN":
-							targetUPMetric.WithLabelValues(tc.Name).Set(5)
+							targetConnStateMetric.WithLabelValues(tc.Name).Set(5)
 						default:
 							targetUPMetric.WithLabelValues(tc.Name).Set(0)
+							targetConnStateMetric.WithLabelValues(tc.Name).Set(0)
 						}
 					} else {
 						if a.isLeader {
 							if ownTargets[tc.Name] == a.Config.Clustering.InstanceName {
 								targetUPMetric.WithLabelValues(tc.Name).Set(0)
+								targetConnStateMetric.WithLabelValues(tc.Name).Set(0)
 							}
 						} else {
 							targetUPMetric.WithLabelValues(tc.Name).Set(0)
+							targetConnStateMetric.WithLabelValues(tc.Name).Set(0)
 						}
 					}
 				}


### PR DESCRIPTION
Currently target_up metric is 1 even when the connection failed because of auth issues

So I have made changes to reflect with grpc connection states, with one minor change, even from grpc Ready=2, i have kept ready as 1 so our users will still see target_up =1 when the target is actually up
```
const (
	// Idle indicates the ClientConn is idle.
	Idle [State](https://pkg.go.dev/google.golang.org/grpc/connectivity#State) = [iota](https://pkg.go.dev/builtin#iota)
	// Connecting indicates the ClientConn is connecting.
	Connecting
	// Ready indicates the ClientConn is ready for work.
	Ready
	// TransientFailure indicates the ClientConn has seen a failure but expects to recover.
	TransientFailure
	// Shutdown indicates the ClientConn has started shutting down.
	Shutdown
)
```