### PR TITLE
updating API references to 'github.com/openconfig/gnmic/pkg/api'

### DIFF
--- a/docs/user_guide/golang_package/gnmi_options.md
+++ b/docs/user_guide/golang_package/gnmi_options.md
@@ -1,5 +1,5 @@
 
-The package `github.com/openconfig/gnmic/api` exposes a set of `api.GNMIOption` that can be used with 
+The package `github.com/openconfig/gnmic/pkg/api` exposes a set of `api.GNMIOption` that can be used with 
 `api.NewGetRequest(...api.GNMIOption) GNMIOption`, `api.NewSetRequest(...api.GNMIOption) GNMIOption` or `api.NewSubscribeRequest(...api.GNMIOption) GNMIOption` to create a gNMI Request.
 
 ```golang

--- a/docs/user_guide/golang_package/intro.md
+++ b/docs/user_guide/golang_package/intro.md
@@ -1,4 +1,4 @@
-`gnmic` (`github.com/openconfig/gnmic/api`) can be imported as a dependency in your Golang programs.
+`gnmic` (`github.com/openconfig/gnmic/pkg/api`) can be imported as a dependency in your Golang programs.
 
 It acts as a wrapper around the `openconfig/gnmi` package providing a user friendly API to create a target and easily craft gNMI requests.
 
@@ -12,7 +12,7 @@ func NewGetRequest(opts ...GNMIOption) (*gnmi.GetRequest, error)
 
 The below 2 snippets create a Get Request with 2 paths, `json_ietf` encoding and data type `STATE`
 
-Using `github.com/openconfig/gnmic/api`
+Using `github.com/openconfig/gnmic/pkg/api`
 
 ```golang
 getReq, err := api.NewGetRequest(
@@ -56,7 +56,7 @@ func NewSetRequest(opts ...GNMIOption) (*gnmi.SetRequest, error)
 
 The below 2 snippets create a Set Request with one two updates, one replace and one delete messages:
 
-Using `github.com/openconfig/gnmic/api`
+Using `github.com/openconfig/gnmic/pkg/api`
 
 ```golang
 setReq, err := api.NewSetRequest(
@@ -168,7 +168,7 @@ func NewSubscribePollRequest(opts ...GNMIOption) *gnmi.SubscribeRequest
 
 The below 2 snippets create a `stream` subscribe request with 2 paths, `json_ietf` encoding and a sample interval of 10 seconds:
 
-Using `github.com/openconfig/gnmic/api`
+Using `github.com/openconfig/gnmic/pkg/api`
 
 ```golang
 subReq, err := api.NewSubscribeRequest(

--- a/docs/user_guide/golang_package/target_options.md
+++ b/docs/user_guide/golang_package/target_options.md
@@ -1,5 +1,5 @@
 
-The package `github.com/openconfig/gnmic/api` exposes a set of `api.TargetOption` that can be used with 
+The package `github.com/openconfig/gnmic/pkg/api` exposes a set of `api.TargetOption` that can be used with 
 `api.NewTarget(...api.TargetOption) TargetOption` to create `target.Target`.
 
 ```golang


### PR DESCRIPTION
# Problem statement
Noticed that while reading gnmic documentation such as https://gnmic.openconfig.net/user_guide/golang_package/intro/ that it was referring to `github.com/openconfig/gnmic/api` instead of `github.com/openconfig/gnmic/pkg/api`.

# Proposed changes
Change all references of `github.com/openconfig/gnmic/api` instead to `github.com/openconfig/gnmic/pkg/api`.