### PR TITLE
fix(otlp): validate counter-patterns in subscribe mode

### DIFF
--- a/pkg/outputs/otlp_output/otlp_output.go
+++ b/pkg/outputs/otlp_output/otlp_output.go
@@ -197,6 +197,9 @@ func (o *otlpOutput) Init(ctx context.Context, name string, cfg map[string]inter
 		ncfg.Name = options.Name
 	}
 	o.setDefaultsFor(ncfg)
+	if err := o.validateConfig(ncfg); err != nil {
+		return err
+	}
 
 	// Apply logger
 	o.logger = outputs.BindLogger(options.Logger, outputType, ncfg.Name)

--- a/pkg/outputs/otlp_output/otlp_output_test.go
+++ b/pkg/outputs/otlp_output/otlp_output_test.go
@@ -1196,6 +1196,76 @@ func TestOTLP_ChannelCloseFlushes(t *testing.T) {
 	assert.Greater(t, server.ReceivedMetricsCount(), 0, "Remaining batch should be flushed when channel closes")
 }
 
+// TestOTLP_InitCompilesCounterPatterns verifies that Init (the subscribe path)
+// compiles counter-patterns into counterRegexes so that isCounter honors them at
+// runtime. Before the fix, Init only called setDefaultsFor and stored the config
+// without validateConfig, leaving counterRegexes nil so every metric exported as a
+// Gauge in subscribe mode.
+func TestOTLP_InitCompilesCounterPatterns(t *testing.T) {
+	cfg := map[string]interface{}{
+		"endpoint":         "unreachable-host:4317",
+		"protocol":         "grpc",
+		"timeout":          "1s",
+		"counter-patterns": []string{"counters", "octets|packets"},
+	}
+
+	output := &otlpOutput{}
+	err := output.Init(context.Background(), "test-otlp", cfg,
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	)
+	require.NoError(t, err, "Init should succeed with valid counter-patterns")
+	defer output.Close()
+
+	stored := output.cfg.Load()
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.counterRegexes, "counterRegexes should be compiled by Init")
+	assert.Len(t, stored.counterRegexes, 2)
+
+	assert.True(t, output.isCounter(stored, "out-octets"), "matching key should be treated as a counter")
+	assert.False(t, output.isCounter(stored, "oper-status"), "non-matching key should not be a counter")
+}
+
+// TestOTLP_InitEmptyCounterPatterns verifies the default behavior is preserved:
+// with no counter-patterns, counterRegexes is non-nil but empty and every key is a
+// Gauge.
+func TestOTLP_InitEmptyCounterPatterns(t *testing.T) {
+	cfg := map[string]interface{}{
+		"endpoint": "unreachable-host:4317",
+		"protocol": "grpc",
+		"timeout":  "1s",
+	}
+
+	output := &otlpOutput{}
+	err := output.Init(context.Background(), "test-otlp", cfg,
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	)
+	require.NoError(t, err)
+	defer output.Close()
+
+	stored := output.cfg.Load()
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.counterRegexes)
+	assert.Len(t, stored.counterRegexes, 0)
+	assert.False(t, output.isCounter(stored, "out-octets"))
+}
+
+// TestOTLP_InitInvalidCounterPattern verifies that an invalid regex in
+// counter-patterns causes Init to fail cleanly, matching the Update/Validate paths.
+func TestOTLP_InitInvalidCounterPattern(t *testing.T) {
+	cfg := map[string]interface{}{
+		"endpoint":         "unreachable-host:4317",
+		"protocol":         "grpc",
+		"timeout":          "1s",
+		"counter-patterns": []string{"["},
+	}
+
+	output := &otlpOutput{}
+	err := output.Init(context.Background(), "test-otlp", cfg,
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	)
+	assert.Error(t, err, "Init should fail on an invalid counter-pattern")
+}
+
 // Helper to extract attributes map from KeyValue slice
 func extractAttributesMap(attrs []*commonpb.KeyValue) map[string]string {
 	result := make(map[string]string)


### PR DESCRIPTION
## Summary

The OTLP output now honors `counter-patterns` in subscribe mode, exporting matching metrics as counters (monotonic Sums) instead of gauges.

## Why this matters

As reported in #880, the compiled `counterRegexes` slice is populated only inside `validateConfig()`, which `Update()` and `Validate()` call but `Init()` never did. `Init()` (the standard subscribe path) called `setDefaultsFor()` and then stored the config directly, so the running config kept `counterRegexes == nil`, `isCounter()` always returned false, and every numeric metric took the Gauge branch. The option only worked in collector/dynamic mode where the API triggers `Update()`.

The fix calls `o.validateConfig(ncfg)` in `Init()` right after `setDefaultsFor()` and before storing the config, mirroring exactly what `Update()` already does (setDefaultsFor -> validateConfig -> store). This compiles `CounterPatterns` into the config that `Init()` actually stores, so `isCounter()` sees the patterns in subscribe mode. The error from `validateConfig` is returned so an invalid regex fails `Init()` cleanly, matching the Update path. No changes to the converter are needed since `isCounter()`/`convertEventToMetrics()` are already correct once the regexes are populated.

## Testing

Added three unit tests in `pkg/outputs/otlp_output/otlp_output_test.go`, all using an unreachable endpoint (no live device needed, following the existing `TestOTLP_InitSucceedsWithUnreachableEndpoint` pattern):

- valid counter-patterns compile into a non-nil `counterRegexes` of the right length and `isCounter()` returns true for a matching key, false for a non-matching one
- empty counter-patterns leave `counterRegexes` non-nil but empty (default gauge behavior preserved)
- an invalid regex makes `Init()` return an error

`go test ./pkg/outputs/otlp_output/...`, `go vet ./pkg/outputs/otlp_output/...`, and `gofmt -l` all pass.

Fixes #880
