### PR TITLE
Adds gNMI extensions output formatting

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -48,6 +48,7 @@ import (
 	"github.com/openconfig/gnmic/pkg/inputs"
 	"github.com/openconfig/gnmic/pkg/lockers"
 	"github.com/openconfig/gnmic/pkg/outputs"
+	"github.com/openconfig/gnmic/pkg/utils"
 	"github.com/zestor-dev/zestor/store"
 	"github.com/zestor-dev/zestor/store/gomap"
 )
@@ -212,6 +213,7 @@ func (a *App) InitGlobalFlags() {
 	a.RootCmd.PersistentFlags().StringVarP(&a.Config.GlobalFlags.API, "api", "", "", "gnmic api address")
 	a.RootCmd.PersistentFlags().StringArrayVarP(&a.Config.GlobalFlags.ProtoFile, "proto-file", "", nil, "proto file(s) name(s)")
 	a.RootCmd.PersistentFlags().StringArrayVarP(&a.Config.GlobalFlags.ProtoDir, "proto-dir", "", nil, "directory to look for proto files specified with --proto-file")
+	a.RootCmd.PersistentFlags().StringArrayVarP(&a.Config.GlobalFlags.RegisteredExtensions, "registered-extensions", "", nil, "registered (custom) extensions")
 	a.RootCmd.PersistentFlags().StringVarP(&a.Config.GlobalFlags.TargetsFile, "targets-file", "", "", "path to file with targets configuration")
 	a.RootCmd.PersistentFlags().BoolVarP(&a.Config.GlobalFlags.Gzip, "gzip", "", false, "enable gzip compression on gRPC connections")
 	a.RootCmd.PersistentFlags().StringVarP(&a.Config.GlobalFlags.Token, "token", "", "", "token value, used for gRPC token based authentication")
@@ -337,12 +339,22 @@ func (a *App) PrintMsg(address string, msgName string, msg proto.Message) error 
 			return nil
 		}
 	}
+
+	registeredExtensions, err := utils.ParseRegisteredExtensions(a.Config.RegisteredExtensions)
+
+	if err != nil {
+		return err
+	}
+
 	mo := formatters.MarshalOptions{
-		Multiline:        true,
-		Indent:           "  ",
-		Format:           a.Config.Format,
-		ValuesOnly:       a.Config.GetValuesOnly,
-		CalculateLatency: a.Config.CalculateLatency,
+		Multiline:            true,
+		Indent:               "  ",
+		Format:               a.Config.Format,
+		ValuesOnly:           a.Config.GetValuesOnly,
+		CalculateLatency:     a.Config.CalculateLatency,
+		ProtoFiles:           a.Config.ProtoFile,
+		ProtoDir:             a.Config.ProtoDir,
+		RegisteredExtensions: registeredExtensions,
 	}
 	b, err := mo.Marshal(msg, map[string]string{"source": address})
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,23 +105,24 @@ type GlobalFlags struct {
 	LogCompress   bool          `mapstructure:"log-compress,omitempty" json:"log-compress,omitempty" yaml:"log-compress,omitempty"`
 	MaxMsgSize    int           `mapstructure:"max-msg-size,omitempty" json:"max-msg-size,omitempty" yaml:"max-msg-size,omitempty"`
 	//PrometheusAddress string        `mapstructure:"prometheus-address,omitempty" json:"prometheus-address,omitempty" yaml:"prometheus-address,omitempty"`
-	PrintRequest     bool          `mapstructure:"print-request,omitempty" json:"print-request,omitempty" yaml:"print-request,omitempty"`
-	Retry            time.Duration `mapstructure:"retry,omitempty" json:"retry,omitempty" yaml:"retry,omitempty"`
-	TargetBufferSize uint          `mapstructure:"target-buffer-size,omitempty" json:"target-buffer-size,omitempty" yaml:"target-buffer-size,omitempty"`
-	ClusterName      string        `mapstructure:"cluster-name,omitempty" json:"cluster-name,omitempty" yaml:"cluster-name,omitempty"`
-	InstanceName     string        `mapstructure:"instance-name,omitempty" json:"instance-name,omitempty" yaml:"instance-name,omitempty"`
-	API              string        `mapstructure:"api,omitempty" json:"api,omitempty" yaml:"api,omitempty"`
-	ProtoFile        []string      `mapstructure:"proto-file,omitempty" json:"proto-file,omitempty" yaml:"proto-file,omitempty"`
-	ProtoDir         []string      `mapstructure:"proto-dir,omitempty" json:"proto-dir,omitempty" yaml:"proto-dir,omitempty"`
-	TargetsFile      string        `mapstructure:"targets-file,omitempty" json:"targets-file,omitempty" yaml:"targets-file,omitempty"`
-	Gzip             bool          `mapstructure:"gzip,omitempty" json:"gzip,omitempty" yaml:"gzip,omitempty"`
-	File             []string      `mapstructure:"file,omitempty" json:"file,omitempty" yaml:"file,omitempty"`
-	Dir              []string      `mapstructure:"dir,omitempty" json:"dir,omitempty" yaml:"dir,omitempty"`
-	Exclude          []string      `mapstructure:"exclude,omitempty" json:"exclude,omitempty" yaml:"exclude,omitempty"`
-	Token            string        `mapstructure:"token,omitempty" json:"token,omitempty" yaml:"token,omitempty"`
-	UseTunnelServer  bool          `mapstructure:"use-tunnel-server,omitempty" json:"use-tunnel-server,omitempty" yaml:"use-tunnel-server,omitempty"`
-	AuthScheme       string        `mapstructure:"auth-scheme,omitempty" json:"auth-scheme,omitempty" yaml:"auth-scheme,omitempty"`
-	CalculateLatency bool          `mapstructure:"calculate-latency,omitempty" json:"calculate-latency,omitempty" yaml:"calculate-latency,omitempty"`
+	PrintRequest         bool          `mapstructure:"print-request,omitempty" json:"print-request,omitempty" yaml:"print-request,omitempty"`
+	Retry                time.Duration `mapstructure:"retry,omitempty" json:"retry,omitempty" yaml:"retry,omitempty"`
+	TargetBufferSize     uint          `mapstructure:"target-buffer-size,omitempty" json:"target-buffer-size,omitempty" yaml:"target-buffer-size,omitempty"`
+	ClusterName          string        `mapstructure:"cluster-name,omitempty" json:"cluster-name,omitempty" yaml:"cluster-name,omitempty"`
+	InstanceName         string        `mapstructure:"instance-name,omitempty" json:"instance-name,omitempty" yaml:"instance-name,omitempty"`
+	API                  string        `mapstructure:"api,omitempty" json:"api,omitempty" yaml:"api,omitempty"`
+	ProtoFile            []string      `mapstructure:"proto-file,omitempty" json:"proto-file,omitempty" yaml:"proto-file,omitempty"`
+	ProtoDir             []string      `mapstructure:"proto-dir,omitempty" json:"proto-dir,omitempty" yaml:"proto-dir,omitempty"`
+	RegisteredExtensions []string      `mapstructure:"registered-extensions,omitempty" json:"registered-extensions,omitempty" yaml:"registered-extensions,omitempty"`
+	TargetsFile          string        `mapstructure:"targets-file,omitempty" json:"targets-file,omitempty" yaml:"targets-file,omitempty"`
+	Gzip                 bool          `mapstructure:"gzip,omitempty" json:"gzip,omitempty" yaml:"gzip,omitempty"`
+	File                 []string      `mapstructure:"file,omitempty" json:"file,omitempty" yaml:"file,omitempty"`
+	Dir                  []string      `mapstructure:"dir,omitempty" json:"dir,omitempty" yaml:"dir,omitempty"`
+	Exclude              []string      `mapstructure:"exclude,omitempty" json:"exclude,omitempty" yaml:"exclude,omitempty"`
+	Token                string        `mapstructure:"token,omitempty" json:"token,omitempty" yaml:"token,omitempty"`
+	UseTunnelServer      bool          `mapstructure:"use-tunnel-server,omitempty" json:"use-tunnel-server,omitempty" yaml:"use-tunnel-server,omitempty"`
+	AuthScheme           string        `mapstructure:"auth-scheme,omitempty" json:"auth-scheme,omitempty" yaml:"auth-scheme,omitempty"`
+	CalculateLatency     bool          `mapstructure:"calculate-latency,omitempty" json:"calculate-latency,omitempty" yaml:"calculate-latency,omitempty"`
 
 	Metadata             map[string]string `mapstructure:"metadata,omitempty" json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	PluginProcessorsPath string            `mapstructure:"plugin-processors-path,omitempty" yaml:"plugin-processors-path,omitempty" json:"plugin-processors-path,omitempty"`

--- a/pkg/formatters/formats.go
+++ b/pkg/formatters/formats.go
@@ -20,15 +20,19 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmic/pkg/utils"
 )
 
 type MarshalOptions struct {
-	Multiline        bool
-	Indent           string
-	Format           string
-	OverrideTS       bool
-	ValuesOnly       bool
-	CalculateLatency bool
+	Multiline            bool
+	Indent               string
+	Format               string
+	OverrideTS           bool
+	ValuesOnly           bool
+	CalculateLatency     bool
+	RegisteredExtensions utils.RegisteredExtensions
+	ProtoFiles           []string
+	ProtoDir             []string
 }
 
 // Marshal //

--- a/pkg/formatters/msg.go
+++ b/pkg/formatters/msg.go
@@ -17,26 +17,28 @@ import (
 )
 
 type syncResponseMsg struct {
-	SyncResponse bool                  `json:"sync-response,omitempty"`
-	Extensions   []*gnmi_ext.Extension `json:"extensions,omitempty"`
+	SyncResponse      bool                       `json:"sync-response,omitempty"`
+	Extensions        []*gnmi_ext.Extension      `json:"extensions,omitempty"`
+	DecodedExtensions map[int32]decodedExtension `json:"decodedExtensions,omitempty"`
 }
 
 type notificationRspMsg struct {
-	Meta             map[string]interface{} `json:"meta,omitempty"`
-	Source           string                 `json:"source,omitempty"`
-	SystemName       string                 `json:"system-name,omitempty"`
-	SubscriptionName string                 `json:"subscription-name,omitempty"`
-	Timestamp        int64                  `json:"timestamp,omitempty"`
-	Time             *time.Time             `json:"time,omitempty"`
-	RecvTimestamp    int64                  `json:"recv-timestamp,omitempty"`
-	RecvTime         *time.Time             `json:"recv-time,omitempty"`
-	LatencyNano      int64                  `json:"latency-nano,omitempty"`
-	LatencyMilli     int64                  `json:"latency-milli,omitempty"`
-	Prefix           string                 `json:"prefix,omitempty"`
-	Target           string                 `json:"target,omitempty"`
-	Updates          []update               `json:"updates,omitempty"`
-	Deletes          []string               `json:"deletes,omitempty"`
-	Extensions       []*gnmi_ext.Extension  `json:"extensions,omitempty"`
+	Meta              map[string]interface{}     `json:"meta,omitempty"`
+	Source            string                     `json:"source,omitempty"`
+	SystemName        string                     `json:"system-name,omitempty"`
+	SubscriptionName  string                     `json:"subscription-name,omitempty"`
+	Timestamp         int64                      `json:"timestamp,omitempty"`
+	Time              *time.Time                 `json:"time,omitempty"`
+	RecvTimestamp     int64                      `json:"recv-timestamp,omitempty"`
+	RecvTime          *time.Time                 `json:"recv-time,omitempty"`
+	LatencyNano       int64                      `json:"latency-nano,omitempty"`
+	LatencyMilli      int64                      `json:"latency-milli,omitempty"`
+	Prefix            string                     `json:"prefix,omitempty"`
+	Target            string                     `json:"target,omitempty"`
+	Updates           []update                   `json:"updates,omitempty"`
+	Deletes           []string                   `json:"deletes,omitempty"`
+	Extensions        []*gnmi_ext.Extension      `json:"extensions,omitempty"`
+	DecodedExtensions map[int32]decodedExtension `json:"decodedExtensions,omitempty"`
 }
 type update struct {
 	Path   string
@@ -67,18 +69,22 @@ type getRqMsg struct {
 	Extensions []*gnmi_ext.Extension `json:"extensions,omitempty"`
 }
 
+type decodedExtension map[string]any
+
 type getRspMsg struct {
-	Notifications []notificationRspMsg  `json:"notifications,omitempty"`
-	Extensions    []*gnmi_ext.Extension `json:"extensions,omitempty"`
+	Notifications     []notificationRspMsg       `json:"notifications,omitempty"`
+	Extensions        []*gnmi_ext.Extension      `json:"extensions,omitempty"`
+	DecodedExtensions map[int32]decodedExtension `json:"decodedExtensions,omitempty"`
 }
 type setRspMsg struct {
-	Source     string                `json:"source,omitempty"`
-	Timestamp  int64                 `json:"timestamp,omitempty"`
-	Time       time.Time             `json:"time,omitempty"`
-	Prefix     string                `json:"prefix,omitempty"`
-	Target     string                `json:"target,omitempty"`
-	Results    []updateResultMsg     `json:"results,omitempty"`
-	Extensions []*gnmi_ext.Extension `json:"extensions,omitempty"`
+	Source            string                     `json:"source,omitempty"`
+	Timestamp         int64                      `json:"timestamp,omitempty"`
+	Time              time.Time                  `json:"time,omitempty"`
+	Prefix            string                     `json:"prefix,omitempty"`
+	Target            string                     `json:"target,omitempty"`
+	Results           []updateResultMsg          `json:"results,omitempty"`
+	Extensions        []*gnmi_ext.Extension      `json:"extensions,omitempty"`
+	DecodedExtensions map[int32]decodedExtension `json:"decodedExtensions,omitempty"`
 }
 
 type updateResultMsg struct {

--- a/pkg/utils/gnmiext.go
+++ b/pkg/utils/gnmiext.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type RegisteredExtensions map[int32]string
+
+func ParseRegisteredExtensions(pairs []string) (RegisteredExtensions, error) {
+	res := RegisteredExtensions{}
+
+	for _, p := range pairs {
+		idMsg := strings.Split(p, ":")
+
+		if len(idMsg) < 2 {
+			return nil, fmt.Errorf("'%s' registered extension has invalid format, 123:package.Message format is expected", p)
+		}
+
+		id, err := strconv.ParseInt(idMsg[0], 10, 32)
+
+		if err != nil {
+			return nil, err
+		}
+
+		res[int32(id)] = idMsg[1]
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
Resolves https://github.com/openconfig/gnmic/issues/761.

Input:
```bash
gnmic -a 127.0.0.1 --insecure \
	--proto-dir protos \
	--proto-file ext1.proto \
	--proto-file ext2.proto \
	--registered-extensions 10:package1.Message1 \
	--registered-extensions 20:package2.Message2 \
	get --target node1 --path root:/
```

Output:
```json5
{
	// ...
	"extension": [
    {
      "Ext": {
        "RegisteredExt": {
          "id": 10,
          "msg": "protobytes"
        }
      }
    },
    {
      "Ext": {
        "RegisteredExt": {
          "id": 20,
          "msg": "protobytes"
        }
      }
    }
  ],
	"decodedExtensions": {
		"10": { "ext1_message": { "msg1_field": 10 } },
		"20": { "ext2_message": { "msg2_field": 20 } }
	}
}
```

It should work for all types of responses (get, set, sub).