### PR TITLE
fail xpath parsing when there are trailing chars after a key and before the next path element

### DIFF
--- a/pkg/api/path/path.go
+++ b/pkg/api/path/path.go
@@ -179,6 +179,11 @@ func parseXPathKeys(s string) (map[string]string, error) {
 			}
 			kvs[escapedBracketsReplacer.Replace(k)] = escapedBracketsReplacer.Replace(v)
 			inKey = false
+
+		default:
+			if !inKey {
+				return nil, errMalformedXPathKey
+			}
 		}
 		prevRune = r
 	}

--- a/pkg/app/gnmi_client_subscribe.go
+++ b/pkg/app/gnmi_client_subscribe.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openconfig/grpctunnel/tunnel"
 	"google.golang.org/grpc"
 
+	"github.com/openconfig/gnmic/pkg/api"
 	"github.com/openconfig/gnmic/pkg/api/types"
 	"github.com/openconfig/gnmic/pkg/config"
 	"github.com/openconfig/gnmic/pkg/lockers"
@@ -169,7 +170,7 @@ func (a *App) clientSubscribe(ctx context.Context, tc *types.TargetConfig) error
 	for scName, sc := range subscriptionsConfigs {
 		req, err := utils.CreateSubscribeRequest(sc, tc, a.Config.Encoding)
 		if err != nil {
-			if errors.Is(errors.Unwrap(err), config.ErrConfig) {
+			if errors.Is(errors.Unwrap(err), config.ErrConfig) || errors.Is(errors.Unwrap(err), api.ErrInvalidValue) {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
fix #751 