### PR TITLE
feat: OTLP output map boolean values to int 1/0

### DIFF
--- a/pkg/outputs/otlp_output/otlp_converter.go
+++ b/pkg/outputs/otlp_output/otlp_converter.go
@@ -317,6 +317,12 @@ func (o *otlpOutput) createNumberDataPointWithValue(cfg *config, event *formatte
 		} else {
 			return nil
 		}
+	case bool:
+		if v {
+			dp.Value = &metricspb.NumberDataPoint_AsInt{AsInt: 1}
+		} else {
+			dp.Value = &metricspb.NumberDataPoint_AsInt{AsInt: 0}
+		}
 	default:
 		if cfg.Debug {
 			o.logger.Printf("unsupported value type %T for metric %s", v, event.Name)


### PR DESCRIPTION
Extend createNumberDataPointWithValue to handle bool values by mapping true → 1 and false → 0 as NumberDataPoint_AsInt. Previously booleans were treated as unsupported and dropped.