### PR TITLE
feat: add strip-leading-underscore option to OTLP metric names

### DIFF
--- a/pkg/outputs/otlp_output/otlp_converter.go
+++ b/pkg/outputs/otlp_output/otlp_converter.go
@@ -1,4 +1,4 @@
-// © 2025 NVIDIA Corporation
+// © 2025-2026 NVIDIA Corporation
 //
 // This code is a Contribution to the gNMIc project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
 // No other rights or licenses in or to any of NVIDIA's intellectual property are granted for any other purpose.
@@ -233,7 +233,13 @@ func (o *otlpOutput) buildMetricName(cfg *config, event *formatters.EventMsg, va
 
 	// Append the value key (metric path), converting slashes to underscores
 	// e.g., "interfaces/interface/state/counters/in-octets" -> "interfaces_interface_state_counters_in_octets"
-	metricPath := strings.ReplaceAll(valueKey, "/", "_")
+	// gNMI paths arrive with a leading "/"; strip it when configured so the conversion
+	// does not produce a leading "_" (or a double "_" when a prefix is set).
+	path := valueKey
+	if cfg.StripLeadingUnderscore {
+		path = strings.TrimPrefix(path, "/")
+	}
+	metricPath := strings.ReplaceAll(path, "/", "_")
 	sb.WriteString(metricPath)
 
 	name := sb.String()

--- a/pkg/outputs/otlp_output/otlp_output.go
+++ b/pkg/outputs/otlp_output/otlp_output.go
@@ -1,4 +1,4 @@
-// © 2025 NVIDIA Corporation
+// © 2025-2026 NVIDIA Corporation
 //
 // This code is a Contribution to the gNMIc project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
 // No other rights or licenses in or to any of NVIDIA's intellectual property are granted for any other purpose.
@@ -115,6 +115,11 @@ type config struct {
 	// and the string stored as an attribute named "value".
 	// if false, string values are dropped.
 	StringsAsAttributes bool `mapstructure:"strings-as-attributes,omitempty"`
+	// boolean, if true, the leading "/" of the metric path is trimmed before the
+	// slash-to-underscore conversion, so a path like "/interfaces/..." becomes
+	// "interfaces_..." instead of "_interfaces_...". Defaults to false for
+	// backward compatibility.
+	StripLeadingUnderscore bool `mapstructure:"strip-leading-underscore,omitempty"`
 
 	// Tags whose values are placed as OTLP Resource attributes and excluded
 	// from data point attributes.

--- a/pkg/outputs/otlp_output/otlp_output_test.go
+++ b/pkg/outputs/otlp_output/otlp_output_test.go
@@ -1,4 +1,4 @@
-// © 2025 NVIDIA Corporation
+// © 2025-2026 NVIDIA Corporation
 //
 // This code is a Contribution to the gNMIc project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
 // No other rights or licenses in or to any of NVIDIA's intellectual property are granted for any other purpose.
@@ -350,6 +350,78 @@ func TestOTLP_SubscriptionNameMapping(t *testing.T) {
 	// Then: subscription_name should be in attributes
 	dataPoint := otlpMetrics.ResourceMetrics[0].ScopeMetrics[0].Metrics[0].GetSum().DataPoints[0]
 	assert.Equal(t, "arista", getDataPointAttribute(dataPoint, "subscription_name"))
+}
+
+// TestBuildMetricName_StripLeadingUnderscore verifies the strip-leading-underscore config option.
+// gNMI paths arrive with a leading "/" (see pkg/formatters/event.go updateToEvent), which the
+// slash->underscore conversion turns into a leading "_". This test pins both the backward-compatible
+// default (option off) and the new behavior (option on).
+func TestBuildMetricName_StripLeadingUnderscore(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config
+		event    *formatters.EventMsg
+		valueKey string
+		expected string
+	}{
+		{
+			name:     "default preserves leading underscore (backward compat)",
+			cfg:      &config{},
+			event:    &formatters.EventMsg{Name: "sub1"},
+			valueKey: "/interfaces/interface/state/counters/in-octets",
+			expected: "_interfaces_interface_state_counters_in_octets",
+		},
+		{
+			name:     "enabled removes leading underscore",
+			cfg:      &config{StripLeadingUnderscore: true},
+			event:    &formatters.EventMsg{Name: "sub1"},
+			valueKey: "/interfaces/interface/state/counters/in-octets",
+			expected: "interfaces_interface_state_counters_in_octets",
+		},
+		{
+			name:     "disabled with metric-prefix yields double underscore (backward compat)",
+			cfg:      &config{MetricPrefix: "gnmic"},
+			event:    &formatters.EventMsg{Name: "sub1"},
+			valueKey: "/interfaces/interface/state/counters/in-octets",
+			expected: "gnmic__interfaces_interface_state_counters_in_octets",
+		},
+		{
+			name:     "enabled with metric-prefix has single underscore separator",
+			cfg:      &config{StripLeadingUnderscore: true, MetricPrefix: "gnmic"},
+			event:    &formatters.EventMsg{Name: "sub1"},
+			valueKey: "/interfaces/interface/state/counters/in-octets",
+			expected: "gnmic_interfaces_interface_state_counters_in_octets",
+		},
+		{
+			name:     "enabled with append-subscription-name has single underscore separator",
+			cfg:      &config{StripLeadingUnderscore: true, AppendSubscriptionName: true},
+			event:    &formatters.EventMsg{Name: "arista"},
+			valueKey: "/interfaces/interface/state/counters/in-octets",
+			expected: "arista_interfaces_interface_state_counters_in_octets",
+		},
+		{
+			name:     "enabled does not touch non-leading underscores",
+			cfg:      &config{StripLeadingUnderscore: true},
+			event:    &formatters.EventMsg{Name: "sub1"},
+			valueKey: "/a_b/c",
+			expected: "a_b_c",
+		},
+		{
+			name:     "enabled is a no-op when path has no leading slash",
+			cfg:      &config{StripLeadingUnderscore: true},
+			event:    &formatters.EventMsg{Name: "sub1"},
+			valueKey: "interfaces/interface",
+			expected: "interfaces_interface",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := newTestOutput(tt.cfg)
+			got := output.buildMetricName(tt.cfg, tt.event, tt.valueKey)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
 }
 
 // Helper functions


### PR DESCRIPTION
## Summary

Add an opt-in `strip-leading-underscore` config option to the OTLP output. gNMI
paths are emitted with a leading `/`, which the slash-to-underscore conversion
in `buildMetricName` turns into a leading `_` on every metric name — and a
double `_` when `metric-prefix` is set.

When enabled, the option trims the leading `/` from the path before the
slash-to-underscore conversion, so
`/interfaces/interface/state/counters/in-octets` becomes
`interfaces_interface_state_counters_in_octets` instead of
`_interfaces_interface_state_counters_in_octets`.

Defaults to `false` to preserve existing metric names for users with
dashboards or alerting rules pinned to the current output.

## Example

```yaml
outputs:
  otlp-out:
    type: otlp
    endpoint: collector:4317
    strip-leading-underscore: true
```

## Behavior matrix

| `strip-leading-underscore` | `metric-prefix` | Output |
|---|---|---|
| `false` (default) | unset | `_interfaces_...` (unchanged) |
| `true` | unset | `interfaces_...` |
| `false` | `gnmic` | `gnmic__interfaces_...` (unchanged) |
| `true` | `gnmic` | `gnmic_interfaces_...` |