### PR TITLE
deps: fixes dep issue w/ gnmic/pkg/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openconfig/gnmic
 
 go 1.24.7
 
-replace github.com/openconfig/gnmic/pkg/api v0.1.8 => ./pkg/api
+replace github.com/openconfig/gnmic/pkg/api v0.1.9 => ./pkg/api
 
 replace github.com/openconfig/gnmic/pkg/cache v0.1.3 => ./pkg/cache
 
@@ -41,7 +41,7 @@ require (
 	github.com/nsf/termbox-go v1.1.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/openconfig/gnmi v0.14.1
-	github.com/openconfig/gnmic/pkg/api v0.1.8
+	github.com/openconfig/gnmic/pkg/api v0.1.9
 	github.com/openconfig/gnmic/pkg/cache v0.1.3
 	github.com/openconfig/goyang v1.6.3
 	github.com/openconfig/ygot v0.34.0


### PR DESCRIPTION
**Problem**

`openconfig/gnmic` v0.40.0 and newer rely on `openconfig/gnmic/pkg/api` v0.1.**9** however the go.mod file for the former modules specifies `openconfig/gnmic/pkg/api` v0.1.**8**.

As such, if you try to build gnmic without the replace directives it fails.

I tripped on this because we have a wrapper around gnmic that pulls in the `openconfig/gnmic` module as a **dependency** rather than building in repo; as such the replace directives are not processed.

**Repro**

To reproduce this one can simply remove the `replace` directives in the go.mod file, run `go mod tidy`, and then run `go build`; at which point you will be met with the following error:

```
❯ go build
pkg/app/api.go:105:14: tc.DeepCopy undefined (type *"github.com/openconfig/gnmic/pkg/api/types".TargetConfig has no field or method DeepCopy)
pkg/app/api.go:117:11: t.DeepCopy undefined (type *"github.com/openconfig/gnmic/pkg/api/types".TargetConfig has no field or method DeepCopy)
pkg/app/api.go:242:11: t.DeepCopy undefined (type *"github.com/openconfig/gnmic/pkg/api/types".TargetConfig has no field or method DeepCopy)
```

**Root Cause**

openconfig/gnmic#556 introduced a new `DeepCopy` method on a type in the `gnmic/pkg/api` module and then consumed that method in the `gnmic` module.

While a gnmic/pkg/api v0.1.9 was cut, the go.mod file for the `gnmic` module was never updated. My guess is this was never detected because we leverage replace directives for local dev.

To prevent issues like this in the future we may want to consider using Go Workspaces for dev instead of replace directives.