### PR TITLE
fix: enforce OTel Resource immutability in OTLP output

### DIFF
--- a/pkg/outputs/otlp_output/otlp_converter.go
+++ b/pkg/outputs/otlp_output/otlp_converter.go
@@ -103,17 +103,29 @@ func (o *otlpOutput) convertToOTLP(events []*formatters.EventMsg) *metricsv1.Exp
 	return req
 }
 
-// groupByResource groups events by their source (device) for resource attribution
+// groupByResource groups events by a stable identifier of the producing
+// entity so that each group becomes one OTLP Resource. The key is taken from
+// the first non-empty tag in the preference chain device -> target -> source,
+// falling back to the literal "unknown" only when all three are absent.
+// Preferring device over source prevents cross-target contamination in
+// deployments that legitimately strip source (e.g., because it duplicates
+// device), which previously collapsed every target into a single "unknown"
+// bucket.
 func (o *otlpOutput) groupByResource(events []*formatters.EventMsg) map[string][]*formatters.EventMsg {
 	groups := make(map[string][]*formatters.EventMsg)
 
 	for _, event := range events {
-		// Use source as resource key
-		source := event.Tags["source"]
-		if source == "" {
-			source = "unknown"
+		key := event.Tags["device"]
+		if key == "" {
+			key = event.Tags["target"]
 		}
-		groups[source] = append(groups[source], event)
+		if key == "" {
+			key = event.Tags["source"]
+		}
+		if key == "" {
+			key = "unknown"
+		}
+		groups[key] = append(groups[key], event)
 	}
 
 	return groups

--- a/pkg/outputs/otlp_output/otlp_converter.go
+++ b/pkg/outputs/otlp_output/otlp_converter.go
@@ -55,8 +55,9 @@ func (o *otlpOutput) convertToOTLP(events []*formatters.EventMsg) *metricsv1.Exp
 	skippedEvents := 0
 
 	for _, groupedEvents := range resourceGroups {
+		resource, divergent := o.createResource(cfg, groupedEvents)
 		rm := &metricspb.ResourceMetrics{
-			Resource: o.createResource(cfg, groupedEvents[0]),
+			Resource: resource,
 			ScopeMetrics: []*metricspb.ScopeMetrics{
 				{
 					Scope: &commonpb.InstrumentationScope{
@@ -70,7 +71,7 @@ func (o *otlpOutput) convertToOTLP(events []*formatters.EventMsg) *metricsv1.Exp
 
 		// Convert each event to OTLP metric
 		for _, event := range groupedEvents {
-			metrics, err := o.convertEventToMetrics(cfg, event)
+			metrics, err := o.convertEventToMetrics(cfg, divergent, event)
 			if err != nil {
 				if cfg.Debug {
 					o.logger.Printf("DEBUG: failed to convert event %s: %v", event.Name, err)
@@ -118,18 +119,48 @@ func (o *otlpOutput) groupByResource(events []*formatters.EventMsg) map[string][
 	return groups
 }
 
-// createResource creates OTLP Resource from event metadata.
-// Tags listed in cfg.ResourceTagKeys are placed as resource attributes.
-func (o *otlpOutput) createResource(cfg *config, event *formatters.EventMsg) *resourcepb.Resource {
+// createResource creates an OTLP Resource from the metadata shared by every
+// event in a group. For each key in cfg.ResourceTagKeys, the value is promoted
+// to Resource only if every event that carries the tag agrees on the value
+// (absence is lenient — an event that does not carry the tag does not
+// constrain the group). Keys whose values diverge across the group are
+// returned in the divergent map so that the caller can route them to
+// per-datapoint attributes instead. This enforces the OTel Resource spec,
+// which requires Resource attributes to be immutable identifiers of the
+// entity producing the telemetry.
+func (o *otlpOutput) createResource(cfg *config, groupedEvents []*formatters.EventMsg) (*resourcepb.Resource, map[string]bool) {
 	attrs := make([]*commonpb.KeyValue, 0, len(cfg.ResourceTagKeys)+len(cfg.ResourceAttributes))
+	divergent := make(map[string]bool)
 
 	for _, key := range cfg.ResourceTagKeys {
-		if val, ok := event.Tags[key]; ok {
-			attrs = append(attrs, &commonpb.KeyValue{
-				Key:   key,
-				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: val}},
-			})
+		var chosen string
+		var seen, diverges bool
+		for _, ev := range groupedEvents {
+			v, ok := ev.Tags[key]
+			if !ok {
+				continue
+			}
+			if !seen {
+				chosen = v
+				seen = true
+				continue
+			}
+			if v != chosen {
+				diverges = true
+				break
+			}
 		}
+		if !seen {
+			continue
+		}
+		if diverges {
+			divergent[key] = true
+			continue
+		}
+		attrs = append(attrs, &commonpb.KeyValue{
+			Key:   key,
+			Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: chosen}},
+		})
 	}
 
 	for key, val := range cfg.ResourceAttributes {
@@ -139,14 +170,15 @@ func (o *otlpOutput) createResource(cfg *config, event *formatters.EventMsg) *re
 		})
 	}
 
-	return &resourcepb.Resource{
-		Attributes: attrs,
-	}
+	return &resourcepb.Resource{Attributes: attrs}, divergent
 }
 
 // convertEventToMetrics converts a single gNMI event to OTLP metrics.
-// Returns nil if the event has no valid values to convert.
-func (o *otlpOutput) convertEventToMetrics(cfg *config, event *formatters.EventMsg) ([]*metricspb.Metric, error) {
+// Returns nil if the event has no valid values to convert. The divergent map
+// carries the per-group set of resource-tag-keys whose values varied across
+// the group; those keys are kept as per-datapoint attributes instead of being
+// excluded in favor of the Resource.
+func (o *otlpOutput) convertEventToMetrics(cfg *config, divergent map[string]bool, event *formatters.EventMsg) ([]*metricspb.Metric, error) {
 	if len(event.Values) == 0 {
 		if cfg.Debug {
 			o.logger.Printf("DEBUG: event has no values (event: %s)", event.Name)
@@ -154,7 +186,7 @@ func (o *otlpOutput) convertEventToMetrics(cfg *config, event *formatters.EventM
 		return nil, nil
 	}
 
-	attributes := o.extractAttributesForMetric(cfg, event)
+	attributes := o.extractAttributesForMetric(cfg, divergent, event)
 
 	result := make([]*metricspb.Metric, 0, len(event.Values))
 	for k, v := range event.Values {
@@ -251,12 +283,15 @@ func (o *otlpOutput) buildMetricName(cfg *config, event *formatters.EventMsg, va
 }
 
 // extractAttributesForMetric extracts data point attributes from event tags.
-// Tags listed in cfg.ResourceTagKeys are excluded (they live on the Resource).
-func (o *otlpOutput) extractAttributesForMetric(cfg *config, event *formatters.EventMsg) []*commonpb.KeyValue {
+// Tags listed in cfg.ResourceTagKeys are excluded (they live on the Resource)
+// unless the group-level divergence map marks them as divergent, in which case
+// the value could not be promoted to Resource and must flow through to the
+// datapoint with its correct per-event value.
+func (o *otlpOutput) extractAttributesForMetric(cfg *config, divergent map[string]bool, event *formatters.EventMsg) []*commonpb.KeyValue {
 	attrs := make([]*commonpb.KeyValue, 0, len(event.Tags))
 
 	for key, val := range event.Tags {
-		if cfg.resourceTagSet[key] {
+		if cfg.resourceTagSet[key] && !divergent[key] {
 			continue
 		}
 		attrs = append(attrs, &commonpb.KeyValue{

--- a/pkg/outputs/otlp_output/otlp_output_test.go
+++ b/pkg/outputs/otlp_output/otlp_output_test.go
@@ -620,6 +620,101 @@ func TestExtractAttributesForMetric_NoDivergenceMatchesOriginalBehavior(t *testi
 	assert.Equal(t, "RE0", v)
 }
 
+// TestGroupByResource_PrefersDeviceOverTargetAndSource pins the preference
+// order: when device is present, it is used as the group key regardless of
+// whether target or source is also present. device is the most stable and
+// human-readable identifier of the producing entity, so it leads the chain.
+func TestGroupByResource_PrefersDeviceOverTargetAndSource(t *testing.T) {
+	output := newTestOutput(&config{})
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"device": "bbr2", "target": "bbr2-t", "source": "10.1.1.1:6030"}},
+		{Tags: map[string]string{"device": "bbr2", "target": "bbr2-t", "source": "10.1.1.1:6030"}},
+		{Tags: map[string]string{"device": "fnx5", "target": "fnx5-t", "source": "10.2.2.2:6030"}},
+	}
+
+	groups := output.groupByResource(events)
+
+	assert.Len(t, groups["bbr2"], 2, "device leads the preference chain")
+	assert.Len(t, groups["fnx5"], 1)
+	_, ok := groups["10.1.1.1:6030"]
+	assert.False(t, ok, "source must not be used when device is present")
+}
+
+// TestGroupByResource_UsesSourceWhenDeviceAndTargetAbsent verifies that when
+// only source is present, it is still used as the group key — matching
+// behavior prior to this change for deployments that have not set device or
+// target tags.
+func TestGroupByResource_UsesSourceWhenDeviceAndTargetAbsent(t *testing.T) {
+	output := newTestOutput(&config{})
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"source": "10.1.1.1:6030"}},
+		{Tags: map[string]string{"source": "10.2.2.2:6030"}},
+	}
+
+	groups := output.groupByResource(events)
+
+	assert.Len(t, groups["10.1.1.1:6030"], 1)
+	assert.Len(t, groups["10.2.2.2:6030"], 1)
+}
+
+// TestGroupByResource_FallsBackToDeviceWhenSourceAbsent verifies that when
+// events have no source tag (e.g., stripped by a processor because it
+// duplicates device), grouping falls back to device so per-target Resource
+// isolation is preserved.
+func TestGroupByResource_FallsBackToDeviceWhenSourceAbsent(t *testing.T) {
+	output := newTestOutput(&config{})
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"device": "bbr2"}},
+		{Tags: map[string]string{"device": "bbr2"}},
+		{Tags: map[string]string{"device": "fnx5"}},
+	}
+
+	groups := output.groupByResource(events)
+
+	assert.Len(t, groups["bbr2"], 2)
+	assert.Len(t, groups["fnx5"], 1)
+	_, ok := groups["unknown"]
+	assert.False(t, ok, "unknown bucket must not be populated when device is present")
+}
+
+// TestGroupByResource_FallsBackToTargetWhenSourceAndDeviceAbsent verifies the
+// third step of the fallback chain: when both source and device are absent,
+// fall back to target.
+func TestGroupByResource_FallsBackToTargetWhenSourceAndDeviceAbsent(t *testing.T) {
+	output := newTestOutput(&config{})
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"target": "bbr2-logical"}},
+		{Tags: map[string]string{"target": "bbr2-logical"}},
+	}
+
+	groups := output.groupByResource(events)
+
+	assert.Len(t, groups["bbr2-logical"], 2)
+	_, ok := groups["unknown"]
+	assert.False(t, ok)
+}
+
+// TestGroupByResource_FallsBackToUnknownAsLastResort documents that when the
+// whole fallback chain is empty, events collapse into a literal "unknown"
+// bucket. This is the same landmine behavior as before the fallback chain —
+// preserved as a last resort.
+func TestGroupByResource_FallsBackToUnknownAsLastResort(t *testing.T) {
+	output := newTestOutput(&config{})
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"unrelated": "x"}},
+		{Tags: map[string]string{"unrelated": "y"}},
+	}
+
+	groups := output.groupByResource(events)
+
+	assert.Len(t, groups["unknown"], 2)
+}
+
 // Helper functions
 
 func createTestEvent() *formatters.EventMsg {

--- a/pkg/outputs/otlp_output/otlp_output_test.go
+++ b/pkg/outputs/otlp_output/otlp_output_test.go
@@ -424,6 +424,202 @@ func TestBuildMetricName_StripLeadingUnderscore(t *testing.T) {
 	}
 }
 
+// getResourceAttr returns the value of an attribute on a Resource, and whether it was present.
+func getResourceAttr(r interface{ GetAttributes() []*commonpb.KeyValue }, key string) (string, bool) {
+	for _, a := range r.GetAttributes() {
+	    if a.Key == key {
+	        return a.Value.GetStringValue(), true
+	    }
+	}
+	return "", false
+}
+
+// getAttr returns the value of an attribute in a KeyValue slice, and whether it was present.
+func getAttr(attrs []*commonpb.KeyValue, key string) (string, bool) {
+	for _, a := range attrs {
+		if a.Key == key {
+			return a.Value.GetStringValue(), true
+		}
+	}
+	return "", false
+}
+
+// TestCreateResource_UniformTagsPromoted pins the backward-compatible path:
+// when every event in the group agrees on a resource-tag-keys value, that tag
+// is promoted to the Resource and not flagged as divergent.
+func TestCreateResource_UniformTagsPromoted(t *testing.T) {
+	cfg := &config{
+		ResourceTagKeys: []string{"device", "model", "vendor"},
+	}
+	output := newTestOutput(cfg)
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"device": "bbr2", "model": "junos", "vendor": "juniper", "component_name": "RE0"}},
+		{Tags: map[string]string{"device": "bbr2", "model": "junos", "vendor": "juniper", "component_name": "FPC0"}},
+	}
+
+	resource, divergent := output.createResource(cfg, events)
+
+	device, ok := getResourceAttr(resource, "device")
+	require.True(t, ok, "device should be on Resource")
+	assert.Equal(t, "bbr2", device)
+
+	model, ok := getResourceAttr(resource, "model")
+	require.True(t, ok)
+	assert.Equal(t, "junos", model)
+
+	assert.Empty(t, divergent, "no divergent keys expected when all events agree")
+}
+
+// TestCreateResource_DivergentTagsInDivergenceSet is the spec-violation fix:
+// when a resource-tag-keys value varies across events in the group, the tag
+// is omitted from Resource and reported in the divergence set so that the
+// per-datapoint attribute extraction can route it correctly.
+func TestCreateResource_DivergentTagsInDivergenceSet(t *testing.T) {
+	cfg := &config{
+		ResourceTagKeys: []string{"device", "serial_no"},
+	}
+	output := newTestOutput(cfg)
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"device": "bbr2", "serial_no": "BUILTIN"}},
+		{Tags: map[string]string{"device": "bbr2", "serial_no": "1W1CUPAA04012"}},
+	}
+
+	resource, divergent := output.createResource(cfg, events)
+
+	device, ok := getResourceAttr(resource, "device")
+	require.True(t, ok)
+	assert.Equal(t, "bbr2", device, "uniform tag still promoted")
+
+	_, ok = getResourceAttr(resource, "serial_no")
+	assert.False(t, ok, "divergent tag must not appear on Resource")
+
+	assert.True(t, divergent["serial_no"], "serial_no must be flagged as divergent")
+	assert.False(t, divergent["device"], "device should not be flagged")
+}
+
+// TestCreateResource_MissingFromSomeEventsIsLenient pins the lenient semantic:
+// a tag present in some events and absent in others, where the present events
+// all agree, is still promoted to Resource. Absence does not count as divergence.
+func TestCreateResource_MissingFromSomeEventsIsLenient(t *testing.T) {
+	cfg := &config{
+		ResourceTagKeys: []string{"model"},
+	}
+	output := newTestOutput(cfg)
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"model": "junos"}},
+		{Tags: map[string]string{}}, // model absent
+		{Tags: map[string]string{"model": "junos"}},
+	}
+
+	resource, divergent := output.createResource(cfg, events)
+
+	model, ok := getResourceAttr(resource, "model")
+	require.True(t, ok, "model should be promoted when present events agree")
+	assert.Equal(t, "junos", model)
+	assert.False(t, divergent["model"])
+}
+
+// TestCreateResource_MissingFromAllEventsSkipped verifies that a resource-tag-key
+// absent from every event in the group is neither promoted nor flagged as divergent.
+func TestCreateResource_MissingFromAllEventsSkipped(t *testing.T) {
+	cfg := &config{
+		ResourceTagKeys: []string{"vendor"},
+	}
+	output := newTestOutput(cfg)
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"device": "bbr2"}},
+		{Tags: map[string]string{"device": "bbr2"}},
+	}
+
+	resource, divergent := output.createResource(cfg, events)
+
+	_, ok := getResourceAttr(resource, "vendor")
+	assert.False(t, ok, "absent tag not promoted")
+	assert.False(t, divergent["vendor"], "absent tag not divergent either")
+}
+
+// TestCreateResource_ResourceAttributesStillAppended verifies that the static
+// cfg.ResourceAttributes map continues to be merged into the Resource regardless
+// of divergence handling for resource-tag-keys.
+func TestCreateResource_ResourceAttributesStillAppended(t *testing.T) {
+	cfg := &config{
+		ResourceTagKeys:    []string{"device"},
+		ResourceAttributes: map[string]string{"telemetry.source": "gnmi"},
+	}
+	output := newTestOutput(cfg)
+
+	events := []*formatters.EventMsg{
+		{Tags: map[string]string{"device": "bbr2"}},
+	}
+
+	resource, _ := output.createResource(cfg, events)
+
+	v, ok := getResourceAttr(resource, "telemetry.source")
+	require.True(t, ok)
+	assert.Equal(t, "gnmi", v)
+}
+
+// TestExtractAttributesForMetric_DivergentKeysIncluded verifies that when a
+// resource-tag-key is flagged as divergent for the current group, the event's
+// own value for that key flows through to datapoint attributes with its correct
+// per-event value instead of being excluded as a resource-only tag.
+func TestExtractAttributesForMetric_DivergentKeysIncluded(t *testing.T) {
+	cfg := &config{
+		ResourceTagKeys: []string{"device", "serial_no"},
+	}
+	output := newTestOutput(cfg)
+
+	event := &formatters.EventMsg{Tags: map[string]string{
+		"device":         "bbr2",
+		"serial_no":      "BUILTIN",
+		"component_name": "RE0",
+	}}
+	divergent := map[string]bool{"serial_no": true}
+
+	attrs := output.extractAttributesForMetric(cfg, divergent, event)
+
+	v, ok := getAttr(attrs, "serial_no")
+	require.True(t, ok, "divergent resource-tag-key must appear on datapoint attrs")
+	assert.Equal(t, "BUILTIN", v, "with this event's correct value")
+
+	_, ok = getAttr(attrs, "device")
+	assert.False(t, ok, "non-divergent resource-tag-key still excluded from datapoint attrs")
+
+	v, ok = getAttr(attrs, "component_name")
+	require.True(t, ok, "non-resource tag still on datapoint attrs")
+	assert.Equal(t, "RE0", v)
+}
+
+// TestExtractAttributesForMetric_NoDivergenceMatchesOriginalBehavior is a
+// regression pin: when no keys are divergent, datapoint attrs exclude every
+// resource-tag-key — matching behavior prior to this change.
+func TestExtractAttributesForMetric_NoDivergenceMatchesOriginalBehavior(t *testing.T) {
+	cfg := &config{
+		ResourceTagKeys: []string{"device", "model"},
+	}
+	output := newTestOutput(cfg)
+
+	event := &formatters.EventMsg{Tags: map[string]string{
+		"device":         "bbr2",
+		"model":          "junos",
+		"component_name": "RE0",
+	}}
+
+	attrs := output.extractAttributesForMetric(cfg, map[string]bool{}, event)
+
+	_, ok := getAttr(attrs, "device")
+	assert.False(t, ok)
+	_, ok = getAttr(attrs, "model")
+	assert.False(t, ok)
+	v, ok := getAttr(attrs, "component_name")
+	require.True(t, ok)
+	assert.Equal(t, "RE0", v)
+}
+
 // Helper functions
 
 func createTestEvent() *formatters.EventMsg {


### PR DESCRIPTION
Fixes #854.

Two commits:

1. **divergence check** — `createResource(cfg, groupedEvents[0])` becomes
   `createResource(cfg, groupedEvents []*EventMsg)` with a per-key uniformity
   check. Divergent values route to datapoint attributes; only uniform values
   are promoted to Resource.

2. **grouping fallback** — `groupByResource` prefers
   `device → target → source → "unknown"`, preventing cross-target collapse
   when source is stripped.

## Validation

Side-by-side test on 2 Junos targets, identical config except image,
30 minutes of OTLP traffic to a real OTel Collector + Mimir.

`oc_…_bgp_neighbors_neighbor_state_established_transitions` series per
device:

| | bbr1 | bbr2 |
|---|---|---|
| Fixed (this PR) | 70 | 70 |
| Current main (buggy) | 82 | 78 |

Fixed is symmetric per device and matches the pre-mitigation production
baseline. Buggy is asymmetric (`[0]`-pick variance leaking through) and
produces 20 extra time series across just 2 devices.

In production, when I started stripping `source`, this pattern turned a
few thousand time series into tens of thousands at fleet scale.

## Tests

12 new TDD-driven tests on `createResource`,
`extractAttributesForMetric`, and `groupByResource`. All passing; full
project builds clean.