### PR TITLE
`api/config/targets`: reflect app behaviour in docs

### DIFF
--- a/docs/user_guide/api/configuration.md
+++ b/docs/user_guide/api/configuration.md
@@ -216,7 +216,7 @@ Returns an empty body if successful.
 === "Request"
     ```bash
     curl --request POST -H "Content-Type: application/json" \
-         -d '{"address": "10.10.10.10:57400", "username": "admin", "password": "admin", "insecure": true}' \
+         -d '{"name": "10.10.10.10:57400", "address": "10.10.10.10:57400", "username": "admin", "password": "admin", "insecure": true}' \
          gnmic-api-address:port/api/v1/config/targets
     ```
 === "200 OK"


### PR DESCRIPTION
Hello maintainers,

Thanks for the job you guys are doing on the project. This is my first ever PR. Your feedback is much appreciated.

The API documentation does not reflect the app behaviour. Using [the payload given as example](https://gnmic.openconfig.net/user_guide/api/configuration/#post-apiv1configtargets), here are the logs,

```
2025/09/18 21:32:25.142379 /build/pkg/app/target.go:123: [gnmic] adding target {"address":"127.0.0.1:4002","username":"admin","password":"****","insecure":true}
127.0.0.1 - - [18/Sep/2025:21:32:25 +0000] "POST /api/v1/config/targets HTTP/1.1" 200 0
```
And response on `GET /api/v1/config/targets`:
```
127.0.0.1 - - [18/Sep/2025:21:32:25 +0000] "GET /api/v1/config/targets HTTP/1.1" 200 113
{"":{"address":"127.0.0.1:4002","username":"admin","password":"****","insecure":true,"retry-timer":10000000000}}
```
Without a field `name`, the response is keyed with an empty string. Other endpoints need that field, such as [`GET /api/v1/targets/{id}`](https://gnmic.openconfig.net/user_guide/api/targets/#get-apiv1targetsid) .

Herewith the logs with the field `name` set in the payload,
```
2025/09/18 21:35:46.510272 /build/pkg/app/target.go:123: [gnmic] adding target {"name":"target2","address":"127.0.0.1:4002","username":"admin","password":"****","insecure":true}
127.0.0.1 - - [18/Sep/2025:21:35:46 +0000] "POST /api/v1/config/targets HTTP/1.1" 200 0
```
And response on `GET /api/v1/config/targets`:
```
127.0.0.1 - - [18/Sep/2025:21:35:46 +0000] "GET /api/v1/config/targets HTTP/1.1" 200 137
{"target2":{"name":"target2","address":"127.0.0.1:4002","username":"admin","password":"****","insecure":true,"retry-timer":10000000000}}
```