### PR TITLE
chore: bump Go to 1.25.10 and prometheus to v0.311.3 (May 2026 CVEs)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ on:
   #     - "!releases/**"
   
 env:
-  GOVER: 1.25.9
+  GOVER: 1.25.10
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
     tags:
       - v*
 env:
-  GOVER: 1.25.9
+  GOVER: 1.25.10
   GORELEASER_VER: v2.13.3
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
       - "main"
       - "!releases/**"
 env:
-  GOVER: 1.25.9
+  GOVER: 1.25.10
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25.9 AS builder
+FROM golang:1.25.10 AS builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pkg/sftp v1.13.9
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
-	github.com/prometheus/prometheus v0.311.2
+	github.com/prometheus/prometheus v0.311.3
 	github.com/redis/go-redis/v9 v9.14.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/prometheus/prometheus v0.311.2 h1:6fBxp93y08GAZGNT1o3bIhgV/AMYvBFfU+ltDNEsHg8=
-github.com/prometheus/prometheus v0.311.2/go.mod h1:gjsCxTKtHO1Q8T9333u1s+lUR1OjPyM7ruuGH8RvVyo=
+github.com/prometheus/prometheus v0.311.3 h1:3IrVxQv6v5i/ZCGi6OrYeBhtCwaPTn6Z3DYruXoYm3M=
+github.com/prometheus/prometheus v0.311.3/go.mod h1:gjsCxTKtHO1Q8T9333u1s+lUR1OjPyM7ruuGH8RvVyo=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8AOIL7EB/X911+m4EHsnWEHeJ0c+3TTBrg=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.14.0 h1:u4tNCjXOyzfgeLN+vAZaW1xUooqWDqVEsZN0U01jfAE=


### PR DESCRIPTION
## Why I did it

Two related security bumps from the 2026-05-07 wave:

**1. Go toolchain → 1.25.10** ([golang-announce qcCIEXso47M](https://groups.google.com/g/golang-announce/c/qcCIEXso47M)). Closes five stdlib DoS/crash CVEs that #864 left behind because it pinned to 1.25.9 (latest at the time):

| CVE | Package | Notes |
|---|---|---|
| CVE-2026-33811 | `net.LookupCNAME` (cgo resolver) | double-free / crash |
| CVE-2026-33814 | `net/http`, `golang.org/x/net/http2` | HTTP/2 `SETTINGS_MAX_FRAME_SIZE=0` infinite-loop DoS |
| CVE-2026-39820 | `net/mail.ParseAddress` / `ParseDate` | DoS via crafted input |
| CVE-2026-39836 | `net.Dial` / `LookupPort` on Windows | panic on NUL byte |
| CVE-2026-42499 | `net/mail.consumePhrase` | DoS via pathological RFC 5322 |

Only CVE-2026-33814 is plausibly reachable in gnmic (gRPC is HTTP/2 — a malicious gNMI target could send the bad SETTINGS frame and hang the transport). The other four cover stdlib symbols (`net/mail`, Windows-only `Dial`, cgo `LookupCNAME`) gnmic does not exercise but which still flag on SBOM-level scans against the embedded toolchain version. The matching `golang.org/x/net v0.53.0` bump for CVE-2026-33814 is already on `main` via prior dependabot merges, so the toolchain pin is the only remaining gap.

**2. `github.com/prometheus/prometheus` → v0.311.3.** Closes [CVE-2026-42151](https://github.com/advisories/GHSA-wg65-39gg-5wfj) (HIGH, CVSS 7.5): Prometheus < v0.311.3 exposes Azure AD OAuth client secrets in plaintext via the config API because the field was typed as `string` instead of `Secret`. Fixed only in v0.311.3.

gnmic uses prometheus as a library for `prometheus_output` (gNMI data exported as metrics) and does not expose Prometheus's config API or use Azure OAuth, so practical impact in gnmic is essentially zero. The bump is included so SBOM-level scanners stop flagging the row.

## How I did it

Two commits:

1. `chore(ci): bump Go toolchain to 1.25.10` — four-line bump of the `1.25.9` pin in `.github/workflows/{test,lint,release}.yml` (`GOVER`) and `Dockerfile` (`FROM golang:1.25.9 → 1.25.10`). No source changes; no `go.mod` / `go.sum` change required.
2. `chore(deps): bump prometheus to v0.311.3 to address CVE-2026-42151` — `go get github.com/prometheus/prometheus@v0.311.3 && go mod tidy`. Touches only `go.mod` (1 line) and `go.sum` (2 lines). No transitive churn.

## How to verify it

- `go build ./...` — clean
- `go vet ./...` — clean
- CI on this PR will exercise the new toolchain across all three workflows.