### PR TITLE
feat(otlp_output): add OTLP/HTTP transport and harden output lifecycle

### DIFF
--- a/docs/user_guide/outputs/otlp_output.md
+++ b/docs/user_guide/outputs/otlp_output.md
@@ -249,3 +249,4 @@ When `enable-metrics` is set to `true`, the OTLP output exposes the following Pr
 | `gnmic_otlp_output_number_of_failed_events_total` | Counter | Number of events that failed to send. |
 | `gnmic_otlp_output_send_duration_seconds` | Histogram | Duration of sending batches to the OTLP endpoint. |
 | `gnmic_otlp_output_rejected_data_points_total` | Counter | Number of data points rejected by the OTLP endpoint in `PartialSuccess` responses. |
+| `gnmic_otlp_output_malformed_responses_total` | Counter | Number of successful (2xx) OTLP/HTTP export responses whose body could not be parsed as an OTLP response. |

--- a/docs/user_guide/outputs/otlp_output.md
+++ b/docs/user_guide/outputs/otlp_output.md
@@ -1,116 +1,169 @@
-`gnmic` supports exporting subscription updates as [OpenTelemetry](https://opentelemetry.io/) metrics using the [OTLP](https://opentelemetry.io/docs/specs/otlp/) protocol.
+`gnmic` can export subscription updates as [OpenTelemetry](https://opentelemetry.io/) metrics using the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/).
 
-This output can be used to push metrics to any OTLP-compatible backend such as [Grafana Alloy](https://grafana.com/docs/alloy/latest/), [Grafana Mimir](https://grafana.com/docs/mimir/latest/), [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), [Datadog](https://www.datadoghq.com/), [Dynatrace](https://www.dynatrace.com/), or any system that accepts OTLP metrics over gRPC.
+The OTLP output supports both OTLP/gRPC and OTLP/HTTP. OTLP/gRPC commonly uses port `4317`; OTLP/HTTP commonly uses port `4318` and the `/v1/metrics` path.
 
 ## Configuration
 
-An OTLP output can be defined using the below format in `gnmic` config file under `outputs` section:
+### OTLP/gRPC
 
 ```yaml
 outputs:
-  output1:
-    # required
+  otlp-grpc:
     type: otlp
-    # required, address of the OTLP collector
-    endpoint: localhost:4317
-    # string, transport protocol. Only "grpc" is supported.
-    # defaults to "grpc"
+    endpoint: collector.example.com:4317
     protocol: grpc
-    # duration, defaults to 10s.
-    # RPC timeout for each export request.
-    timeout: 10s
-    # tls config
+```
+
+### OTLP/HTTP
+
+```yaml
+outputs:
+  otlp-http:
+    type: otlp
+    endpoint: collector.example.com:4318
+    protocol: http
+```
+
+With the configuration above, `gnmic` sends OTLP metrics to:
+
+```text
+http://collector.example.com:4318/v1/metrics
+```
+
+### OTLP/HTTP with mTLS
+
+```yaml
+outputs:
+  otlp-http:
+    type: otlp
+    endpoint: collector.example.com:4318
+    protocol: http
     tls:
-      # string, path to the CA certificate file,
-      # this will be used to verify the server certificate when `skip-verify` is false
-      ca-file:
-      # string, client certificate file.
-      cert-file:
-      # string, client key file.
-      key-file:
-      # boolean, if true, the client will not verify the server
-      # certificate against the available certificate chain.
-      skip-verify: false
-    # integer, defaults to 1000.
-    # number of events to buffer before sending a batch to the collector.
-    # events are sent every `interval` or when the batch is full, whichever comes first.
-    batch-size: 1000
-    # duration, defaults to 5s.
-    # time interval between export requests.
-    interval: 5s
-    # integer, defaults to 2x batch-size.
-    # size of the internal event buffer.
-    buffer-size: 2000
-    # integer, defaults to 3.
-    # number of retries per export request on failure.
-    max-retries: 3
-    # string, to be used as the metric namespace
-    metric-prefix: ""
-    # boolean, if true the subscription name will be prepended to the metric name after the prefix.
-    append-subscription-name: false
-    # boolean, if true, string type values are exported as gauge metrics with value=1
-    # and the string stored as an attribute named "value".
-    # if false, string values are dropped.
-    strings-as-attributes: false
-    # boolean, defaults to false.
-    # if true, the leading "/" on the gNMI path is stripped before "/" -> "_" conversion,
-    # so metric names do not start with "_" (see Metric naming below).
-    strip-leading-underscore: false
-    # list of tag keys to place as OTLP Resource attributes.
-    # these tags are excluded from data point attributes.
-    # defaults to empty (all tags become data point attributes).
-    resource-tag-keys:
-      # - device
-      # - vendor
-      # - model
-      # - site
-      # - source
-    # list of regex patterns matched against the value key (metric path).
-    # if any pattern matches, the metric is exported as a monotonic cumulative Sum (counter).
-    # unmatched metrics are exported as Gauges.
-    # defaults to empty (all metrics are Gauges).
-    counter-patterns:
-      # - "counter"
-      # - "octets|packets|bytes"
-      # - "errors|discards|drops"
-    # map of string:string, additional static attributes to add to the OTLP Resource.
-    resource-attributes:
-      # key: value
-    # map of string:string, HTTP headers (or gRPC metadata) to include with every export request.
-    # Use this to set tenant/org identifiers required by multi-tenant backends such as
-    # Grafana Mimir, Loki, or Tempo.
-    headers:
-      # X-Scope-OrgID: my-tenant
-    # integer, defaults to 1.
-    # number of workers processing events.
-    num-workers: 1
-    # boolean, defaults to false.
-    # enables debug logging.
-    debug: false
-    # boolean, defaults to false.
-    # enables the collection and export (via prometheus) of output specific metrics.
-    enable-metrics: false
-    # list of processors to apply on the message before writing
-    event-processors:
+      ca-file: /etc/gnmic/certs/ca.crt
+      cert-file: /etc/gnmic/certs/client.crt
+      key-file: /etc/gnmic/certs/client.key
 ```
 
-## Metric Naming
+## Configuration Reference
 
-The metric name is built from up to three parts joined by underscores:
+| Field | Default | Description |
+|---|---:|---|
+| `type` | required | Must be `otlp`. |
+| `endpoint` | required | OTLP endpoint. Bare endpoints must be `host:port`. |
+| `protocol` | `grpc` | Transport protocol. One of `grpc` or `http`. |
+| `timeout` | `10s` | Timeout for each export attempt. |
+| `tls` | unset | TLS configuration. Supports `ca-file`, `cert-file`, `key-file`, and `skip-verify`. |
+| `batch-size` | `1000` | Number of events to buffer before sending a batch. |
+| `interval` | `5s` | Maximum time to wait before sending a non-empty batch. |
+| `buffer-size` | `2 * batch-size` | Size of the internal event channel. Changing it on a live config reload swaps the channel and may drop events still buffered in the old one. |
+| `max-retries` | `3` | Number of retry attempts after the first export attempt fails. |
+| `compression` | `gzip` for HTTP | HTTP request body compression. One of `gzip` or `none`. Ignored by OTLP/gRPC. |
+| `metric-prefix` | unset | Prefix added to generated metric names. |
+| `append-subscription-name` | `false` | Adds the subscription name to generated metric names. |
+| `strip-leading-underscore` | `false` | Removes a leading `/` from the gNMI path before `/` is converted to `_`. |
+| `strings-as-attributes` | `false` | Exports string values as gauge metrics with value `1` and a `value` data point attribute. If false, string values are dropped. |
+| `resource-tag-keys` | unset | Tags to place on the OTLP Resource instead of the data point. |
+| `counter-patterns` | unset | Regex patterns matched against value names. Matching values are exported as monotonic cumulative Sums. |
+| `resource-attributes` | unset | Static attributes added to every OTLP Resource. |
+| `headers` | unset | gRPC metadata or HTTP headers added to every export request. |
+| `num-workers` | `1` | Number of worker goroutines processing event batches. |
+| `debug` | `false` | Enables debug logging for this output. |
+| `enable-metrics` | `false` | Enables Prometheus metrics for this output. |
+| `event-processors` | unset | Event processors to apply before events are converted to OTLP metrics. |
 
-1. The value of `metric-prefix`, if configured.
+## Transport
+
+For OTLP/gRPC, bare endpoints must include a port:
+
+```yaml
+endpoint: collector.example.com:4317
+protocol: grpc
+```
+
+gRPC target URIs such as `dns:///collector.example.com:4317` can also be used.
+
+For OTLP/HTTP, the endpoint can be either a bare `host:port` value or a full URL.
+
+Bare HTTP endpoints are converted to a full metrics URL. Without `tls`, `gnmic` uses `http`; with `tls`, it uses `https`.
+
+```yaml
+endpoint: collector.example.com:4318
+protocol: http
+```
+
+This becomes:
+
+```text
+http://collector.example.com:4318/v1/metrics
+```
+
+Full HTTP URLs preserve the configured scheme and path:
+
+```yaml
+endpoint: https://collector.example.com/custom/metrics/path
+protocol: http
+```
+
+If the path is empty or `/`, it defaults to `/v1/metrics`.
+
+Only `http` and `https` URL schemes are accepted for OTLP/HTTP. User information in URLs is rejected; use `headers` for authentication data.
+
+HTTP redirects are never followed: a redirect response is treated as a permanent export failure. This prevents a redirecting endpoint from receiving the metrics payload and configured headers at a different origin.
+
+## TLS and Compression
+
+The `tls` block applies to both OTLP/gRPC and OTLP/HTTP.
+
+For OTLP/HTTP, do not configure an `http://` URL with a `tls` block. Use a bare `host:port` endpoint or an `https://` URL when TLS is required.
+
+When `protocol: http` is used, request body compression defaults to `gzip`:
+
+```yaml
+outputs:
+  otlp-http:
+    type: otlp
+    endpoint: collector.example.com:4318
+    protocol: http
+    compression: gzip
+```
+
+Set `compression: none` to disable HTTP request compression. The `compression` field is ignored by OTLP/gRPC.
+
+## Metric Names
+
+Metric names are built from:
+
+1. `metric-prefix`, if configured.
 2. The subscription name, if `append-subscription-name` is `true`.
-3. The gNMI path (value key), with `/` and `-` replaced by `_`.
+3. The gNMI value path, with `/` and `-` replaced by `_`.
 
-For example, a gNMI update from subscription `port-stats` with path:
+For example, given a subscription named `port-stats` defined under the `subscriptions:` section of the `gnmic` configuration:
 
+```yaml
+subscriptions:
+  port-stats:
+    paths:
+      - /interfaces/interface/state/counters/in-octets
+    mode: stream
 ```
+
+a gNMI update from this subscription with path:
+
+```text
 /interfaces/interface[name=1/1/1]/state/counters/in-octets
 ```
 
-with `metric-prefix: gnmic` and `append-subscription-name: true`, produces a metric named:
+with `metric-prefix: gnmic` and `append-subscription-name: true`, produces:
 
+```text
+gnmic_port_stats__interfaces_interface_state_counters_in_octets
 ```
+
+The `port_stats` segment is the subscription name `port-stats` after `-` is converted to `_` (Prometheus does not allow hyphens in metric names).
+
+The leading `/` of the gNMI path becomes a leading `_` in the path-derived segment, which combines with the trailing `_` of the prefix or subscription name to form a `__` separator. Set `strip-leading-underscore: true` to elide the leading `/` and produce a single-`_` separator:
+
+```text
 gnmic_port_stats_interfaces_interface_state_counters_in_octets
 ```
 
@@ -118,14 +171,11 @@ With `strip-leading-underscore: true`, a value key that begins with `/` has that
 
 Boolean gNMI values are exported as numeric data points with `0` or `1` (integer), classified as a Gauge or Sum according to `counter-patterns` like other numeric types.
 
-## Metric Type Detection
+## Metric Types
 
-Metrics are classified based on the `counter-patterns` configuration:
+By default, numeric values are exported as Gauges.
 
-- **Sum (monotonic counter)**: if the value key matches any regex in `counter-patterns`.
-- **Gauge**: all other numeric values.
-
-By default `counter-patterns` is empty, so all metrics are exported as Gauges. To classify counter-like metrics, configure the patterns explicitly:
+Use `counter-patterns` to export matching values as monotonic cumulative Sums:
 
 ```yaml
 counter-patterns:
@@ -133,16 +183,13 @@ counter-patterns:
   - "errors|discards|drops"
 ```
 
-Each pattern is a Go [regexp](https://pkg.go.dev/regexp/syntax) matched against the value key (the gNMI path portion of the metric, **before name transformation**).
+Patterns are Go [regexp](https://pkg.go.dev/regexp/syntax) expressions matched against the value name before metric name transformation.
 
-## Resource and Data Point Attributes
+## Resource Attributes
 
-Event tags are split between the OTLP Resource and data point attributes based on the `resource-tag-keys` configuration:
+Event tags are exported as data point attributes by default.
 
-- Tags whose keys appear in `resource-tag-keys` are placed as **Resource attributes** and excluded from data point attributes.
-- All remaining tags become **data point attributes** (equivalent to Prometheus labels).
-
-By default `resource-tag-keys` is empty, so all tags become data point attributes. To move device-level metadata to the OTLP Resource (keeping it out of Prometheus labels), configure it explicitly:
+Use `resource-tag-keys` to move selected tags to the OTLP Resource:
 
 ```yaml
 resource-tag-keys:
@@ -153,48 +200,52 @@ resource-tag-keys:
   - source
 ```
 
-Additional static attributes can be added to every Resource using `resource-attributes`:
+Static Resource attributes can be configured with `resource-attributes`:
 
 ```yaml
 resource-attributes:
-  service.name: gnmic-collector
+  service.name: gnmic
   deployment.environment: production
 ```
 
-## OTLP Resource Grouping
+Events are grouped by a stable identifier of the producing entity — the first non-empty tag in the chain `device → target → source`, or `unknown` if all are absent. Each group becomes one OTLP `ResourceMetrics` entry.
 
-Events are grouped by their `source` tag (the target device address). Each unique source becomes a separate OTLP `ResourceMetrics` entry with its own set of resource attributes.
+## Headers
 
-## Custom Headers
-
-The `headers` field attaches key/value pairs to every export request — as gRPC metadata when using the `grpc` protocol, or as HTTP headers when using `http`.
-
-This is required by multi-tenant Grafana backends (Mimir, Loki, Tempo) which use the `X-Scope-OrgID` header to route data to the correct tenant:
+The `headers` field attaches key/value pairs to every export request. Headers are sent as gRPC metadata when `protocol: grpc` is used, and as HTTP headers when `protocol: http` is used.
 
 ```yaml
 outputs:
-  mimir-output:
+  otlp-http:
     type: otlp
-    endpoint: mimir.example.com:4317
+    endpoint: collector.example.com:4318
+    protocol: http
     headers:
-      X-Scope-OrgID: my-tenant-id
+      X-Scope-OrgID: my-tenant
+      Authorization: Bearer <token>
 ```
 
-Multiple headers can be set simultaneously:
+For OTLP/HTTP, user-supplied headers cannot override the required OTLP `Content-Type` or `Content-Encoding` headers.
 
-```yaml
-headers:
-  X-Scope-OrgID: my-tenant-id
-  X-Custom-Header: some-value
-```
+Header values are treated as credentials: `gnmic` redacts them in its own log output (header names remain visible).
 
-## OTLP Output Metrics
+## Retries and Partial Success
+
+`max-retries` applies to both OTLP/gRPC and OTLP/HTTP.
+
+For OTLP/HTTP, retryable status codes are `429`, `502`, `503`, and `504`. Other HTTP status codes are treated as permanent failures. When a retryable response includes a `Retry-After` header, `gnmic` honors it up to an internal cap of 30 seconds; otherwise it uses exponential backoff with jitter.
+
+OTLP `PartialSuccess` responses with rejected data points are not retried for either OTLP/gRPC or OTLP/HTTP. When output metrics are enabled, rejected data points are counted by `gnmic_otlp_output_rejected_data_points_total`.
+
+A `PartialSuccess` response counts as a delivered export: the batch is accounted in `gnmic_otlp_output_number_of_sent_events_total` (the sent/failed counters track export requests at event granularity), while the partial loss is reported exclusively by `gnmic_otlp_output_rejected_data_points_total`. Alert on the rejected counter to detect data loss — a batch whose data points are all rejected still counts as sent.
+
+## Output Metrics
 
 When `enable-metrics` is set to `true`, the OTLP output exposes the following Prometheus metrics:
 
 | Metric Name | Type | Description |
 |---|---|---|
-| `gnmic_otlp_output_number_of_sent_events_total` | Counter | Number of events successfully sent to the OTLP collector |
-| `gnmic_otlp_output_number_of_failed_events_total` | Counter | Number of events that failed to send |
-| `gnmic_otlp_output_send_duration_seconds` | Histogram | Duration of sending batches to the OTLP collector |
-| `gnmic_otlp_output_rejected_data_points_total` | Counter | Number of data points rejected by the collector (PartialSuccess) |
+| `gnmic_otlp_output_number_of_sent_events_total` | Counter | Number of events successfully sent to the OTLP endpoint. |
+| `gnmic_otlp_output_number_of_failed_events_total` | Counter | Number of events that failed to send. |
+| `gnmic_otlp_output_send_duration_seconds` | Histogram | Duration of sending batches to the OTLP endpoint. |
+| `gnmic_otlp_output_rejected_data_points_total` | Counter | Number of data points rejected by the OTLP endpoint in `PartialSuccess` responses. |

--- a/docs/user_guide/outputs/output_intro.md
+++ b/docs/user_guide/outputs/output_intro.md
@@ -9,6 +9,7 @@ In the context of gnmi subscriptions (on top of terminal output) `gnmic` support
 * [ClickHouse](clickhouse_output.md)
 * [Prometheus Server](prometheus_output.md)
 * [Prometheus Remote Write](prometheus_write_output.md)
+* [OpenTelemetry](otlp_output.md)
 * [UDP Server](udp_output.md)
 * [TCP Server](tcp_output.md)
 
@@ -68,7 +69,7 @@ outputs:
 
 #### Output formats
 
-Different formats are supported for all outputs
+Some outputs support the generic `format` option:
 
 **Format/output** | **proto**                          | **protojson**                   |  **prototext**                      | **json**                       | **event**
 ----------------- | ---------------------------------- | --------------------------------| ------------------------------------|--------------------------------|--------------------------------:
@@ -79,6 +80,7 @@ Different formats are supported for all outputs
 **InfluxDB**      | <span>NA</span>                    | <span>NA</span>                 | <span>NA</span>                     |<span>NA</span>                 |<span>NA</span>                    
 **ClickHouse**    | <span>NA</span>                    | <span>NA</span>                 | <span>NA</span>                     |<span>NA</span>                 |<span>NA</span>                    
 **Prometheus**    | <span>NA</span>                    | <span>NA</span>                 | <span>NA</span>                     |<span>NA</span>                 |<span>NA</span>                    
+**OpenTelemetry** | <span>NA</span>                    | <span>NA</span>                 | <span>NA</span>                     |<span>NA</span>                 |<span>NA</span>
 
 #### Formats examples
 

--- a/pkg/outputs/otlp_output/otlp_converter.go
+++ b/pkg/outputs/otlp_output/otlp_converter.go
@@ -33,9 +33,7 @@ var stringsBuilderPool = sync.Pool{
 }
 
 // convertToOTLP converts gNMI EventMsg slice to OTLP ExportMetricsServiceRequest
-func (o *otlpOutput) convertToOTLP(events []*formatters.EventMsg) *metricsv1.ExportMetricsServiceRequest {
-	cfg := o.cfg.Load()
-
+func (o *otlpOutput) convertToOTLP(cfg *config, events []*formatters.EventMsg) *metricsv1.ExportMetricsServiceRequest {
 	o.logger.Debug("convertToOTLP called", "events", len(events))
 
 	// Group events by resource (source)
@@ -481,11 +479,14 @@ func (o *otlpOutput) validateMetricData(rmIdx, smIdx, mIdx int, m *metricspb.Met
 }
 
 // sendGRPC sends the OTLP metrics via gRPC
-func (o *otlpOutput) sendGRPC(ctx context.Context, req *metricsv1.ExportMetricsServiceRequest) error {
-	cfg := o.cfg.Load()
-	gs := o.grpcState.Load()
+func (o *otlpOutput) sendGRPC(ctx context.Context, state *outputState, req *metricsv1.ExportMetricsServiceRequest) error {
+	cfg := state.cfg
+	gs := state.transport.grpcState
 
 	if gs == nil || gs.client == nil {
+		// Belt-and-suspenders: when Protocol == "grpc", buildOutputState
+		// guarantees grpcState is populated. See sendHTTP for the same
+		// rationale.
 		return fmt.Errorf("gRPC client not initialized")
 	}
 
@@ -521,14 +522,16 @@ func (o *otlpOutput) sendGRPC(ctx context.Context, req *metricsv1.ExportMetricsS
 	o.logger.Debug("gRPC Export succeeded")
 
 	if response.PartialSuccess != nil && response.PartialSuccess.RejectedDataPoints > 0 {
-		errMsg := fmt.Sprintf("OTEL rejected %d data points: %s",
-			response.PartialSuccess.RejectedDataPoints,
-			response.PartialSuccess.ErrorMessage)
-		o.logger.Error(errMsg)
+		o.logger.Error("OTEL rejected data points",
+			"rejected", response.PartialSuccess.RejectedDataPoints,
+			"message", response.PartialSuccess.ErrorMessage)
 		if cfg.EnableMetrics {
 			otlpRejectedDataPoints.WithLabelValues(cfg.Name).Add(float64(response.PartialSuccess.RejectedDataPoints))
 		}
-		return fmt.Errorf("%s", errMsg)
+		return &partialSuccessError{
+			rejected:     response.PartialSuccess.RejectedDataPoints,
+			errorMessage: response.PartialSuccess.ErrorMessage,
+		}
 	}
 
 	return nil

--- a/pkg/outputs/otlp_output/otlp_http.go
+++ b/pkg/outputs/otlp_output/otlp_http.go
@@ -267,6 +267,11 @@ func (o *otlpOutput) sendHTTP(ctx context.Context, state *outputState, req *metr
 	}
 	cfg := state.cfg
 
+	if err := o.validateRequest(req); err != nil {
+		o.logger.Error("validation error", "err", err)
+		return fmt.Errorf("request validation failed: %w", err)
+	}
+
 	raw, err := proto.Marshal(req)
 	if err != nil {
 		// proto.Marshal can fail for requests containing invalid UTF-8 in string
@@ -339,8 +344,13 @@ func (o *otlpOutput) sendHTTP(ctx context.Context, state *outputState, req *metr
 		}
 		var respProto metricsv1.ExportMetricsServiceResponse
 		if err := proto.Unmarshal(respBody, &respProto); err != nil {
-			// Malformed response body but transport-level success — log and accept.
-			o.logger.Debug("failed to unmarshal OTLP response body", "err", err)
+			// Malformed response body but transport-level success — accept (retrying
+			// would duplicate data) but surface it: a collector answering 2xx with a
+			// non-OTLP body is misconfigured or broken.
+			o.logger.Warn("failed to unmarshal OTLP response body", "err", err)
+			if cfg.EnableMetrics {
+				otlpMalformedResponses.WithLabelValues(cfg.Name).Inc()
+			}
 			return nil
 		}
 		if respProto.PartialSuccess != nil && respProto.PartialSuccess.RejectedDataPoints > 0 {

--- a/pkg/outputs/otlp_output/otlp_http.go
+++ b/pkg/outputs/otlp_output/otlp_http.go
@@ -1,0 +1,418 @@
+// © 2026 NVIDIA Corporation
+//
+// This code is a Contribution to the gNMIc project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of NVIDIA's intellectual property are granted for any other purpose.
+// This code is provided on an "as is" basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package otlp_output
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	rand "math/rand/v2"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	metricsv1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+const otlpHTTPMetricsPath = "/v1/metrics"
+
+// httpExportError carries the HTTP status code alongside the underlying error,
+// so the caller can distinguish retryable (429/5xx) from permanent (4xx) failures.
+type httpExportError struct {
+	status     int
+	retryAfter time.Duration // populated from Retry-After header if present; 0 otherwise
+	msg        string
+}
+
+func (e *httpExportError) Error() string {
+	return fmt.Sprintf("HTTP export returned status %d: %s", e.status, e.msg)
+}
+
+// isPermanentHTTPError returns true when the error should NOT be retried.
+// Per OTLP spec (https://opentelemetry.io/docs/specs/otlp/), retryable status
+// codes are 429 Too Many Requests, 502 Bad Gateway, 503 Service Unavailable,
+// and 504 Gateway Timeout. All other 4xx and 5xx are permanent.
+// Transport-level errors (no *httpExportError) are retryable — typically
+// transient network blips.
+func isPermanentHTTPError(err error) bool {
+	var hee *httpExportError
+	if !errors.As(err, &hee) {
+		return false
+	}
+	switch hee.status {
+	case http.StatusTooManyRequests, // 429
+		http.StatusBadGateway,         // 502
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout:     // 504
+		return false
+	default:
+		return true
+	}
+}
+
+// partialSuccessError marks a 2xx response that included a non-empty
+// PartialSuccess.RejectedDataPoints. Per OTLP spec, clients MUST NOT retry
+// these — the server already accepted some points; retrying duplicates them.
+// This applies to both HTTP and gRPC transports.
+type partialSuccessError struct {
+	rejected     int64
+	errorMessage string
+}
+
+func (e *partialSuccessError) Error() string {
+	return fmt.Sprintf("OTEL rejected %d data points: %s", e.rejected, e.errorMessage)
+}
+
+// isPartialSuccessError returns true when the error is a partial-success
+// rejection. The retry loop short-circuits on this just as it does on
+// permanent HTTP errors.
+func isPartialSuccessError(err error) bool {
+	var pse *partialSuccessError
+	return errors.As(err, &pse)
+}
+
+// parseRetryAfter interprets the Retry-After header per RFC 7231 §7.1.3.
+// It accepts either a delta-seconds integer or an HTTP-date.
+// Returns 0 when the header is absent, empty, or unparseable.
+func parseRetryAfter(h string, now time.Time) time.Duration {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return 0
+	}
+	// Delta-seconds form.
+	if secs, err := strconv.Atoi(h); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	// HTTP-date form.
+	if t, err := http.ParseTime(h); err == nil {
+		d := t.Sub(now)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}
+
+// resolveMetricsURL normalizes a user-supplied endpoint into the absolute URL
+// that sendHTTP will POST to. It accepts either a bare "host:port"
+// (in which case scheme is chosen from tlsEnabled and path defaults to /v1/metrics)
+// or a full URL (scheme is preserved; if no path is set, /v1/metrics is appended).
+//
+// Both forms are revalidated by url.Parse before return: a bare endpoint that
+// would synthesize an unparseable URL (e.g. embedded whitespace or control
+// characters) is rejected here so the failure surfaces at Init time, not at
+// the first send. This also makes http.NewRequestWithContext in sendHTTP
+// unreachable for malformed inputs (see Appendix D).
+func resolveMetricsURL(endpoint string, tlsEnabled bool) (string, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", fmt.Errorf("endpoint is required")
+	}
+
+	// If no scheme, synthesize one. The bare form is strictly host:port — a
+	// path component here is a configuration mistake (e.g. "localhost:4318/foo")
+	// that we reject rather than silently mangle into "/foo/v1/metrics".
+	// A missing port is also rejected: gnmic requires the port to be explicit
+	// for bare endpoints rather than guessing 4318 (the OTLP/HTTP convention)
+	// or falling through to URL scheme defaults (80/443). Operators who omit
+	// the port by mistake would otherwise dial the wrong service silently.
+	if !strings.Contains(endpoint, "://") {
+		if strings.ContainsRune(endpoint, '/') {
+			return "", fmt.Errorf("bare endpoint %q must be host:port only; use a full URL if a path is needed", endpoint)
+		}
+		host, port, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			return "", fmt.Errorf("bare endpoint %q must be host:port: %w", endpoint, err)
+		}
+		if host == "" || port == "" {
+			return "", fmt.Errorf("bare endpoint %q must be host:port (e.g. host:4318)", endpoint)
+		}
+		scheme := "http"
+		if tlsEnabled {
+			scheme = "https"
+		}
+		endpoint = scheme + "://" + endpoint + otlpHTTPMetricsPath
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid endpoint URL %q: %w", endpoint, err)
+	}
+	// Per the OTLP exporter spec, only http and https are valid schemes.
+	// Reject anything else here so misconfigurations fail at Init rather than
+	// surfacing as a confusing client.Do error at first send.
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		// ok
+	default:
+		return "", fmt.Errorf("unsupported endpoint scheme %q: must be http or https", u.Scheme)
+	}
+	// Reject userinfo in URL — auth must go through the Headers config field
+	// (e.g. "Authorization: Bearer ..."). Userinfo in URLs leaks into logs and
+	// error messages and is not how OTLP backends authenticate clients.
+	if u.User != nil {
+		return "", fmt.Errorf("endpoint must not include userinfo; use the headers config field for authentication")
+	}
+	// url.Parse is lenient — a Host that contains whitespace or control chars
+	// will parse but cannot be used in a real request. Reject explicitly.
+	// Use Hostname() (not Host) so a port-only string like ":4318" — which
+	// has Host==":4318" but no actual hostname — is rejected. This is the
+	// difference between "fails at Init" and "fails on first dial".
+	if u.Hostname() == "" || strings.ContainsAny(u.Host, " \t\r\n") {
+		return "", fmt.Errorf("invalid endpoint host %q", u.Host)
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = otlpHTTPMetricsPath
+	}
+	return u.String(), nil
+}
+
+// httpClientState is the transport-specific state for protocol: http.
+// Stored in an atomic.Pointer on otlpOutput so it can be swapped atomically
+// during live config reload. Headers are built per-request in sendHTTP from
+// state.cfg.Headers — that way a reload that changes only the headers map
+// (e.g. tenant rotation) takes effect on the next batch without a transport
+// rebuild.
+type httpClientState struct {
+	client   *http.Client
+	endpoint string
+}
+
+func (o *otlpOutput) initHTTPFor(cfg *config) (*httpClientState, error) {
+	// Strict-coherence guard (ratified Decision 1): an explicit http:// scheme
+	// combined with a configured tls block is almost always a misconfiguration
+	// that silently disables mTLS. Reject early with a clear message rather than
+	// letting the operator discover this only via packet capture in production.
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	if cfg.TLS != nil && strings.HasPrefix(strings.ToLower(endpoint), "http://") {
+		return nil, fmt.Errorf("endpoint scheme is http:// but tls block is configured; use https:// (or a bare host:port) or remove the tls block")
+	}
+
+	var tlsConfig *tls.Config
+	if cfg.TLS != nil {
+		var err error
+		tlsConfig, err = o.createTLSConfigFor(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create TLS config: %w", err)
+		}
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		// TLSHandshakeTimeout matches http.DefaultTransport's value; without this
+		// a hung TLS server could stall the dialer indefinitely even though we
+		// rely on per-request context deadlines.
+		TLSHandshakeTimeout:   10 * time.Second,
+		MaxIdleConns:          10,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		// No client-side Timeout: per-request context timeout is the authoritative deadline,
+		// matching the gRPC path (which uses context.WithTimeout in sendGRPC).
+		//
+		// Never follow redirects. Go strips Authorization on cross-host
+		// redirects but forwards user-defined headers (e.g. X-Scope-OrgID or
+		// custom credential headers), and a 307/308 replays the POST body —
+		// a redirecting (or compromised) collector must not be able to pull
+		// the payload and headers to another origin. ErrUseLastResponse
+		// surfaces the 3xx as a regular response, which the status
+		// classification in sendHTTP treats as a permanent error.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Pass the already-trimmed `endpoint` through (not cfg.Endpoint) so the
+	// coherence check above and URL resolution operate on the same string.
+	resolvedURL, err := resolveMetricsURL(endpoint, cfg.TLS != nil)
+	if err != nil {
+		return nil, err
+	}
+
+	o.logger.Info("initialized OTLP HTTP client", "endpoint", resolvedURL)
+	return &httpClientState{client: client, endpoint: resolvedURL}, nil
+}
+
+func (o *otlpOutput) sendHTTP(ctx context.Context, state *outputState, req *metricsv1.ExportMetricsServiceRequest) error {
+	hs := state.transport.httpState
+	if hs == nil {
+		// Belt-and-suspenders: when Protocol == "http", buildOutputState
+		// guarantees httpState is populated. This guard catches partial
+		// init (test scaffolding) and any future code path that publishes
+		// a state with mismatched protocol/transport.
+		return fmt.Errorf("HTTP client not initialized")
+	}
+	cfg := state.cfg
+
+	raw, err := proto.Marshal(req)
+	if err != nil {
+		// proto.Marshal can fail for requests containing invalid UTF-8 in string
+		// fields (proto3 mandates valid UTF-8). Tested in TestSendHTTP_MarshalRejectsInvalidUTF8.
+		return fmt.Errorf("marshal OTLP request: %w", err)
+	}
+
+	body := raw
+	useGzip := cfg.Compression == "gzip"
+	if useGzip {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		if _, err := gw.Write(raw); err != nil {
+			// unreachable: gzip.Writer over a *bytes.Buffer cannot return an error.
+			return fmt.Errorf("gzip encode: %w", err)
+		}
+		if err := gw.Close(); err != nil {
+			// unreachable: same as above — flushing to bytes.Buffer cannot fail.
+			return fmt.Errorf("gzip close: %w", err)
+		}
+		body = buf.Bytes()
+	}
+
+	if cfg.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.Timeout)
+		defer cancel()
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, hs.endpoint, bytes.NewReader(body))
+	if err != nil {
+		// unreachable: hs.endpoint was validated by resolveMetricsURL at Init time;
+		// method is a constant; body is a *bytes.Reader. See Appendix D.
+		return fmt.Errorf("build HTTP request: %w", err)
+	}
+	// Build headers per-request from state.cfg so header-only reloads take effect
+	// on the next batch. User-supplied headers are set FIRST, then Content-Type
+	// and Content-Encoding are set last so the user can't accidentally override
+	// them via the headers map (preserving the OTLP wire format contract).
+	for k, v := range cfg.Headers {
+		httpReq.Header.Set(k, v)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	if useGzip {
+		httpReq.Header.Set("Content-Encoding", "gzip")
+	} else {
+		// Content-Encoding is protocol-owned in both directions: a
+		// user-supplied value would mislabel the uncompressed body.
+		// Header.Set canonicalizes names, so this also catches
+		// "content-encoding" etc.
+		httpReq.Header.Del("Content-Encoding")
+	}
+
+	resp, err := hs.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("HTTP export failed: %w", err)
+	}
+	// Defers run LIFO: drain runs before close so the connection is reusable.
+	// Drain happens AFTER any deliberate read of the body below — order matters.
+	defer resp.Body.Close()
+	defer io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode/100 == 2 {
+		// Read up to 64 KiB of the response body to check for PartialSuccess.
+		// OTLP responses are normally small; the cap prevents a misbehaving server
+		// from forcing us to allocate unbounded memory on each export.
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		if len(respBody) == 0 {
+			return nil
+		}
+		var respProto metricsv1.ExportMetricsServiceResponse
+		if err := proto.Unmarshal(respBody, &respProto); err != nil {
+			// Malformed response body but transport-level success — log and accept.
+			o.logger.Debug("failed to unmarshal OTLP response body", "err", err)
+			return nil
+		}
+		if respProto.PartialSuccess != nil && respProto.PartialSuccess.RejectedDataPoints > 0 {
+			o.logger.Error("OTEL rejected data points",
+				"rejected", respProto.PartialSuccess.RejectedDataPoints,
+				"message", respProto.PartialSuccess.ErrorMessage)
+			if cfg.EnableMetrics {
+				otlpRejectedDataPoints.WithLabelValues(cfg.Name).Add(float64(respProto.PartialSuccess.RejectedDataPoints))
+			}
+			return &partialSuccessError{
+				rejected:     respProto.PartialSuccess.RejectedDataPoints,
+				errorMessage: respProto.PartialSuccess.ErrorMessage,
+			}
+		}
+		return nil
+	}
+
+	// Best-effort read of a small response body to include in the error message.
+	bodySnippet := make([]byte, 256)
+	n, _ := io.ReadFull(resp.Body, bodySnippet)
+	return &httpExportError{
+		status:     resp.StatusCode,
+		retryAfter: parseRetryAfter(resp.Header.Get("Retry-After"), time.Now()),
+		msg:        string(bodySnippet[:n]),
+	}
+}
+
+// retryAfterFromError returns the Retry-After duration from a wrapped
+// httpExportError, or 0 if no hint is available.
+func retryAfterFromError(err error) time.Duration {
+	var hee *httpExportError
+	if errors.As(err, &hee) {
+		return hee.retryAfter
+	}
+	return 0
+}
+
+// effectiveRetrySleep computes how long the retry loop should sleep before the
+// next attempt, given the protocol, attempt index, server-supplied Retry-After
+// hint, and our configured maxSleep cap. Extracted so the cap branch is
+// unit-testable without long sleeps in tests.
+//
+// gRPC: linear backoff (attempt+1) * 100ms. Retry-After is ignored. (Decision 2 —
+// HTTP-only spec compliance; a gRPC retry overhaul is separate work.)
+//
+// HTTP, server-supplied Retry-After present (>0): use it, capped at maxSleep.
+// HTTP, no Retry-After: exponential backoff with full jitter per OTLP spec
+// (https://opentelemetry.io/docs/specs/otlp/) — base = min(maxSleep, 2^attempt * 100ms),
+// sleep = random in [0, base) per AWS's 2015 "Exponential Backoff And Jitter".
+//
+// Param `maxSleep` is named so to avoid shadowing the `cap` builtin.
+func effectiveRetrySleep(protocol string, attempt int, retryAfter, maxSleep time.Duration) time.Duration {
+	// Server-supplied Retry-After always wins (HTTP only).
+	if protocol == "http" && retryAfter > 0 {
+		if retryAfter > maxSleep {
+			return maxSleep
+		}
+		return retryAfter
+	}
+	// gRPC: linear backoff.
+	if protocol != "http" {
+		return time.Duration(attempt+1) * 100 * time.Millisecond
+	}
+	// HTTP: exponential backoff with full jitter, per OTLP spec.
+	// Cap the exponent to avoid 1<<attempt overflow on pathological MaxRetries.
+	exp := attempt
+	if exp > 30 {
+		exp = 30
+	}
+	base := time.Duration(1<<exp) * 100 * time.Millisecond
+	if base <= 0 || base > maxSleep {
+		base = maxSleep
+	}
+	return time.Duration(rand.Int64N(int64(base))) // [0, base) — canonical AWS full-jitter
+}

--- a/pkg/outputs/otlp_output/otlp_http_test.go
+++ b/pkg/outputs/otlp_output/otlp_http_test.go
@@ -43,7 +43,9 @@ import (
 	"github.com/zestor-dev/zestor/store"
 	"github.com/zestor-dev/zestor/store/gomap"
 	metricsv1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -303,7 +305,7 @@ func TestInitHTTPFor_WithMTLS(t *testing.T) {
 
 	// Headers are built per-request now, so verify they arrive at the server.
 	o.state.Store(&outputState{cfg: cfg, transport: &transportState{httpState: hs}})
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Equal(t, "application/x-protobuf", gotContentType)
 	require.Equal(t, "tenant-1", gotOrgID)
 }
@@ -385,14 +387,14 @@ func TestSendHTTP_HeaderReloadTakesEffect(t *testing.T) {
 	withCfg(o, func(c *config) {
 		c.Headers = map[string]string{"X-Scope-OrgID": "tenant-old"}
 	})
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Equal(t, "tenant-old", gotOrgID)
 
 	// Simulate a header-only reload — same transport, new headers.
 	withCfg(o, func(c *config) {
 		c.Headers = map[string]string{"X-Scope-OrgID": "tenant-new"}
 	})
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Equal(t, "tenant-new", gotOrgID, "header-only reload must take effect on the next batch")
 }
 
@@ -410,7 +412,7 @@ func TestSendHTTP_UserHeadersCannotOverrideProtocolHeaders(t *testing.T) {
 	withCfg(o, func(c *config) {
 		c.Headers = map[string]string{"Content-Type": "application/json"} // bogus override attempt
 	})
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Equal(t, "application/x-protobuf", gotContentType, "user Headers must not override Content-Type")
 }
 
@@ -449,7 +451,7 @@ func TestSendHTTP_SuccessfulExport(t *testing.T) {
 	o.state.Store(&outputState{cfg: cfg, transport: &transportState{httpState: hs}})
 
 	// Minimal valid ExportMetricsServiceRequest.
-	req := &metricsv1.ExportMetricsServiceRequest{}
+	req := validExportRequest()
 	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), req))
 
 	require.Equal(t, "application/x-protobuf", gotContentType)
@@ -530,7 +532,7 @@ func TestSendHTTP_NoTimeoutConfigured(t *testing.T) {
 	o := newHTTPTestOutput(t, srv)
 	withCfg(o, func(c *config) { c.Timeout = 0 })
 
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 }
 
 // Decision-path: client.Do failure (transport error). Stop the server first so
@@ -541,7 +543,7 @@ func TestSendHTTP_DialFailure(t *testing.T) {
 	o := newHTTPTestOutput(t, srv)
 	srv.Close() // close before the call so dial fails
 
-	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	err := o.sendHTTP(context.Background(), o.state.Load(), validExportRequest())
 	require.Error(t, err)
 }
 
@@ -556,19 +558,10 @@ func TestSendHTTP_MarshalRejectsInvalidUTF8(t *testing.T) {
 
 	o := newHTTPTestOutput(t, srv)
 	invalid := string([]byte{0xff, 0xfe, 0xfd}) // not valid UTF-8
-	req := &metricsv1.ExportMetricsServiceRequest{
-		ResourceMetrics: []*metricspb.ResourceMetrics{
-			{
-				ScopeMetrics: []*metricspb.ScopeMetrics{
-					{
-						Metrics: []*metricspb.Metric{
-							{Name: invalid},
-						},
-					},
-				},
-			},
-		},
-	}
+	// Structurally valid (validateRequest doesn't check UTF-8) so the
+	// failure is isolated to the marshal step.
+	req := validExportRequest()
+	req.ResourceMetrics[0].ScopeMetrics[0].Metrics[0].Name = invalid
 	err := o.sendHTTP(context.Background(), o.state.Load(), req)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "marshal OTLP request")
@@ -623,7 +616,7 @@ func TestSendHTTP_PermanentErrorNotRetried(t *testing.T) {
 	defer srv.Close()
 
 	o := newHTTPTestOutput(t, srv)
-	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	err := o.sendHTTP(context.Background(), o.state.Load(), validExportRequest())
 	require.Error(t, err)
 	require.True(t, isPermanentHTTPError(err))
 	require.Equal(t, 1, calls, "sendHTTP itself should not retry")
@@ -636,7 +629,7 @@ func TestSendHTTP_RetryableError(t *testing.T) {
 	defer srv.Close()
 
 	o := newHTTPTestOutput(t, srv)
-	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	err := o.sendHTTP(context.Background(), o.state.Load(), validExportRequest())
 	require.Error(t, err)
 	require.False(t, isPermanentHTTPError(err))
 }
@@ -690,7 +683,7 @@ func TestSendHTTP_PartialSuccessReturnsError(t *testing.T) {
 	defer srv.Close()
 
 	o := newHTTPTestOutput(t, srv)
-	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	err := o.sendHTTP(context.Background(), o.state.Load(), validExportRequest())
 	require.Error(t, err, "PartialSuccess with rejected points must surface as an error (parity with gRPC)")
 	require.Contains(t, err.Error(), "rejected 7")
 }
@@ -714,7 +707,7 @@ func TestSendHTTP_PartialSuccessZeroRejected(t *testing.T) {
 	defer srv.Close()
 
 	o := newHTTPTestOutput(t, srv)
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 }
 
 // Decision-path: empty 200 body must succeed (the early-return short-circuit).
@@ -725,12 +718,12 @@ func TestSendHTTP_EmptyResponseBody(t *testing.T) {
 	defer srv.Close()
 
 	o := newHTTPTestOutput(t, srv)
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 }
 
-// Decision-path (debug off): malformed (non-protobuf) 200 body must NOT cause
-// an error; the transport-level success is authoritative. The Debug branch
-// is silent in this variant.
+// Decision-path: malformed (non-protobuf) 200 body must NOT cause an error;
+// the transport-level success is authoritative. EnableMetrics is off in this
+// variant, so the malformed-responses counter branch is skipped.
 func TestSendHTTP_MalformedResponseBody_DebugOff(t *testing.T) {
 	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -740,12 +733,12 @@ func TestSendHTTP_MalformedResponseBody_DebugOff(t *testing.T) {
 
 	o := newHTTPTestOutput(t, srv)
 	require.False(t, o.state.Load().cfg.Debug, "precondition: debug must be off for this variant")
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 }
 
-// Decision-path (debug on): same scenario but Debug enabled — exercises the
-// `if cfg.Debug { o.logger.Printf(...) }` branch. Captures log output via a
-// buffer to verify the warning was emitted.
+// Same scenario with log capture: the unmarshal failure must be logged.
+// Level and metric assertions live in
+// TestSendHTTP_MalformedResponseWarnsAndIncrementsMetric.
 func TestSendHTTP_MalformedResponseBody_DebugOn(t *testing.T) {
 	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -758,7 +751,72 @@ func TestSendHTTP_MalformedResponseBody_DebugOn(t *testing.T) {
 	o.logger = slog.New(slog.NewTextHandler(&logbuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	withCfg(o, func(c *config) { c.Debug = true })
 
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
+	require.Contains(t, logbuf.String(), "failed to unmarshal OTLP response body")
+}
+
+// validExportRequest returns the smallest request that passes validateRequest,
+// for tests exercising transport behavior rather than payload content.
+func validExportRequest() *metricsv1.ExportMetricsServiceRequest {
+	return &metricsv1.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricspb.ResourceMetrics{{
+			Resource: &resourcepb.Resource{},
+			ScopeMetrics: []*metricspb.ScopeMetrics{{
+				Scope: &commonpb.InstrumentationScope{},
+				Metrics: []*metricspb.Metric{{
+					Name: "test_metric",
+					Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{
+						DataPoints: []*metricspb.NumberDataPoint{{
+							TimeUnixNano: 1,
+							Value:        &metricspb.NumberDataPoint_AsDouble{AsDouble: 1},
+						}},
+					}},
+				}},
+			}},
+		}},
+	}
+}
+
+// Parity with sendGRPC: structurally invalid requests must be rejected by
+// validateRequest before anything goes on the wire.
+func TestSendHTTP_InvalidRequestRejectedBeforeSend(t *testing.T) {
+	var serverHit atomic.Bool
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		serverHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "request validation failed")
+	require.False(t, serverHit.Load(), "invalid request must not reach the collector")
+}
+
+// A 2xx response whose body doesn't unmarshal as an OTLP response is still
+// accepted (transport-level success is authoritative, retrying would duplicate
+// data), but must be visible to operators: Warn log + malformed-responses counter.
+func TestSendHTTP_MalformedResponseWarnsAndIncrementsMetric(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not a protobuf"))
+	})
+	defer srv.Close()
+
+	var logbuf bytes.Buffer
+	o := newHTTPTestOutput(t, srv)
+	o.logger = slog.New(slog.NewTextHandler(&logbuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	withCfg(o, func(c *config) {
+		c.EnableMetrics = true
+		c.Name = "test-malformed-output"
+	})
+
+	before := testutil.ToFloat64(otlpMalformedResponses.WithLabelValues("test-malformed-output"))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
+	after := testutil.ToFloat64(otlpMalformedResponses.WithLabelValues("test-malformed-output"))
+	require.Equal(t, float64(1), after-before, "malformed response must increment the counter")
+	require.Contains(t, logbuf.String(), "level=WARN", "unmarshal failure must be logged at Warn")
 	require.Contains(t, logbuf.String(), "failed to unmarshal OTLP response body")
 }
 
@@ -787,7 +845,7 @@ func TestSendHTTP_PartialSuccessIncrementsMetric(t *testing.T) {
 
 	cfgName := o.state.Load().cfg.Name
 	before := testutil.ToFloat64(otlpRejectedDataPoints.WithLabelValues(cfgName))
-	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	err := o.sendHTTP(context.Background(), o.state.Load(), validExportRequest())
 	require.Error(t, err)
 	after := testutil.ToFloat64(otlpRejectedDataPoints.WithLabelValues(cfgName))
 	require.Equal(t, float64(3), after-before, "metric must advance by RejectedDataPoints")
@@ -1238,7 +1296,7 @@ func TestSendHTTP_GzipCompression(t *testing.T) {
 	require.NoError(t, err)
 	o.state.Store(&outputState{cfg: cfg, transport: &transportState{httpState: hs}})
 
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Equal(t, "gzip", gotEncoding)
 
 	var roundtrip metricsv1.ExportMetricsServiceRequest
@@ -1275,7 +1333,7 @@ func TestSendHTTP_GzipIsDefaultForHTTP(t *testing.T) {
 	defer o.Close()
 
 	require.Equal(t, "gzip", o.state.Load().cfg.Compression, "default must populate Compression for http")
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Equal(t, "gzip", gotEncoding)
 }
 
@@ -1306,7 +1364,7 @@ func TestSendHTTP_CompressionNoneOptOut(t *testing.T) {
 	))
 	defer o.Close()
 
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Equal(t, "", gotEncoding, "compression: none must produce no Content-Encoding header")
 }
 
@@ -1407,7 +1465,7 @@ func TestUpdate_TransportNotClosedWhileBatchInFlight(t *testing.T) {
 	sendDone := make(chan error, 1)
 	go func() {
 		defer state.transport.inFlight.Done()
-		sendDone <- o.sendHTTP(context.Background(), state, &metricsv1.ExportMetricsServiceRequest{})
+		sendDone <- o.sendHTTP(context.Background(), state, validExportRequest())
 	}()
 
 	// Wait until the server has received the request (so the goroutine is
@@ -1568,7 +1626,7 @@ func TestSendHTTP_RedirectNotFollowed(t *testing.T) {
 	defer srv.Close()
 
 	o := newHTTPTestOutput(t, srv)
-	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	err := o.sendHTTP(context.Background(), o.state.Load(), validExportRequest())
 	require.Error(t, err)
 
 	var hee *httpExportError
@@ -1600,7 +1658,7 @@ func TestSendHTTP_UserContentEncodingStrippedWhenNoCompression(t *testing.T) {
 		c.Headers = map[string]string{"content-encoding": "gzip"}
 	})
 
-	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), validExportRequest()))
 	require.Empty(t, gotEncoding, "user Content-Encoding must be stripped when compression is none")
 	var roundtrip metricsv1.ExportMetricsServiceRequest
 	require.NoError(t, proto.Unmarshal(gotBody, &roundtrip), "body must be raw (uncompressed) protobuf")

--- a/pkg/outputs/otlp_output/otlp_http_test.go
+++ b/pkg/outputs/otlp_output/otlp_http_test.go
@@ -1,0 +1,1665 @@
+// © 2026 NVIDIA Corporation
+//
+// This code is a Contribution to the gNMIc project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of NVIDIA's intellectual property are granted for any other purpose.
+// This code is provided on an "as is" basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package otlp_output
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openconfig/gnmic/pkg/api/types"
+	"github.com/openconfig/gnmic/pkg/formatters"
+	"github.com/openconfig/gnmic/pkg/logging"
+	"github.com/openconfig/gnmic/pkg/outputs"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/zestor-dev/zestor/store"
+	"github.com/zestor-dev/zestor/store/gomap"
+	metricsv1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestMTLSHarness_ClientCanReachServer(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	client := srv.NewClient()
+	resp, err := client.Get(srv.URL + "/ping")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestMTLSHarness_ClientWithoutCertIsRejected(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	// Client with TLS but NO client cert → handshake should fail.
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: srv.CAPool()},
+	}}
+	_, err := client.Get(srv.URL + "/ping")
+	require.Error(t, err, "server must reject client with no cert")
+}
+
+// mTLSTestServer is an httptest server that requires a client cert
+// issued by its embedded CA. Cert/key files are materialized to tmpdir
+// so they can be passed through TLSConfig.CaFile / CertFile / KeyFile.
+type mTLSTestServer struct {
+	*httptest.Server
+	caPool      *x509.CertPool
+	caPEMPath   string
+	cliCertPEM  []byte
+	cliKeyPEM   []byte
+	cliCertPath string
+	cliKeyPath  string
+}
+
+func newMTLSTestServer(t *testing.T, handler http.HandlerFunc) *mTLSTestServer {
+	t.Helper()
+
+	caCert, caKey := mustGenCA(t)
+	serverCert, serverKey := mustGenLeaf(t, caCert, caKey, "localhost", true)
+	clientCert, clientKey := mustGenLeaf(t, caCert, caKey, "gnmic-test-client", false)
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	srvTLSCert, err := tls.X509KeyPair(pemCert(serverCert), pemKey(serverKey))
+	require.NoError(t, err)
+
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{srvTLSCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+	// Suppress expected TLS-handshake-rejection noise on stderr during tests
+	// like TestMTLSHarness_ClientWithoutCertIsRejected. Future tests reusing
+	// this harness benefit automatically.
+	srv.Config.ErrorLog = log.New(io.Discard, "", 0)
+	srv.StartTLS()
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	cliCertPath := filepath.Join(dir, "client.crt")
+	cliKeyPath := filepath.Join(dir, "client.key")
+	require.NoError(t, os.WriteFile(caPath, pemCert(caCert), 0o600))
+	require.NoError(t, os.WriteFile(cliCertPath, pemCert(clientCert), 0o600))
+	require.NoError(t, os.WriteFile(cliKeyPath, pemKey(clientKey), 0o600))
+
+	return &mTLSTestServer{
+		Server:      srv,
+		caPool:      caPool,
+		caPEMPath:   caPath,
+		cliCertPEM:  pemCert(clientCert),
+		cliKeyPEM:   pemKey(clientKey),
+		cliCertPath: cliCertPath,
+		cliKeyPath:  cliKeyPath,
+	}
+}
+
+func (s *mTLSTestServer) CAPool() *x509.CertPool { return s.caPool }
+func (s *mTLSTestServer) CAPath() string         { return s.caPEMPath }
+func (s *mTLSTestServer) ClientCertPath() string { return s.cliCertPath }
+func (s *mTLSTestServer) ClientKeyPath() string  { return s.cliKeyPath }
+
+// NewClient returns a plain http.Client with the server CA trusted and
+// the client cert loaded — useful for harness self-tests.
+func (s *mTLSTestServer) NewClient() *http.Client {
+	cliCert, _ := tls.X509KeyPair(s.cliCertPEM, s.cliKeyPEM)
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:      s.caPool,
+			Certificates: []tls.Certificate{cliCert},
+			MinVersion:   tls.VersionTLS12,
+		},
+	}}
+}
+
+func mustGenCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "gnmic-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func mustGenLeaf(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, isServer bool) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		// ECDSA keys: KeyUsageDigitalSignature only. KeyUsageKeyEncipherment
+		// is RSA-specific (RFC 5246) and meaningless for EC keys; the Go stdlib
+		// generate_cert.go documents this explicitly.
+		KeyUsage: x509.KeyUsageDigitalSignature,
+	}
+	if isServer {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		// httptest.Server.URL is https://127.0.0.1:<port> (or [::1] for v6),
+		// so the server cert must have IP SANs as well as the DNS SAN.
+		tmpl.DNSNames = []string{"localhost"}
+		tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+	} else {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func pemCert(c *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})
+}
+
+func pemKey(k *ecdsa.PrivateKey) []byte {
+	der, _ := x509.MarshalECPrivateKey(k)
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+func TestResolveMetricsURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		tls      bool
+		want     string
+		wantErr  bool
+	}{
+		{"bare_host_port_tls", "panoptes.example.com:4318", true, "https://panoptes.example.com:4318/v1/metrics", false},
+		{"bare_host_port_plain", "localhost:4318", false, "http://localhost:4318/v1/metrics", false},
+		{"full_https_url_with_path", "https://panoptes.example.com/api/v1/metrics", true, "https://panoptes.example.com/api/v1/metrics", false},
+		{"full_http_url_no_path", "http://localhost:4318", false, "http://localhost:4318/v1/metrics", false},
+		{"full_https_url_no_path_appends_default", "https://panoptes.example.com:4318", true, "https://panoptes.example.com:4318/v1/metrics", false},
+		{"full_url_with_root_slash_path", "https://panoptes.example.com/", true, "https://panoptes.example.com/v1/metrics", false},
+		{"empty_endpoint", "", false, "", true},
+		{"url_with_whitespace", " https://x.com ", true, "https://x.com/v1/metrics", false},
+		// Decision-path: explicit URL with malformed structure must reach url.Parse failure.
+		{"malformed_full_url", "http://[::1", false, "", true},
+		// Decision-path: synthesized bare endpoints must also be validated, otherwise garbage
+		// like "foo bar:4318" survives Init and only fails much later inside http.NewRequestWithContext.
+		{"bare_endpoint_with_space_rejected", "foo bar:4318", false, "", true},
+		{"bare_endpoint_with_control_char_rejected", "foo\nbar:4318", false, "", true},
+		// Decision-path: per the OTLP exporter spec, only http and https schemes are valid.
+		{"unsupported_scheme_ftp", "ftp://example.com:4318", false, "", true},
+		{"unsupported_scheme_grpc", "grpc://example.com:4317", false, "", true},
+		// Decision-path: port-only ":4318" must NOT pass — SplitHostPort gives host=="".
+		{"port_only_bare_rejected", ":4318", false, "", true},
+		// Decision-path: bare endpoint must include a port; OTLP has no convention
+		// for defaulting bare HTTP endpoints to 80/443, so silently doing so would
+		// surprise operators who omitted the port by mistake.
+		{"bare_no_port_rejected", "panoptes", false, "", true},
+		{"bare_trailing_colon_rejected", "panoptes:", false, "", true},
+		// Decision-path: bare endpoint must be host:port only; paths require a full URL.
+		{"bare_endpoint_with_path_rejected", "localhost:4318/custom", false, "", true},
+		// Decision-path: userinfo in URL must be rejected — auth goes through Headers config.
+		{"userinfo_rejected", "https://user:pass@host:4318", true, "", true},
+		// Positive: IPv6 bare and full URLs must work end-to-end.
+		{"ipv6_bare_with_brackets", "[::1]:4318", false, "http://[::1]:4318/v1/metrics", false},
+		{"ipv6_full_url", "https://[::1]:4318", true, "https://[::1]:4318/v1/metrics", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveMetricsURL(tc.endpoint, tc.tls)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// newInitHTTPHelperOutput is a tiny helper for tests that exercise initHTTPFor
+// directly (no transport publication required). Keeps test bodies short.
+func newInitHTTPHelperOutput() *otlpOutput {
+	o := &otlpOutput{}
+	o.state = new(atomic.Pointer[outputState])
+	o.logger = logging.DiscardLogger()
+	return o
+}
+
+func TestInitHTTPFor_WithMTLS(t *testing.T) {
+	var (
+		gotContentType string
+		gotOrgID       string
+	)
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotOrgID = r.Header.Get("X-Scope-OrgID")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newInitHTTPHelperOutput()
+	cfg := &config{
+		Endpoint: srv.URL,
+		Protocol: "http",
+		TLS: &types.TLSConfig{
+			CaFile:   srv.CAPath(),
+			CertFile: srv.ClientCertPath(),
+			KeyFile:  srv.ClientKeyPath(),
+		},
+		Headers: map[string]string{"X-Scope-OrgID": "tenant-1"},
+	}
+
+	hs, err := o.initHTTPFor(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, hs)
+	require.NotNil(t, hs.client)
+	require.Contains(t, hs.endpoint, "/v1/metrics")
+
+	// Headers are built per-request now, so verify they arrive at the server.
+	o.state.Store(&outputState{cfg: cfg, transport: &transportState{httpState: hs}})
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Equal(t, "application/x-protobuf", gotContentType)
+	require.Equal(t, "tenant-1", gotOrgID)
+}
+
+func TestInitHTTPFor_NoTLSBlock(t *testing.T) {
+	o := newInitHTTPHelperOutput()
+	cfg := &config{Endpoint: "localhost:4318", Protocol: "http"}
+
+	hs, err := o.initHTTPFor(cfg)
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:4318/v1/metrics", hs.endpoint)
+}
+
+// Strict-coherence guard: configuring TLS while pinning a plaintext URL is
+// almost always a misconfiguration that silently disables mTLS. Reject at Init.
+func TestInitHTTPFor_PlaintextURLWithTLSBlockErrors(t *testing.T) {
+	o := newInitHTTPHelperOutput()
+	cfg := &config{
+		Endpoint: "http://panoptes.observability.svc:4318",
+		Protocol: "http",
+		TLS:      &types.TLSConfig{CaFile: "/some/ca.crt"},
+	}
+
+	_, err := o.initHTTPFor(cfg)
+	require.Error(t, err, "must reject http:// URL when tls block is configured")
+	require.Contains(t, err.Error(), "tls")
+}
+
+// Mirror case stays permissive: https:// URL with no tls block uses system roots.
+func TestInitHTTPFor_HTTPSURLWithoutTLSBlockAllowed(t *testing.T) {
+	o := newInitHTTPHelperOutput()
+	cfg := &config{Endpoint: "https://panoptes.example.com/v1/metrics", Protocol: "http"}
+
+	hs, err := o.initHTTPFor(cfg)
+	require.NoError(t, err)
+	require.Equal(t, "https://panoptes.example.com/v1/metrics", hs.endpoint)
+}
+
+// Decision-path: createTLSConfigFor failure must propagate as a clear Init error.
+func TestInitHTTPFor_TLSCreateFails(t *testing.T) {
+	o := newInitHTTPHelperOutput()
+	cfg := &config{
+		Endpoint: "https://panoptes.example.com:4318",
+		Protocol: "http",
+		TLS: &types.TLSConfig{
+			CaFile:   "/nonexistent/path/ca.crt",
+			CertFile: "/nonexistent/path/client.crt",
+			KeyFile:  "/nonexistent/path/client.key",
+		},
+	}
+
+	_, err := o.initHTTPFor(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "TLS")
+}
+
+// Decision-path: empty endpoint reaching resolveMetricsURL must surface as Init error.
+func TestInitHTTPFor_EmptyEndpointErrors(t *testing.T) {
+	o := newInitHTTPHelperOutput()
+	cfg := &config{Endpoint: "", Protocol: "http"}
+
+	_, err := o.initHTTPFor(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpoint is required")
+}
+
+// Decision-path: a reload that changes only Headers must take effect on the
+// next batch without a transport rebuild. The old design cached headers in
+// httpClientState and silently ignored such reloads.
+func TestSendHTTP_HeaderReloadTakesEffect(t *testing.T) {
+	var gotOrgID string
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotOrgID = r.Header.Get("X-Scope-OrgID")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.Headers = map[string]string{"X-Scope-OrgID": "tenant-old"}
+	})
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Equal(t, "tenant-old", gotOrgID)
+
+	// Simulate a header-only reload — same transport, new headers.
+	withCfg(o, func(c *config) {
+		c.Headers = map[string]string{"X-Scope-OrgID": "tenant-new"}
+	})
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Equal(t, "tenant-new", gotOrgID, "header-only reload must take effect on the next batch")
+}
+
+// User-supplied headers cannot override the OTLP-required Content-Type or
+// (when compression is on) Content-Encoding. Document and enforce this contract.
+func TestSendHTTP_UserHeadersCannotOverrideProtocolHeaders(t *testing.T) {
+	var gotContentType string
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.Headers = map[string]string{"Content-Type": "application/json"} // bogus override attempt
+	})
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Equal(t, "application/x-protobuf", gotContentType, "user Headers must not override Content-Type")
+}
+
+func TestSendHTTP_SuccessfulExport(t *testing.T) {
+	var gotBody []byte
+	var gotContentType, gotOrgID string
+
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, otlpHTTPMetricsPath, r.URL.Path)
+		gotContentType = r.Header.Get("Content-Type")
+		gotOrgID = r.Header.Get("X-Scope-OrgID")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := &otlpOutput{}
+	o.state = new(atomic.Pointer[outputState])
+	o.logger = logging.DiscardLogger()
+
+	cfg := &config{
+		Endpoint: srv.URL,
+		Protocol: "http",
+		Timeout:  5 * time.Second,
+		TLS: &types.TLSConfig{
+			CaFile:   srv.CAPath(),
+			CertFile: srv.ClientCertPath(),
+			KeyFile:  srv.ClientKeyPath(),
+		},
+		Headers: map[string]string{"X-Scope-OrgID": "tenant-1"},
+	}
+
+	hs, err := o.initHTTPFor(cfg)
+	require.NoError(t, err)
+	o.state.Store(&outputState{cfg: cfg, transport: &transportState{httpState: hs}})
+
+	// Minimal valid ExportMetricsServiceRequest.
+	req := &metricsv1.ExportMetricsServiceRequest{}
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), req))
+
+	require.Equal(t, "application/x-protobuf", gotContentType)
+	require.Equal(t, "tenant-1", gotOrgID)
+
+	// Round-trip check: unmarshal body and compare.
+	var roundtrip metricsv1.ExportMetricsServiceRequest
+	require.NoError(t, proto.Unmarshal(gotBody, &roundtrip))
+}
+
+// withCfg applies a mutation to a copy of the current config and atomically
+// publishes a new outputState that shares the same *transportState pointer.
+// Test-only convenience — production reloads via Update(). Direct mutation
+// of state.Load().cfg is an unsynchronized write that defeats atomic.Pointer;
+// this helper does it safely. Sharing the transport pointer matches Update's
+// no-rebuild path (and avoids the WaitGroup-copy issue that would arise from
+// allocating a fresh transportState for every cfg-only test mutation).
+func withCfg(o *otlpOutput, mutate func(*config)) {
+	oldState := o.state.Load()
+	cfg := *oldState.cfg
+	mutate(&cfg)
+	newState := &outputState{
+		cfg:       &cfg,
+		transport: oldState.transport,
+	}
+	o.state.Store(newState)
+}
+
+// newHTTPTestOutput is shared by every test that drives sendHTTP through a real
+// httptest server. Defining it here in Task 5 so subsequent tasks can use it
+// without re-introducing.
+func newHTTPTestOutput(t *testing.T, srv *mTLSTestServer) *otlpOutput {
+	t.Helper()
+	o := &otlpOutput{}
+	o.state = new(atomic.Pointer[outputState])
+	o.logger = logging.DiscardLogger()
+	cfg := &config{
+		Endpoint: srv.URL,
+		Protocol: "http",
+		Timeout:  2 * time.Second,
+		TLS: &types.TLSConfig{
+			CaFile:   srv.CAPath(),
+			CertFile: srv.ClientCertPath(),
+			KeyFile:  srv.ClientKeyPath(),
+		},
+	}
+	hs, err := o.initHTTPFor(cfg)
+	require.NoError(t, err)
+	o.state.Store(&outputState{cfg: cfg, transport: &transportState{httpState: hs}})
+	return o
+}
+
+// Decision-path: defensive guard for "Init never ran or partially failed".
+// Constructs an outputState with cfg.Protocol == "http" but no httpState —
+// exactly the shape that would be invalid in production but possible from
+// hand-built test scaffolding.
+func TestSendHTTP_NoStateInitialized(t *testing.T) {
+	o := &otlpOutput{}
+	o.state = new(atomic.Pointer[outputState])
+	o.logger = logging.DiscardLogger()
+	state := &outputState{cfg: &config{Protocol: "http", Endpoint: "https://x"}, transport: &transportState{}}
+	o.state.Store(state)
+
+	err := o.sendHTTP(context.Background(), state, &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not initialized")
+}
+
+// Decision-path: cfg.Timeout == 0 skips the WithTimeout branch.
+// We start an mTLS server, send normally, and just verify success — exercising
+// the no-timeout path. Hangs would be caught by the test runner's overall timeout.
+func TestSendHTTP_NoTimeoutConfigured(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) { c.Timeout = 0 })
+
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+}
+
+// Decision-path: client.Do failure (transport error). Stop the server first so
+// the dial fails — this exercises the "HTTP export failed" branch without
+// hitting the response classification code.
+func TestSendHTTP_DialFailure(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {})
+	o := newHTTPTestOutput(t, srv)
+	srv.Close() // close before the call so dial fails
+
+	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err)
+}
+
+// Decision-path: proto.Marshal fails when a string field contains invalid UTF-8
+// (proto3 requires UTF-8). The server handler must NOT be reached because the
+// failure is local to the marshal step.
+func TestSendHTTP_MarshalRejectsInvalidUTF8(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("server must not receive a request when proto.Marshal fails")
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	invalid := string([]byte{0xff, 0xfe, 0xfd}) // not valid UTF-8
+	req := &metricsv1.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricspb.ResourceMetrics{
+			{
+				ScopeMetrics: []*metricspb.ScopeMetrics{
+					{
+						Metrics: []*metricspb.Metric{
+							{Name: invalid},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := o.sendHTTP(context.Background(), o.state.Load(), req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "marshal OTLP request")
+}
+
+// Table-driven decision-path coverage for isPermanentHTTPError.
+// Per OTLP spec (https://opentelemetry.io/docs/specs/otlp/), retryable status
+// codes are 429, 502, 503, 504. All other 4xx and 5xx are permanent.
+// Transport-level errors (errors.As fails to find *httpExportError) are
+// treated as retryable — typically transient network blips.
+func TestIsPermanentHTTPError_Table(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		permanent bool
+	}{
+		// Transport / wrapped non-HTTP errors → retryable.
+		{"transport_error", fmt.Errorf("dial tcp: connection refused"), false},
+		{"nil_error", nil, false}, // nil isn't permanent (caller checks err != nil first)
+
+		// Retryable per OTLP spec.
+		{"status_429_too_many_requests", &httpExportError{status: 429}, false},
+		{"status_502_bad_gateway", &httpExportError{status: 502}, false},
+		{"status_503_service_unavailable", &httpExportError{status: 503}, false},
+		{"status_504_gateway_timeout", &httpExportError{status: 504}, false},
+
+		// Permanent (4xx and 5xx not in retryable set).
+		{"status_400_bad_request", &httpExportError{status: 400}, true},
+		{"status_401_unauthorized", &httpExportError{status: 401}, true},
+		{"status_403_forbidden", &httpExportError{status: 403}, true},
+		{"status_404_not_found", &httpExportError{status: 404}, true},
+		{"status_408_request_timeout_permanent_per_otlp", &httpExportError{status: 408}, true},
+		{"status_500_internal_server_error", &httpExportError{status: 500}, true},
+		{"status_501_not_implemented", &httpExportError{status: 501}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.permanent, isPermanentHTTPError(tc.err))
+		})
+	}
+}
+
+// Sanity check that the integration with a live server matches the table:
+// permanent 400 surfaces as permanent, retryable 503 does not, and sendHTTP
+// itself never retries (the loop is in sendBatch).
+func TestSendHTTP_PermanentErrorNotRetried(t *testing.T) {
+	var calls int
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest) // 400
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err)
+	require.True(t, isPermanentHTTPError(err))
+	require.Equal(t, 1, calls, "sendHTTP itself should not retry")
+}
+
+func TestSendHTTP_RetryableError(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // 503
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err)
+	require.False(t, isPermanentHTTPError(err))
+}
+
+// Table-driven decision-path coverage for parseRetryAfter (RFC 7231 §7.1.3).
+func TestParseRetryAfter_Table(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		in   string
+		want time.Duration
+	}{
+		{"empty", "", 0},
+		{"whitespace_only", "   ", 0},
+		{"zero_seconds", "0", 0},
+		{"five_seconds", "5", 5 * time.Second},
+		{"surrounded_by_whitespace", "  5  ", 5 * time.Second},
+		{"negative_seconds_clamped_to_zero", "-1", 0},
+		{"unparseable", "not-a-number", 0},
+		{"http_date_in_future", now.Add(10 * time.Second).UTC().Format(http.TimeFormat), 10 * time.Second},
+		{"http_date_in_past", now.Add(-time.Hour).UTC().Format(http.TimeFormat), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseRetryAfter(tc.in, now)
+			// HTTP-date precision is seconds; allow a tiny tolerance to absorb formatting jitter.
+			diff := got - tc.want
+			if diff < 0 {
+				diff = -diff
+			}
+			require.Less(t, diff, time.Second, "got=%v want=%v", got, tc.want)
+		})
+	}
+}
+
+func TestSendHTTP_PartialSuccessReturnsError(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Build a 200 response containing a PartialSuccess with rejected points.
+		respProto := &metricsv1.ExportMetricsServiceResponse{
+			PartialSuccess: &metricsv1.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 7,
+				ErrorMessage:       "schema validation failed for 7 points",
+			},
+		}
+		body, err := proto.Marshal(respProto)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err, "PartialSuccess with rejected points must surface as an error (parity with gRPC)")
+	require.Contains(t, err.Error(), "rejected 7")
+}
+
+// Decision-path: PartialSuccess present but RejectedDataPoints == 0 must NOT
+// surface as an error. This is the "informational" PartialSuccess case (e.g.
+// server reporting metadata about a fully-accepted batch).
+func TestSendHTTP_PartialSuccessZeroRejected(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		respProto := &metricsv1.ExportMetricsServiceResponse{
+			PartialSuccess: &metricsv1.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 0,
+				ErrorMessage:       "informational",
+			},
+		}
+		body, _ := proto.Marshal(respProto)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+}
+
+// Decision-path: empty 200 body must succeed (the early-return short-circuit).
+func TestSendHTTP_EmptyResponseBody(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK) // no body written
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+}
+
+// Decision-path (debug off): malformed (non-protobuf) 200 body must NOT cause
+// an error; the transport-level success is authoritative. The Debug branch
+// is silent in this variant.
+func TestSendHTTP_MalformedResponseBody_DebugOff(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("this is definitely not a protobuf"))
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	require.False(t, o.state.Load().cfg.Debug, "precondition: debug must be off for this variant")
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+}
+
+// Decision-path (debug on): same scenario but Debug enabled — exercises the
+// `if cfg.Debug { o.logger.Printf(...) }` branch. Captures log output via a
+// buffer to verify the warning was emitted.
+func TestSendHTTP_MalformedResponseBody_DebugOn(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not a protobuf"))
+	})
+	defer srv.Close()
+
+	var logbuf bytes.Buffer
+	o := newHTTPTestOutput(t, srv)
+	o.logger = slog.New(slog.NewTextHandler(&logbuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	withCfg(o, func(c *config) { c.Debug = true })
+
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Contains(t, logbuf.String(), "failed to unmarshal OTLP response body")
+}
+
+// Decision-path: when EnableMetrics is set, PartialSuccess rejections must
+// increment the otlpRejectedDataPoints counter (parity with gRPC path).
+func TestSendHTTP_PartialSuccessIncrementsMetric(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		respProto := &metricsv1.ExportMetricsServiceResponse{
+			PartialSuccess: &metricsv1.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 3,
+				ErrorMessage:       "rejected 3",
+			},
+		}
+		body, _ := proto.Marshal(respProto)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.EnableMetrics = true
+		c.Name = "test-metric-output"
+	})
+
+	cfgName := o.state.Load().cfg.Name
+	before := testutil.ToFloat64(otlpRejectedDataPoints.WithLabelValues(cfgName))
+	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err)
+	after := testutil.ToFloat64(otlpRejectedDataPoints.WithLabelValues(cfgName))
+	require.Equal(t, float64(3), after-before, "metric must advance by RejectedDataPoints")
+}
+
+func TestSendHTTP_RetryAfterHeaderHonored(t *testing.T) {
+	start := time.Now()
+	var callTimes []time.Time
+	var calls int
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callTimes = append(callTimes, time.Now())
+		calls++
+		if calls <= 1 {
+			w.Header().Set("Retry-After", "1") // 1 second
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.MaxRetries = 3
+		c.resourceTagSet = map[string]bool{}
+	})
+
+	// Build one event and run through the public sendBatch path so we exercise the retry loop.
+	events := []*formatters.EventMsg{{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags:   map[string]string{"source": "x"},
+		Values: map[string]interface{}{"value": int64(1)},
+	}}
+	o.sendBatch(context.Background(), events)
+
+	require.GreaterOrEqual(t, calls, 2, "should retry at least once")
+	require.GreaterOrEqual(t, time.Since(start), 1*time.Second, "must wait >=1s per Retry-After")
+}
+
+func TestSendHTTP_PermanentErrorStopsRetryLoop(t *testing.T) {
+	var calls int
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.MaxRetries = 5
+		c.resourceTagSet = map[string]bool{}
+	})
+
+	events := []*formatters.EventMsg{{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags:   map[string]string{"source": "x"},
+		Values: map[string]interface{}{"value": int64(1)},
+	}}
+	o.sendBatch(context.Background(), events)
+
+	require.Equal(t, 1, calls, "permanent 400 must not retry")
+}
+
+// Table-driven decision-path coverage for effectiveRetrySleep.
+//
+// gRPC and the Retry-After-honoring path are deterministic — assert exact
+// values. The HTTP no-Retry-After path uses exponential backoff with full
+// jitter, so we assert the result lies in the canonical [0, base) range
+// where base = min(maxSleep, 2^attempt * 100ms).
+func TestEffectiveRetrySleep_Table(t *testing.T) {
+	const testCap = 30 * time.Second
+
+	type bound struct {
+		min, max time.Duration // inclusive lower, exclusive upper
+	}
+	cases := []struct {
+		name       string
+		protocol   string
+		attempt    int
+		retryAfter time.Duration
+		// Exactly one of `want` or `bound` must be set.
+		want  time.Duration
+		bound *bound
+	}{
+		// gRPC: deterministic linear backoff regardless of Retry-After.
+		{name: "grpc_attempt0_no_retry_after", protocol: "grpc", attempt: 0, retryAfter: 0, want: 100 * time.Millisecond},
+		{name: "grpc_attempt2_no_retry_after", protocol: "grpc", attempt: 2, retryAfter: 0, want: 300 * time.Millisecond},
+		{name: "grpc_ignores_retry_after", protocol: "grpc", attempt: 0, retryAfter: 5 * time.Second, want: 100 * time.Millisecond},
+
+		// HTTP with Retry-After: deterministic.
+		{name: "http_retry_after_under_cap_used", protocol: "http", attempt: 0, retryAfter: 5 * time.Second, want: 5 * time.Second},
+		{name: "http_retry_after_at_cap_used", protocol: "http", attempt: 0, retryAfter: testCap, want: testCap},
+		{name: "http_retry_after_above_cap_clamped", protocol: "http", attempt: 0, retryAfter: 5 * time.Minute, want: testCap},
+
+		// HTTP without Retry-After: exponential backoff with full jitter — assert range.
+		// base for attempt=0 is 100ms, attempt=1 is 200ms, attempt=2 is 400ms.
+		{name: "http_attempt0_no_retry_after", protocol: "http", attempt: 0, retryAfter: 0, bound: &bound{0, 100 * time.Millisecond}},
+		{name: "http_attempt1_no_retry_after", protocol: "http", attempt: 1, retryAfter: 0, bound: &bound{0, 200 * time.Millisecond}},
+		{name: "http_attempt2_no_retry_after", protocol: "http", attempt: 2, retryAfter: 0, bound: &bound{0, 400 * time.Millisecond}},
+		{name: "http_zero_retry_after_falls_back", protocol: "http", attempt: 0, retryAfter: 0, bound: &bound{0, 100 * time.Millisecond}},
+		{name: "http_negative_retry_after_falls_back", protocol: "http", attempt: 0, retryAfter: -time.Second, bound: &bound{0, 100 * time.Millisecond}},
+		// Large attempt: base saturates at maxSleep cap. 2^9 * 100ms = 51.2s > 30s cap → bound is [0, testCap).
+		{name: "http_high_attempt_clamped_to_cap", protocol: "http", attempt: 9, retryAfter: 0, bound: &bound{0, testCap}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveRetrySleep(tc.protocol, tc.attempt, tc.retryAfter, testCap)
+			if tc.bound != nil {
+				require.GreaterOrEqual(t, got, tc.bound.min, "jitter lower bound")
+				require.Less(t, got, tc.bound.max, "jitter exclusive upper bound")
+				return
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestUpdate_HTTPHeaderOnlyReload_NextBatchCarriesNewHeader drives the public
+// Update() API through the no-rebuild path (only cfg.Headers changed) and
+// verifies that the new header value reaches the server on the very next batch.
+//
+// Decision-path: needsTransportRebuild == false → cfg-only swap. Headers are
+// read per-request from state.cfg.Headers (Task 15c invariant), so a reload
+// that changes only the headers map takes effect without rebuilding the
+// HTTP transport.
+func TestUpdate_HTTPHeaderOnlyReload_NextBatchCarriesNewHeader(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		orgIDs []string
+	)
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		orgIDs = append(orgIDs, r.Header.Get("X-Scope-OrgID"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	tlsCfgMap := map[string]interface{}{
+		"ca-file":   srv.CAPath(),
+		"cert-file": srv.ClientCertPath(),
+		"key-file":  srv.ClientKeyPath(),
+	}
+	baseCfgMap := map[string]interface{}{
+		"endpoint":   srv.URL,
+		"protocol":   "http",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "100ms",
+		"tls":        tlsCfgMap,
+		"headers":    map[string]interface{}{"X-Scope-OrgID": "tenant-A"},
+	}
+
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-header-reload", baseCfgMap,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	// Send batch A — expect tenant-A.
+	o.WriteEvent(context.Background(), &formatters.EventMsg{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags: map[string]string{"source": "x"}, Values: map[string]interface{}{"value": int64(1)},
+	})
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(orgIDs) >= 1
+	}, 2*time.Second, 20*time.Millisecond, "batch A must arrive at server")
+
+	mu.Lock()
+	firstID := orgIDs[len(orgIDs)-1]
+	mu.Unlock()
+	require.Equal(t, "tenant-A", firstID, "first batch must carry tenant-A header")
+
+	// Build a cfg map identical except for the header value (no transport rebuild).
+	updatedCfgMap := map[string]interface{}{
+		"endpoint":   srv.URL,
+		"protocol":   "http",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "100ms",
+		"tls":        tlsCfgMap,
+		"headers":    map[string]interface{}{"X-Scope-OrgID": "tenant-B"},
+	}
+	require.NoError(t, o.Update(context.Background(), updatedCfgMap))
+
+	// Send batch B — expect tenant-B.
+	countBefore := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(orgIDs)
+	}()
+	o.WriteEvent(context.Background(), &formatters.EventMsg{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags: map[string]string{"source": "x"}, Values: map[string]interface{}{"value": int64(1)},
+	})
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(orgIDs) > countBefore
+	}, 2*time.Second, 20*time.Millisecond, "batch B must arrive after header-only reload")
+
+	mu.Lock()
+	lastID := orgIDs[len(orgIDs)-1]
+	mu.Unlock()
+	require.Equal(t, "tenant-B", lastID, "batch after header-only Update must carry tenant-B header")
+}
+
+// Statistical sanity for full-jitter distribution: many samples must span the
+// [0, base) range (not all clustered near zero or near base). 100 samples is
+// sufficient to detect a stuck PRNG without making the test flaky.
+func TestEffectiveRetrySleep_JitterDistribution(t *testing.T) {
+	const testCap = 30 * time.Second
+	const samples = 100
+	const attempt = 4 // base = 1.6s; plenty of room for the distribution to spread
+
+	base := time.Duration(1<<attempt) * 100 * time.Millisecond
+	var minSeen, maxSeen time.Duration = base, 0
+	for i := 0; i < samples; i++ {
+		got := effectiveRetrySleep("http", attempt, 0, testCap)
+		require.GreaterOrEqual(t, got, time.Duration(0))
+		require.Less(t, got, base)
+		if got < minSeen {
+			minSeen = got
+		}
+		if got > maxSeen {
+			maxSeen = got
+		}
+	}
+	// Across 100 samples we expect to see at least the lower 25% and upper 25%
+	// of the range. If the PRNG is stuck this fails loudly.
+	require.Less(t, minSeen, base/4, "samples should span the lower quartile")
+	require.Greater(t, maxSeen, base*3/4, "samples should span the upper quartile")
+}
+
+// Decision-path: retryAfterFromError must return 0 for plain (non-typed) errors.
+// The Retry-After-honoring tests cover the typed-error path.
+func TestRetryAfterFromError_NonHTTPError(t *testing.T) {
+	require.Equal(t, time.Duration(0), retryAfterFromError(fmt.Errorf("plain error")))
+	require.Equal(t, time.Duration(0), retryAfterFromError(nil))
+}
+
+// Decision-path: a Retry-After sleep must be interruptible by ctx cancellation
+// so Close() during a retry doesn't pin the worker.
+func TestSendBatch_ContextCancelledDuringRetryWait(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Always 503 with a long Retry-After so the loop wants to sleep >=1s.
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	const name = "cancelled-retry-accounting"
+	withCfg(o, func(c *config) {
+		c.MaxRetries = 5
+		c.EnableMetrics = true
+		c.Name = name
+		c.resourceTagSet = map[string]bool{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond) // give first attempt time to fail and start sleeping
+		cancel()
+	}()
+
+	events := []*formatters.EventMsg{{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags:   map[string]string{"source": "x"},
+		Values: map[string]interface{}{"value": int64(1)},
+	}}
+
+	start := time.Now()
+	o.sendBatch(ctx, events)
+	elapsed := time.Since(start)
+
+	// Cancellation should land well before the 5-second Retry-After elapses.
+	require.Less(t, elapsed, 2*time.Second, "ctx cancel must interrupt the retry sleep")
+
+	// The cancelled batch was dropped — it must be counted as failed, not
+	// silently lost from the accounting.
+	require.Equal(t, float64(len(events)),
+		testutil.ToFloat64(otlpNumberOfFailedEvents.WithLabelValues(name, "send_failed")),
+		"batch dropped by cancellation must be counted as failed")
+}
+
+func TestOTLP_InitHTTPTransport_Succeeds(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := &otlpOutput{}
+	cfgMap := map[string]interface{}{
+		"type":     "otlp",
+		"endpoint": srv.URL,
+		"protocol": "http",
+		"tls": map[string]interface{}{
+			"ca-file":   srv.CAPath(),
+			"cert-file": srv.ClientCertPath(),
+			"key-file":  srv.ClientKeyPath(),
+		},
+	}
+	err := o.Init(context.Background(), "test-otlp", cfgMap,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	)
+	require.NoError(t, err, "Init with protocol: http must succeed once initHTTPFor is wired")
+	defer o.Close()
+}
+
+// Verifies that Init calls validateConfig. We deliberately pick a failure
+// mode that ONLY validateConfig surfaces — counter-pattern compilation —
+// so this test can't pass via the existing Init transport switch or any
+// other accidental gate. If an implementer forgets the validateConfig call
+// in Init, this test fails: the bad pattern would otherwise be accepted at
+// startup and silently produce a runtime issue later.
+func TestOTLP_InitRunsValidateConfig(t *testing.T) {
+	o := &otlpOutput{}
+	cfg := map[string]interface{}{
+		"endpoint":         "localhost:4317",
+		"protocol":         "grpc",             // valid — passes every other Init gate
+		"counter-patterns": []interface{}{"("}, // unclosed paren; only validateConfig compiles regexes
+	}
+	err := o.Init(context.Background(), "test-otlp", cfg,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid counter-pattern")
+}
+
+// Decision-path: validateConfig must reject protocols outside the allowed set.
+func TestValidateConfig_RejectsBadProtocol(t *testing.T) {
+	o := &otlpOutput{}
+	cfg := &config{
+		Endpoint: "localhost:4317",
+		Protocol: "tcp", // not grpc/http
+	}
+	o.setDefaultsFor(cfg) // run defaults first so other fields are sane
+	cfg.Protocol = "tcp"  // re-apply after setDefaultsFor (which would replace "" with "grpc")
+	err := o.validateConfig(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported protocol")
+}
+
+// Table-driven decision-path coverage for needsTransportRebuild.
+// (Compression-diff case is added in Task 10 once the field exists.)
+func TestNeedsTransportRebuild_Table(t *testing.T) {
+	base := func() *config {
+		return &config{
+			Endpoint: "localhost:4318",
+			Protocol: "http",
+			TLS:      &types.TLSConfig{CaFile: "/ca"},
+		}
+	}
+	withTLS := func(c *config, ca string) *config { c.TLS = &types.TLSConfig{CaFile: ca}; return c }
+
+	cases := []struct {
+		name string
+		old  *config
+		nw   *config
+		want bool
+	}{
+		{"both_nil", nil, nil, true},
+		{"old_nil", nil, base(), true},
+		{"new_nil", base(), nil, true},
+		{"endpoint_changed", base(), func() *config { c := base(); c.Endpoint = "other:4318"; return c }(), true},
+		{"protocol_changed", base(), func() *config { c := base(); c.Protocol = "grpc"; return c }(), true},
+		{"tls_ca_changed", base(), withTLS(base(), "/different-ca"), true},
+		{"tls_added", func() *config { c := base(); c.TLS = nil; return c }(), base(), true},
+		{"tls_removed", base(), func() *config { c := base(); c.TLS = nil; return c }(), true},
+		{"identical_no_rebuild", base(), base(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, needsTransportRebuild(tc.old, tc.nw))
+		})
+	}
+}
+
+func TestOTLP_Close_HTTPReleasesConnections(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := &otlpOutput{}
+	cfgMap := map[string]interface{}{
+		"type":     "otlp",
+		"endpoint": srv.URL,
+		"protocol": "http",
+		"tls": map[string]interface{}{
+			"ca-file":   srv.CAPath(),
+			"cert-file": srv.ClientCertPath(),
+			"key-file":  srv.ClientKeyPath(),
+		},
+	}
+	require.NoError(t, o.Init(context.Background(), "test-otlp", cfgMap,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+
+	// Close must not error and must not panic even though grpcState is nil.
+	require.NoError(t, o.Close())
+
+	// Second Close should be idempotent.
+	require.NoError(t, o.Close())
+}
+
+// Decision-path: Close after initFields ran but before any transport state was
+// stored — exercises every Swap(nil) path returning nil, the cancelFn nil
+// guard, and the eventCh nil guard. Does NOT test the genuinely-zero-value
+// case (initFields never ran) — Close is only required to be safe on the
+// post-initFields surface, which is what every real Init call produces.
+//
+// Note: otlpOutput.wg is *sync.WaitGroup (pointer), not a value, so calling
+// Close without running initFields first would nil-deref. We call initFields
+// directly to mirror the post-Init shape; this is package-private so the test
+// can reach it.
+func TestOTLP_Close_AfterInitFieldsButBeforeTransportStored(t *testing.T) {
+	o := &otlpOutput{}
+	o.initFields()
+	o.logger = logging.DiscardLogger()
+
+	require.NoError(t, o.Close())
+}
+
+func TestSendHTTP_GzipCompression(t *testing.T) {
+	var gotEncoding string
+	var gotBody []byte
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEncoding = r.Header.Get("Content-Encoding")
+		gr, err := gzip.NewReader(r.Body)
+		require.NoError(t, err)
+		gotBody, _ = io.ReadAll(gr)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) { c.Compression = "gzip" })
+	cfg := o.state.Load().cfg
+	hs, err := o.initHTTPFor(cfg)
+	require.NoError(t, err)
+	o.state.Store(&outputState{cfg: cfg, transport: &transportState{httpState: hs}})
+
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Equal(t, "gzip", gotEncoding)
+
+	var roundtrip metricsv1.ExportMetricsServiceRequest
+	require.NoError(t, proto.Unmarshal(gotBody, &roundtrip))
+}
+
+// Default-on verification: a config with protocol:http and no compression set
+// should end up with Compression=="gzip" after setDefaultsFor runs, and the
+// resulting send should carry Content-Encoding: gzip.
+func TestSendHTTP_GzipIsDefaultForHTTP(t *testing.T) {
+	var gotEncoding string
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEncoding = r.Header.Get("Content-Encoding")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := &otlpOutput{}
+	cfgMap := map[string]interface{}{
+		"type":     "otlp",
+		"endpoint": srv.URL,
+		"protocol": "http",
+		// compression intentionally omitted — default should kick in
+		"tls": map[string]interface{}{
+			"ca-file":   srv.CAPath(),
+			"cert-file": srv.ClientCertPath(),
+			"key-file":  srv.ClientKeyPath(),
+		},
+	}
+	require.NoError(t, o.Init(context.Background(), "test-otlp", cfgMap,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	require.Equal(t, "gzip", o.state.Load().cfg.Compression, "default must populate Compression for http")
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Equal(t, "gzip", gotEncoding)
+}
+
+// Opt-out verification: explicit "none" disables gzip even when protocol is http.
+func TestSendHTTP_CompressionNoneOptOut(t *testing.T) {
+	var gotEncoding string
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEncoding = r.Header.Get("Content-Encoding")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := &otlpOutput{}
+	cfgMap := map[string]interface{}{
+		"type":        "otlp",
+		"endpoint":    srv.URL,
+		"protocol":    "http",
+		"compression": "none",
+		"tls": map[string]interface{}{
+			"ca-file":   srv.CAPath(),
+			"cert-file": srv.ClientCertPath(),
+			"key-file":  srv.ClientKeyPath(),
+		},
+	}
+	require.NoError(t, o.Init(context.Background(), "test-otlp", cfgMap,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Equal(t, "", gotEncoding, "compression: none must produce no Content-Encoding header")
+}
+
+// Decision-path: validateConfig must reject compression values outside the allowed set.
+func TestValidateConfig_RejectsBadCompression(t *testing.T) {
+	o := &otlpOutput{}
+	cfg := &config{
+		Endpoint:    "localhost:4318",
+		Protocol:    "http",
+		Compression: "snappy", // not none/gzip
+	}
+	o.setDefaultsFor(cfg)
+	cfg.Compression = "snappy" // re-apply in case defaults changed it
+	err := o.validateConfig(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "compression")
+}
+
+// Decision-path: needsTransportRebuild must trigger on compression change.
+// (Complements the table in Task 8 with the case that became valid in Task 10.)
+func TestNeedsTransportRebuild_CompressionDiff(t *testing.T) {
+	base := &config{Endpoint: "x:4318", Protocol: "http", Compression: "gzip"}
+	changed := &config{Endpoint: "x:4318", Protocol: "http", Compression: "none"}
+	require.True(t, needsTransportRebuild(base, changed))
+	require.True(t, needsTransportRebuild(changed, base))
+}
+
+// Decision-path: PartialSuccess responses must NOT be retried (per OTLP spec).
+// Drives sendBatch (NOT sendHTTP directly) to exercise the retry-loop dispatch.
+func TestSendBatch_HTTPPartialSuccessNotRetried(t *testing.T) {
+	var calls int
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		respProto := &metricsv1.ExportMetricsServiceResponse{
+			PartialSuccess: &metricsv1.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 5,
+				ErrorMessage:       "schema validation failed",
+			},
+		}
+		body, _ := proto.Marshal(respProto)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.MaxRetries = 5
+		c.resourceTagSet = map[string]bool{}
+	})
+
+	events := []*formatters.EventMsg{{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags:   map[string]string{"source": "x"},
+		Values: map[string]interface{}{"value": int64(1)},
+	}}
+	o.sendBatch(context.Background(), events)
+
+	require.Equal(t, 1, calls, "PartialSuccess must not retry — server already accepted points")
+}
+
+// Decision-path: isPartialSuccessError detects the typed sentinel.
+func TestIsPartialSuccessError(t *testing.T) {
+	require.True(t, isPartialSuccessError(&partialSuccessError{rejected: 3, errorMessage: "x"}))
+	require.False(t, isPartialSuccessError(fmt.Errorf("plain error")))
+	require.False(t, isPartialSuccessError(nil))
+	// httpExportError must NOT match — it's a different category.
+	require.False(t, isPartialSuccessError(&httpExportError{status: 503}))
+}
+
+// Decision-path: an in-flight batch holding the OLD outputState must be able
+// to finish even if Update swaps to a new state mid-flight. Under the wall-
+// clock heuristic this would have dropped batches whose lifetime exceeded the
+// fixed 60s window. Under the WaitGroup model, cleanup waits for actual users.
+func TestUpdate_TransportNotClosedWhileBatchInFlight(t *testing.T) {
+	// Server intentionally hangs on the first request (simulates a slow
+	// upstream). The hang is released by closing 'release' from the test.
+	release := make(chan struct{})
+	var hangCount atomic.Int32
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if hangCount.Add(1) == 1 {
+			<-release
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.Timeout = 10 * time.Second // generous so the hang can persist
+	})
+
+	// Start an in-flight sendHTTP via sendBatch. Use a goroutine so the
+	// caller doesn't block on the server hang.
+	state := o.state.Load()
+	state.transport.inFlight.Add(1)
+	sendDone := make(chan error, 1)
+	go func() {
+		defer state.transport.inFlight.Done()
+		sendDone <- o.sendHTTP(context.Background(), state, &metricsv1.ExportMetricsServiceRequest{})
+	}()
+
+	// Wait until the server has received the request (so the goroutine is
+	// actually mid-send and holding the state reference).
+	require.Eventually(t, func() bool { return hangCount.Load() == 1 },
+		2*time.Second, 25*time.Millisecond, "server should receive the first request")
+
+	// Simulate a transport-rebuild reload by manually publishing a new state.
+	// This mirrors what Update's rebuild path does: build new state, lock-
+	// Swap-unlock, async Wait+cleanup.
+	newCfg := *o.state.Load().cfg
+	newHS, err := o.initHTTPFor(&newCfg)
+	require.NoError(t, err)
+	newState := &outputState{cfg: &newCfg, transport: &transportState{httpState: newHS}}
+
+	o.stateMu.Lock()
+	oldState := o.state.Swap(newState)
+	o.stateMu.Unlock()
+
+	// Track when cleanup actually fires.
+	cleanupDone := make(chan struct{})
+	go func() {
+		oldState.transport.inFlight.Wait()
+		oldState.transport.cleanup()
+		close(cleanupDone)
+	}()
+
+	// Critical: cleanupDone must NOT have fired yet — the in-flight goroutine
+	// is still hung on the server response. The 100ms window is comfortably
+	// shorter than the test's 2s overall budget.
+	select {
+	case <-cleanupDone:
+		t.Fatal("cleanup fired while batch was still in-flight — would close the transport under it")
+	case <-time.After(100 * time.Millisecond):
+		// expected: cleanup is still waiting
+	}
+
+	// Release the server hang. The goroutine completes, inFlight drains to
+	// zero, cleanup fires.
+	close(release)
+	require.NoError(t, <-sendDone, "in-flight send should complete after release")
+
+	select {
+	case <-cleanupDone:
+		// expected: cleanup fired once the WaitGroup drained
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup never fired after the in-flight batch completed")
+	}
+}
+
+// Decision-path: a config-only reload between an in-flight batch and a
+// transport-rebuild reload must not let the rebuild close a transport that
+// the original state is still using. The fix shares *transportState across
+// config-only reloads so a single inFlight WaitGroup tracks all batches on
+// that transport.
+//
+// Two-step scenario:
+//  1. Init publishes S1 = {cfg1, T1}. Batch A starts on S1, increments
+//     T1.inFlight.
+//  2. Config-only reload publishes S2 = {cfg2, T1} — same *transportState
+//     pointer. Batch A is still running, holding T1.inFlight.
+//  3. Rebuild reload publishes S3 = {cfg3, T2}. The async cleanup goroutine
+//     waits on oldState.transport.inFlight which == T1.inFlight, so it
+//     correctly blocks until batch A finishes before closing T1.
+func TestUpdate_TwoStepReload_TransportSharedAcrossConfigOnly(t *testing.T) {
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+
+	// S1: published by newHTTPTestOutput.
+	s1 := o.state.Load()
+
+	// Simulate batch A starting on S1: take a count on the transport's
+	// inFlight WaitGroup. The (Load, Add) pair would be serialized via
+	// stateMu in production sendBatch; we mirror that here.
+	o.stateMu.Lock()
+	s1.transport.inFlight.Add(1)
+	o.stateMu.Unlock()
+
+	// Config-only reload: same Headers tweak, transport pointer reused.
+	// This matches Update's no-rebuild path and the withCfg helper, both of
+	// which share the *transportState pointer rather than allocating a new
+	// one (which would create a fresh, empty inFlight WaitGroup).
+	cfg2 := *s1.cfg
+	cfg2.Headers = map[string]string{"X-Scope-OrgID": "tenant-config-only"}
+	s2 := &outputState{cfg: &cfg2, transport: s1.transport}
+	o.stateMu.Lock()
+	o.state.Store(s2)
+	o.stateMu.Unlock()
+
+	// Sanity: same transport pointer across S1 and S2.
+	require.Same(t, s1.transport, s2.transport,
+		"config-only reload must share *transportState — not allocate a new one")
+
+	// Rebuild reload: build a new transportState. Cleanup of the old state
+	// must Wait on s1.transport.inFlight (== s2.transport.inFlight), which
+	// is non-zero because batch A is still running.
+	cfg3 := *s2.cfg
+	newHS, err := o.initHTTPFor(&cfg3)
+	require.NoError(t, err)
+	s3 := &outputState{cfg: &cfg3, transport: &transportState{httpState: newHS}}
+
+	o.stateMu.Lock()
+	oldState := o.state.Swap(s3)
+	o.stateMu.Unlock()
+
+	// The rebuild's async cleanup mirrors Update's rebuild path.
+	cleanupDone := make(chan struct{})
+	go func() {
+		oldState.transport.inFlight.Wait()
+		oldState.transport.cleanup()
+		close(cleanupDone)
+	}()
+
+	// Cleanup must be blocked: batch A is still in flight on the shared
+	// transport. With the buggy pre-fix code, oldState (== s2) had a fresh
+	// empty inFlight, Wait() returned immediately, and cleanup tore down T1
+	// while batch A was still using it.
+	select {
+	case <-cleanupDone:
+		t.Fatal("cleanup completed before in-flight batch finished — transport could be closed under an active batch")
+	case <-time.After(50 * time.Millisecond):
+		// good: still blocked
+	}
+
+	// Releasing batch A unblocks cleanup.
+	s1.transport.inFlight.Done()
+	select {
+	case <-cleanupDone:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup never fired after the in-flight batch completed")
+	}
+}
+
+// Security: redirects must never be followed. A redirecting (or compromised)
+// collector could otherwise pull the metrics payload and user-defined headers
+// (which Go forwards cross-host, unlike Authorization) to another origin —
+// 307/308 replay the POST body. CheckRedirect returns ErrUseLastResponse, so
+// the 3xx surfaces as a response and classifies as a permanent error.
+func TestSendHTTP_RedirectNotFollowed(t *testing.T) {
+	var redirectTargetHits atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	var originHits atomic.Int32
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		originHits.Add(1)
+		w.Header().Set("Location", target.URL+"/v1/metrics")
+		w.WriteHeader(http.StatusPermanentRedirect)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	err := o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{})
+	require.Error(t, err)
+
+	var hee *httpExportError
+	require.ErrorAs(t, err, &hee)
+	require.Equal(t, http.StatusPermanentRedirect, hee.status)
+	require.True(t, isPermanentHTTPError(err), "3xx must classify as permanent, not retryable")
+	require.Equal(t, int32(1), originHits.Load(), "origin must receive exactly one request")
+	require.Equal(t, int32(0), redirectTargetHits.Load(), "redirect target must never be contacted")
+}
+
+// Contract: Content-Encoding is protocol-owned in both directions. With
+// compression: none, a user-supplied Content-Encoding (any case — Header.Set
+// canonicalizes) must be stripped, or the raw protobuf body is mislabelled
+// and the collector tries to gunzip it.
+func TestSendHTTP_UserContentEncodingStrippedWhenNoCompression(t *testing.T) {
+	var gotEncoding string
+	var gotBody []byte
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEncoding = r.Header.Get("Content-Encoding")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	withCfg(o, func(c *config) {
+		c.Compression = "none"
+		// lowercase on purpose: canonicalization must not defeat the strip
+		c.Headers = map[string]string{"content-encoding": "gzip"}
+	})
+
+	require.NoError(t, o.sendHTTP(context.Background(), o.state.Load(), &metricsv1.ExportMetricsServiceRequest{}))
+	require.Empty(t, gotEncoding, "user Content-Encoding must be stripped when compression is none")
+	var roundtrip metricsv1.ExportMetricsServiceRequest
+	require.NoError(t, proto.Unmarshal(gotBody, &roundtrip), "body must be raw (uncompressed) protobuf")
+}
+
+// Accounting: PartialSuccess is request-level success — the server durably
+// accepted everything except the rejected points. The batch counts toward
+// sent_events (even when every point was rejected); the loss signal lives in
+// rejected_data_points_total, and failed_events stays untouched. Data-loss
+// alerting must watch the rejected counter, not the sent/failed pair.
+func TestSendBatch_PartialSuccessCountsSent(t *testing.T) {
+	respBody, err := proto.Marshal(&metricsv1.ExportMetricsServiceResponse{
+		PartialSuccess: &metricsv1.ExportMetricsPartialSuccess{
+			RejectedDataPoints: 2,
+			ErrorMessage:       "all points rejected",
+		},
+	})
+	require.NoError(t, err)
+
+	var hits atomic.Int32
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respBody)
+	})
+	defer srv.Close()
+
+	o := newHTTPTestOutput(t, srv)
+	const name = "partial-success-accounting"
+	withCfg(o, func(c *config) {
+		c.EnableMetrics = true
+		c.Name = name
+		c.MaxRetries = 3
+		c.resourceTagSet = map[string]bool{}
+	})
+
+	events := []*formatters.EventMsg{
+		{
+			Name: "test", Timestamp: time.Now().UnixNano(),
+			Tags:   map[string]string{"source": "x"},
+			Values: map[string]interface{}{"a": int64(1)},
+		},
+		{
+			Name: "test", Timestamp: time.Now().UnixNano(),
+			Tags:   map[string]string{"source": "x"},
+			Values: map[string]interface{}{"b": int64(2)},
+		},
+	}
+	o.sendBatch(context.Background(), events)
+
+	require.Equal(t, int32(1), hits.Load(), "partial success must not be retried")
+	require.Equal(t, float64(len(events)),
+		testutil.ToFloat64(otlpNumberOfSentEvents.WithLabelValues(name)),
+		"partially-successful batch must count as sent")
+	require.Equal(t, float64(0),
+		testutil.ToFloat64(otlpNumberOfFailedEvents.WithLabelValues(name, "send_failed")),
+		"partially-successful batch must not count as failed")
+	require.Equal(t, float64(2),
+		testutil.ToFloat64(otlpRejectedDataPoints.WithLabelValues(name)),
+		"rejected points must be counted on the dedicated counter")
+}

--- a/pkg/outputs/otlp_output/otlp_metrics.go
+++ b/pkg/outputs/otlp_output/otlp_metrics.go
@@ -1,4 +1,4 @@
-// © 2025 NVIDIA Corporation
+// © 2025-2026 NVIDIA Corporation
 //
 // This code is a Contribution to the gNMIc project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
 // No other rights or licenses in or to any of NVIDIA's intellectual property are granted for any other purpose.
@@ -38,4 +38,11 @@ var otlpRejectedDataPoints = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "otlp_output",
 	Name:      "rejected_data_points_total",
 	Help:      "Number of data points rejected by OTLP collector (PartialSuccess)",
+}, []string{"output_name"})
+
+var otlpMalformedResponses = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "gnmic",
+	Subsystem: "otlp_output",
+	Name:      "malformed_responses_total",
+	Help:      "Number of 2xx HTTP export responses whose body failed to unmarshal as an OTLP response",
 }, []string{"output_name"})

--- a/pkg/outputs/otlp_output/otlp_output.go
+++ b/pkg/outputs/otlp_output/otlp_output.go
@@ -1021,6 +1021,7 @@ func (o *otlpOutput) registerMetrics(cfg *config) error {
 		otlpNumberOfFailedEvents,
 		otlpSendDuration,
 		otlpRejectedDataPoints,
+		otlpMalformedResponses,
 	}
 	for _, c := range collectors {
 		if err := o.reg.Register(c); err != nil {

--- a/pkg/outputs/otlp_output/otlp_output.go
+++ b/pkg/outputs/otlp_output/otlp_output.go
@@ -14,8 +14,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
 	"regexp"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,12 +43,17 @@ import (
 )
 
 const (
-	outputType        = "otlp"
-	defaultTimeout    = 10 * time.Second
-	defaultBatchSize  = 1000
-	defaultNumWorkers = 1
-	defaultMaxRetries = 3
-	defaultProtocol   = "grpc"
+	outputType             = "otlp"
+	defaultTimeout         = 10 * time.Second
+	defaultBatchSize       = 1000
+	defaultNumWorkers      = 1
+	defaultMaxRetries      = 3
+	defaultProtocol        = "grpc"
+	defaultCompressionHTTP = "gzip" // default-on for protocol: http; gRPC unaffected
+	// maxRetryAfter caps a server-supplied Retry-After to prevent a single bad
+	// response from pinning a worker for arbitrarily long. Operators rebalancing
+	// or upgrading Panoptes occasionally emit large values.
+	maxRetryAfter = 30 * time.Second
 )
 
 func init() {
@@ -58,10 +66,14 @@ func init() {
 type otlpOutput struct {
 	outputs.BaseOutput
 
-	cfg       *atomic.Pointer[config]
-	dynCfg    *atomic.Pointer[dynConfig]
-	grpcState *atomic.Pointer[grpcClientState]
-	eventCh   *atomic.Pointer[chan *formatters.EventMsg]
+	state *atomic.Pointer[outputState]
+	// stateMu serializes the (Load, state.transport.inFlight.Add(1)) pair in
+	// sendBatch with Update's (Swap, start Wait) so we never Add to a
+	// WaitGroup whose Wait has already returned 0. Held briefly — no
+	// contention at gnmic batching rates (1-10 Hz).
+	stateMu sync.Mutex
+	dynCfg  *atomic.Pointer[dynConfig]
+	eventCh *atomic.Pointer[chan *formatters.EventMsg]
 
 	logger   *slog.Logger
 	rootCtx  context.Context
@@ -69,9 +81,68 @@ type otlpOutput struct {
 	wg       *sync.WaitGroup
 
 	// Metrics
-	reg *prometheus.Registry
+	reg               *prometheus.Registry
+	registeredMetrics []prometheus.Collector // collectors this instance successfully registered
 	// store
 	store store.Store[any]
+}
+
+// transportState owns the protocol-level connection (gRPC conn or HTTP
+// Transport) and the inFlight WaitGroup that tracks every batch currently
+// using it. It is held by outputState through a pointer so a config-only
+// reload can publish a new outputState that shares the same transportState
+// — every concurrent batch, regardless of which outputState revision it
+// captured, increments the same inFlight. A subsequent rebuild reload
+// allocates a new transportState; cleanup of the old transportState
+// blocks on its inFlight before closing the underlying conn/Transport,
+// so an active batch can never observe a torn-down transport.
+//
+// transportState contains a sync.WaitGroup, so it must never be copied —
+// only passed/stored as *transportState.
+type transportState struct {
+	grpcState *grpcClientState // nil when protocol != grpc
+	httpState *httpClientState // nil when protocol != http
+
+	// inFlight tracks every concurrent user of this transport, across all
+	// outputStates that share this *transportState. sendBatch increments
+	// under stateMu before unlocking; Done() fires from a defer. Cleanup
+	// (in Update's rebuild path and Close) Waits on this before closing
+	// conn/Transport.
+	inFlight sync.WaitGroup
+}
+
+// cleanup releases the transport-level resources held here.
+// Safe on a nil receiver and on a transportState whose protocol-specific
+// fields are already nil.
+func (t *transportState) cleanup() {
+	if t == nil {
+		return
+	}
+	if t.grpcState != nil && t.grpcState.conn != nil {
+		_ = t.grpcState.conn.Close()
+	}
+	if t.httpState != nil && t.httpState.client != nil {
+		if tr, ok := t.httpState.client.Transport.(*http.Transport); ok {
+			tr.CloseIdleConnections()
+		}
+	}
+}
+
+// outputState bundles the consistent (cfg, transport) tuple. Workers Load()
+// this once at the top of sendBatch and dispatch against the snapshot — a
+// concurrent Update() that swaps protocol cannot tear the pair, eliminating
+// the "X client not initialized" race when a worker raced cfg.Load against
+// transport-pointer Swap.
+//
+// Config-only reloads share the same *transportState pointer with the
+// previous outputState; only a transport-rebuild reload allocates a new
+// transportState. This guarantees that the inFlight WaitGroup which
+// cleanup waits on really does account for every batch in flight on
+// that transport, regardless of how many config-only reloads were layered
+// on top of it.
+type outputState struct {
+	cfg       *config
+	transport *transportState
 }
 
 type dynConfig struct {
@@ -101,6 +172,11 @@ type config struct {
 	BatchSize  int           `mapstructure:"batch-size,omitempty"`
 	Interval   time.Duration `mapstructure:"interval,omitempty"`
 	BufferSize int           `mapstructure:"buffer-size,omitempty"`
+
+	// Compression applied to the HTTP request body. Only honored when protocol: http.
+	// Valid values: "none", "gzip". Defaults to "gzip" when protocol is "http".
+	// The gRPC path ignores this field.
+	Compression string `mapstructure:"compression,omitempty"`
 
 	// Retry
 	MaxRetries int `mapstructure:"max-retries,omitempty"`
@@ -154,21 +230,68 @@ type config struct {
 }
 
 func (o *otlpOutput) initFields() {
-	o.cfg = new(atomic.Pointer[config])
+	o.state = new(atomic.Pointer[outputState])
 	o.dynCfg = new(atomic.Pointer[dynConfig])
-	o.grpcState = new(atomic.Pointer[grpcClientState])
 	o.eventCh = new(atomic.Pointer[chan *formatters.EventMsg])
 	o.wg = new(sync.WaitGroup)
 	o.logger = logging.DiscardLogger()
 }
 
+// loadCfg returns the currently-published config, or nil if state was never
+// stored. Centralizing the deref protects against a nil state.Load() in
+// places (such as String) that may be called pre-Init in tests.
+func (o *otlpOutput) loadCfg() *config {
+	if s := o.state.Load(); s != nil {
+		return s.cfg
+	}
+	return nil
+}
+
 func (o *otlpOutput) String() string {
-	cfg := o.cfg.Load()
+	cfg := o.loadCfg()
+	// Redact header values: operators put credentials in Headers (the docs
+	// recommend "Authorization: Bearer <token>"), and String() output lands
+	// in the reload log at Info level. Key names stay visible for debugging;
+	// values never do. The copy leaves the live config untouched.
+	if cfg != nil && len(cfg.Headers) > 0 {
+		redacted := *cfg
+		redacted.Headers = make(map[string]string, len(cfg.Headers))
+		for k := range cfg.Headers {
+			redacted.Headers[k] = "***"
+		}
+		cfg = &redacted
+	}
 	b, err := json.Marshal(cfg)
 	if err != nil {
 		return ""
 	}
 	return string(b)
+}
+
+// buildOutputState constructs an outputState for the given config. The error
+// path is exclusively transport-init failures; callers handle protocol-level
+// validation upstream via validateConfig.
+func (o *otlpOutput) buildOutputState(cfg *config) (*outputState, error) {
+	t := &transportState{}
+	switch cfg.Protocol {
+	case "grpc":
+		gs, err := o.initGRPCFor(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize gRPC transport: %w", err)
+		}
+		t.grpcState = gs
+	case "http":
+		hs, err := o.initHTTPFor(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize HTTP transport: %w", err)
+		}
+		t.httpState = hs
+	default:
+		// unreachable: validateConfig rejects this earlier. Kept as a
+		// defensive belt-and-suspenders to mirror Init's old switch.
+		return nil, fmt.Errorf("unsupported protocol %q: must be 'grpc' or 'http'", cfg.Protocol)
+	}
+	return &outputState{cfg: cfg, transport: t}, nil
 }
 
 // Init initializes the OTLP output
@@ -204,16 +327,22 @@ func (o *otlpOutput) Init(ctx context.Context, name string, cfg map[string]inter
 	// Apply logger
 	o.logger = outputs.BindLogger(options.Logger, outputType, ncfg.Name)
 
-	o.cfg.Store(ncfg)
-
-	// Initialize registry
+	// Initialize registry and register metrics (no transport open yet).
 	o.reg = options.Registry
-	err = o.registerMetrics()
-	if err != nil {
+	if err := o.registerMetrics(ncfg); err != nil {
 		return err
 	}
 
-	// Initialize event processors
+	// From this point on, any error must unregister the collectors we just
+	// registered; otherwise a retry of Init will hit "duplicate registration".
+	initSucceeded := false
+	defer func() {
+		if !initSucceeded {
+			o.unregisterMetrics()
+		}
+	}()
+
+	// Build event processors (no transport open yet).
 	dc := new(dynConfig)
 	dc.evps, err = o.buildEventProcessors(ncfg)
 	if err != nil {
@@ -221,21 +350,16 @@ func (o *otlpOutput) Init(ctx context.Context, name string, cfg map[string]inter
 	}
 	o.dynCfg.Store(dc)
 
-	// Initialize transport
-	switch ncfg.Protocol {
-	case "grpc":
-		gs, err := o.initGRPCFor(ncfg)
-		if err != nil {
-			return fmt.Errorf("failed to initialize gRPC transport: %w", err)
-		}
-		o.grpcState.Store(gs)
-	case "http":
-		return fmt.Errorf("HTTP transport not yet implemented")
-	default:
-		return fmt.Errorf("unsupported protocol '%s': must be 'grpc' or 'http'", ncfg.Protocol)
+	// Build and publish the outputState (cfg + transport). This is the last
+	// resource-allocating step that can fail; if buildOutputState succeeds,
+	// Init succeeds (worker startup below cannot fail).
+	state, err := o.buildOutputState(ncfg)
+	if err != nil {
+		return err
 	}
+	o.state.Store(state)
 
-	// Initialize worker channels
+	// Initialize worker channels and start workers.
 	eventCh := make(chan *formatters.EventMsg, ncfg.BufferSize)
 	o.eventCh.Store(&eventCh)
 
@@ -245,11 +369,12 @@ func (o *otlpOutput) Init(ctx context.Context, name string, cfg map[string]inter
 	wctx, o.cancelFn = context.WithCancel(o.rootCtx)
 	o.wg.Add(ncfg.NumWorkers)
 	for i := 0; i < ncfg.NumWorkers; i++ {
-		go o.worker(wctx, i)
+		go o.worker(wctx, i, o.wg)
 	}
 
 	o.logger.Info("initialized OTLP output", "endpoint", ncfg.Endpoint, "protocol", ncfg.Protocol, "batch-size", ncfg.BatchSize, "workers", ncfg.NumWorkers)
 
+	initSucceeded = true
 	return nil
 }
 
@@ -265,13 +390,18 @@ func (o *otlpOutput) Update(ctx context.Context, cfg map[string]any) error {
 		return err
 	}
 
-	currCfg := o.cfg.Load()
+	currState := o.state.Load()
+	var currCfg *config
+	if currState != nil {
+		currCfg = currState.cfg
+	}
 
 	swapChannel := channelNeedsSwap(currCfg, newCfg)
 	restartWorkers := needsWorkerRestart(currCfg, newCfg)
-	rebuildGRPC := needsGRPCRebuild(currCfg, newCfg)
-	rebuildProcessors := slices.Compare(currCfg.EventProcessors, newCfg.EventProcessors) != 0
+	rebuildTransport := needsTransportRebuild(currCfg, newCfg)
+	rebuildProcessors := currCfg == nil || slices.Compare(currCfg.EventProcessors, newCfg.EventProcessors) != 0
 
+	// Build the new dynamic config into a local — do NOT publish yet.
 	dc := new(dynConfig)
 	prevDC := o.dynCfg.Load()
 	if rebuildProcessors {
@@ -282,20 +412,63 @@ func (o *otlpOutput) Update(ctx context.Context, cfg map[string]any) error {
 	} else if prevDC != nil {
 		dc.evps = prevDC.evps
 	}
-	o.dynCfg.Store(dc)
 
-	if rebuildGRPC {
-		gs, err := o.initGRPCFor(newCfg)
+	// Build the new transport into a local if a rebuild is needed — also do
+	// NOT publish yet. All fallible work must complete before any state is
+	// applied so that no error path leaves dynCfg or state mid-update.
+	//
+	// Publish the new outputState atomically. Two paths:
+	//   1) needsTransportRebuild → build a fresh transport and Swap. Workers
+	//      holding the old state reference can finish their batches; we
+	//      Wait() on the old state's inFlight WaitGroup before cleanup so
+	//      teardown happens after the last in-flight user — regardless of
+	//      Timeout × (MaxRetries+1) + maxRetryAfter.
+	//   2) Otherwise (e.g. batch-size, resource-tag-keys) → reuse the
+	//      transport pointers from the old state. No close, no rebuild.
+	var newState *outputState
+	if rebuildTransport {
+		newState, err = o.buildOutputState(newCfg)
 		if err != nil {
-			return fmt.Errorf("failed to rebuild gRPC transport: %w", err)
-		}
-		oldState := o.grpcState.Swap(gs)
-		if oldState != nil && oldState.conn != nil {
-			oldState.conn.Close()
+			return fmt.Errorf("failed to build new transport state: %w", err)
 		}
 	}
 
-	o.cfg.Store(newCfg)
+	// All fallible work is done. Publish dynCfg first, then the new outputState.
+	o.dynCfg.Store(dc)
+
+	if rebuildTransport {
+		o.stateMu.Lock()
+		oldState := o.state.Swap(newState)
+		o.stateMu.Unlock()
+		// Cleanup waits for actual in-flight users to drain — no wall-clock
+		// guess. inFlight lives on transportState, so it accounts for every
+		// batch using this transport across any config-only reloads that
+		// were layered on top of it. After they all complete (Done fires),
+		// the WaitGroup unblocks and we close the underlying transport.
+		// Run async so Update returns promptly. Swap returns nil if Update
+		// races Init (defensive — reachable through some test paths).
+		if oldState != nil {
+			go func() {
+				oldState.transport.inFlight.Wait()
+				oldState.transport.cleanup()
+			}()
+		}
+	} else {
+		// Cfg-only change. Share the *transportState pointer with the
+		// previous state so a single inFlight WaitGroup tracks every batch
+		// using this transport across all config-only reloads.
+		// nil-currState is unreachable in practice (needsTransportRebuild
+		// returns true on nil, taking the rebuild branch above); the guard
+		// below is defensive.
+		nextState := &outputState{cfg: newCfg}
+		if currState != nil {
+			nextState.transport = currState.transport
+		}
+		o.stateMu.Lock()
+		o.state.Store(nextState)
+		o.stateMu.Unlock()
+		// No cleanup — the transport is still live and shared with nextState.
+	}
 
 	if swapChannel || restartWorkers {
 		var newChan chan *formatters.EventMsg
@@ -316,9 +489,9 @@ func (o *otlpOutput) Update(ctx context.Context, cfg map[string]any) error {
 		o.wg = newWG
 		o.eventCh.Store(&newChan)
 
-		o.wg.Add(newCfg.NumWorkers)
+		newWG.Add(newCfg.NumWorkers)
 		for i := 0; i < newCfg.NumWorkers; i++ {
-			go o.worker(runCtx, i)
+			go o.worker(runCtx, i, newWG)
 		}
 
 		if oldCancel != nil {
@@ -362,7 +535,7 @@ func (o *otlpOutput) Validate(cfg map[string]any) error {
 }
 
 func (o *otlpOutput) UpdateProcessor(name string, pcfg map[string]any) error {
-	cfg := o.cfg.Load()
+	cfg := o.loadCfg()
 	dc := o.dynCfg.Load()
 
 	newEvps, changed, err := outputs.UpdateProcessorInSlice(
@@ -391,9 +564,12 @@ func (o *otlpOutput) Write(ctx context.Context, rsp proto.Message, meta outputs.
 		return
 	}
 
-	cfg := o.cfg.Load()
+	cfg := o.loadCfg()
 	dc := o.dynCfg.Load()
-	if dc == nil {
+	if cfg == nil || dc == nil {
+		// nil cfg means Close already ran (state swapped to nil) or Init
+		// never did — either way this write has nowhere to go. Drop it
+		// rather than dereferencing nil on the channel-full path below.
 		return
 	}
 
@@ -438,7 +614,11 @@ func (o *otlpOutput) WriteEvent(ctx context.Context, ev *formatters.EventMsg) {
 		return
 	}
 
-	cfg := o.cfg.Load()
+	cfg := o.loadCfg()
+	if cfg == nil {
+		// Close already ran (or Init never did) — drop, see Write.
+		return
+	}
 	eventCh := *o.eventCh.Load()
 
 	select {
@@ -453,42 +633,64 @@ func (o *otlpOutput) WriteEvent(ctx context.Context, ev *formatters.EventMsg) {
 	}
 }
 
-// Close closes the OTLP output
+// Close closes the OTLP output. Safe to call multiple times.
 func (o *otlpOutput) Close() error {
 	if o.cancelFn != nil {
 		o.cancelFn()
+		o.cancelFn = nil
 	}
 
-	// Close event channel
-	eventCh := o.eventCh.Load()
-	if eventCh != nil {
-		close(*eventCh)
-	}
+	// Deliberately do NOT close the event channel: the outputs manager
+	// dispatches Write/WriteEvent goroutines without synchronizing against
+	// Close, and a send on a closed channel panics the whole process (a
+	// select with a default case does not protect against that). Workers
+	// exit via the context cancellation above; the channel stays live so a
+	// straggling producer just fills the buffer and falls into the
+	// non-blocking drop path in Write/WriteEvent.
 
 	// Wait for workers to finish
 	o.wg.Wait()
 
-	// Close gRPC connection
-	gs := o.grpcState.Load()
-	if gs != nil && gs.conn != nil {
-		return gs.conn.Close()
+	// Cleanup transport state. By this point all workers have exited
+	// (wg.Wait returned), so no goroutine holds an outputState reference —
+	// the transport's inFlight has already drained to zero. The lock around
+	// the Swap preserves the same invariant Update relies on (no Add can
+	// race a Wait), protecting any future code path that holds state
+	// without going through sendBatch. cleanup() handles a nil receiver
+	// and a transportState whose protocol-specific fields are already nil,
+	// so the post-initFields pre-Init shape is also safe.
+	o.stateMu.Lock()
+	oldState := o.state.Swap(nil)
+	o.stateMu.Unlock()
+	if oldState != nil {
+		oldState.transport.inFlight.Wait()
+		oldState.transport.cleanup()
 	}
 
+	o.unregisterMetrics()
 	return nil
 }
 
-// worker processes events in batches
-func (o *otlpOutput) worker(ctx context.Context, id int) {
-	defer o.wg.Done()
+// worker processes events in batches.
+// wg is passed explicitly (rather than read from o.wg) so each goroutine
+// captures its own WaitGroup pointer at spawn time. Update swaps o.wg when
+// num-workers/batch-size/interval change; reading o.wg from the worker
+// would race that swap and could land Done() on the wrong WaitGroup.
+func (o *otlpOutput) worker(ctx context.Context, id int, wg *sync.WaitGroup) {
+	defer wg.Done()
 
-	cfg := o.cfg.Load()
+	cfg := o.loadCfg()
 	o.logger.Debug("worker started", "worker", id)
 
 	batch := make([]*formatters.EventMsg, 0, cfg.BatchSize)
 	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()
 
-	eventCh := *o.eventCh.Load()
+	chPtr := o.eventCh.Load()
+	if chPtr == nil {
+		return
+	}
+	eventCh := *chPtr
 
 	for {
 		select {
@@ -531,26 +733,80 @@ func (o *otlpOutput) sendBatch(ctx context.Context, events []*formatters.EventMs
 		return
 	}
 
-	cfg := o.cfg.Load()
+	// Single Load() at the top of the batch — workers dispatch against this
+	// snapshot for every retry attempt. A concurrent Update() that swaps
+	// protocol cannot tear the (cfg, transport) pair: this batch finishes
+	// against the captured state, and the old transport stays alive until
+	// the in-flight WaitGroup drains (see Update's rebuild path).
+	//
+	// The (Load, Add) pair must be serialized against Update's (Swap, Wait)
+	// via stateMu so we never Add to a WaitGroup whose Wait has already
+	// returned 0 (which would panic per sync.WaitGroup contract).
+	o.stateMu.Lock()
+	state := o.state.Load()
+	state.transport.inFlight.Add(1)
+	o.stateMu.Unlock()
+	defer state.transport.inFlight.Done()
+	cfg := state.cfg
 	start := time.Now()
 
-	req := o.convertToOTLP(events)
+	req := o.convertToOTLP(cfg, events)
 
 	var err error
+retry:
 	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
-		err = o.sendGRPC(ctx, req)
+		switch cfg.Protocol {
+		case "grpc":
+			err = o.sendGRPC(ctx, state, req)
+		case "http":
+			err = o.sendHTTP(ctx, state, req)
+		default:
+			// Init's transport switch rejects unsupported protocols at startup,
+			// and Task 8 adds the same guard to validateConfig (so reload is also
+			// covered). This default is the last line of defense — log and abort
+			// immediately rather than spinning MaxRetries on an error that
+			// cannot resolve itself.
+			o.logger.Error("unsupported protocol, aborting batch", "protocol", cfg.Protocol)
+			err = fmt.Errorf("unsupported protocol %q", cfg.Protocol)
+			break retry
+		}
 
 		if err == nil {
 			o.logger.Debug("successfully sent events", "count", len(events), "attempt", attempt+1)
-			if cfg.EnableMetrics {
-				otlpNumberOfSentEvents.WithLabelValues(cfg.Name).Add(float64(len(events)))
-				otlpSendDuration.WithLabelValues(cfg.Name).Observe(time.Since(start).Seconds())
-			}
+			o.recordBatchSent(cfg, len(events), start)
 			return
 		}
 
+		// PartialSuccess means the server accepted the request and durably
+		// stored everything except the rejected points, which were already
+		// counted in otlpRejectedDataPoints and logged at the response site.
+		// The batch counts as sent (request-level accounting); retrying would
+		// duplicate the accepted points. Data-loss monitoring belongs on the
+		// rejected-data-points counter, not the sent/failed pair.
+		if isPartialSuccessError(err) {
+			o.recordBatchSent(cfg, len(events), start)
+			return
+		}
+
+		// Permanent HTTP errors (non-retryable status codes) abort the loop.
+		if isPermanentHTTPError(err) {
+			o.logger.Debug("permanent error, not retrying", "err", err)
+			break
+		}
+
 		if attempt < cfg.MaxRetries {
-			time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+			sleep := effectiveRetrySleep(cfg.Protocol, attempt, retryAfterFromError(err), maxRetryAfter)
+			// Use a select on ctx.Done so Close()/cancellation can interrupt a long
+			// Retry-After or backoff sleep instead of pinning the worker.
+			select {
+			case <-time.After(sleep):
+			case <-ctx.Done():
+				// Cancelled mid-retry (worker restart or Close). Fall through
+				// to the failure path so the dropped batch is logged and
+				// counted rather than silently lost from the accounting.
+				err = ctx.Err()
+				break retry
+			}
 		}
 	}
 
@@ -558,6 +814,18 @@ func (o *otlpOutput) sendBatch(ctx context.Context, events []*formatters.EventMs
 	if cfg.EnableMetrics {
 		otlpNumberOfFailedEvents.WithLabelValues(cfg.Name, "send_failed").Add(float64(len(events)))
 	}
+}
+
+// recordBatchSent counts a batch as delivered and observes the send duration.
+// Shared by the full-success and partial-success paths in sendBatch so the
+// two cannot drift apart; in the partial case the loss is accounted
+// separately in otlpRejectedDataPoints.
+func (o *otlpOutput) recordBatchSent(cfg *config, count int, start time.Time) {
+	if !cfg.EnableMetrics {
+		return
+	}
+	otlpNumberOfSentEvents.WithLabelValues(cfg.Name).Add(float64(count))
+	otlpSendDuration.WithLabelValues(cfg.Name).Observe(time.Since(start).Seconds())
 }
 
 func (o *otlpOutput) setDefaultsFor(c *config) {
@@ -576,6 +844,9 @@ func (o *otlpOutput) setDefaultsFor(c *config) {
 	if c.Protocol == "" {
 		c.Protocol = defaultProtocol
 	}
+	if c.Protocol == "http" && c.Compression == "" {
+		c.Compression = defaultCompressionHTTP
+	}
 	if c.Name == "" {
 		c.Name = "gnmic-otlp-" + uuid.New().String()
 	}
@@ -592,8 +863,46 @@ func (o *otlpOutput) setDefaultsFor(c *config) {
 }
 
 func (o *otlpOutput) validateConfig(c *config) error {
+	switch c.Protocol {
+	case "grpc", "http":
+		// ok — setDefaultsFor populates "" → "grpc" before we get here
+	default:
+		return fmt.Errorf("unsupported protocol %q: must be 'grpc' or 'http'", c.Protocol)
+	}
+	switch c.Compression {
+	case "", "none", "gzip":
+		// ok ("" remains valid for grpc protocol where the field is ignored)
+	default:
+		return fmt.Errorf("invalid compression %q: must be one of 'none' or 'gzip'", c.Compression)
+	}
 	if c.Endpoint == "" {
 		return fmt.Errorf("endpoint is required")
+	}
+	// Numeric bounds. validateConfig runs after setDefaultsFor, so zero
+	// values have already been replaced by defaults — anything non-positive
+	// here is an explicit operator error. Without these checks a negative
+	// value panics at runtime: buffer-size in make(chan) and num-workers in
+	// wg.Add at Init; batch-size in make([]) and interval in time.NewTicker
+	// inside the worker goroutine, where an unrecovered panic kills the
+	// whole process. Negative timeout silently disables deadlines and
+	// negative max-retries silently drops every batch.
+	if c.Timeout <= 0 {
+		return fmt.Errorf("invalid timeout %s: must be positive", c.Timeout)
+	}
+	if c.BatchSize <= 0 {
+		return fmt.Errorf("invalid batch-size %d: must be positive", c.BatchSize)
+	}
+	if c.Interval <= 0 {
+		return fmt.Errorf("invalid interval %s: must be positive", c.Interval)
+	}
+	if c.BufferSize <= 0 {
+		return fmt.Errorf("invalid buffer-size %d: must be positive", c.BufferSize)
+	}
+	if c.NumWorkers <= 0 {
+		return fmt.Errorf("invalid num-workers %d: must be positive", c.NumWorkers)
+	}
+	if c.MaxRetries < 0 {
+		return fmt.Errorf("invalid max-retries %d: must not be negative", c.MaxRetries)
 	}
 	c.counterRegexes = make([]*regexp.Regexp, 0, len(c.CounterPatterns))
 	for _, p := range c.CounterPatterns {
@@ -615,6 +924,23 @@ func (o *otlpOutput) buildEventProcessors(cfg *config) ([]formatters.EventProces
 }
 
 func (o *otlpOutput) initGRPCFor(cfg *config) (*grpcClientState, error) {
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+
+	// Reject bare host-only endpoints with no port. Forms with an explicit
+	// scheme like "dns:///host:port" or "unix:///path" pass through to
+	// grpc.NewClient, which has its own resolver semantics. The bare form is
+	// strictly host:port — silent fall-through to grpc's default resolver
+	// behavior on a missing port surprises operators who omitted it.
+	if !strings.Contains(endpoint, "://") {
+		host, port, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("bare gRPC endpoint %q must be host:port: %w", endpoint, err)
+		}
+		if host == "" || port == "" {
+			return nil, fmt.Errorf("bare gRPC endpoint %q must be host:port (e.g. host:4317)", endpoint)
+		}
+	}
+
 	var opts []grpc.DialOption
 
 	if cfg.TLS != nil {
@@ -627,7 +953,7 @@ func (o *otlpOutput) initGRPCFor(cfg *config) (*grpcClientState, error) {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
-	conn, err := grpc.NewClient(cfg.Endpoint, opts...)
+	conn, err := grpc.NewClient(endpoint, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OTLP client: %w", err)
 	}
@@ -658,8 +984,23 @@ func (o *otlpOutput) createTLSConfigFor(cfg *config) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func (o *otlpOutput) registerMetrics() error {
-	cfg := o.cfg.Load()
+// unregisterMetrics removes only the collectors this instance successfully
+// registered. Safe on partial registration and safe to call when EnableMetrics
+// is false or o.reg is nil. Used both:
+//   - inside registerMetrics to roll back a partial registration on failure
+//   - in Init's deferred cleanup path when a later step fails after registerMetrics succeeded
+//   - in Close to free the collectors so a future Init on the same registry works
+func (o *otlpOutput) unregisterMetrics() {
+	if o.reg == nil {
+		return
+	}
+	for _, c := range o.registeredMetrics {
+		o.reg.Unregister(c)
+	}
+	o.registeredMetrics = nil
+}
+
+func (o *otlpOutput) registerMetrics(cfg *config) error {
 	if !cfg.EnableMetrics {
 		return nil
 	}
@@ -668,19 +1009,27 @@ func (o *otlpOutput) registerMetrics() error {
 		return nil
 	}
 
-	if err := o.reg.Register(otlpNumberOfSentEvents); err != nil {
-		return err
+	success := false
+	defer func() {
+		if !success {
+			o.unregisterMetrics()
+		}
+	}()
+
+	collectors := []prometheus.Collector{
+		otlpNumberOfSentEvents,
+		otlpNumberOfFailedEvents,
+		otlpSendDuration,
+		otlpRejectedDataPoints,
 	}
-	if err := o.reg.Register(otlpNumberOfFailedEvents); err != nil {
-		return err
-	}
-	if err := o.reg.Register(otlpSendDuration); err != nil {
-		return err
-	}
-	if err := o.reg.Register(otlpRejectedDataPoints); err != nil {
-		return err
+	for _, c := range collectors {
+		if err := o.reg.Register(c); err != nil {
+			return err
+		}
+		o.registeredMetrics = append(o.registeredMetrics, c)
 	}
 
+	success = true
 	return nil
 }
 
@@ -702,11 +1051,12 @@ func needsWorkerRestart(old, nw *config) bool {
 		old.Interval != nw.Interval
 }
 
-func needsGRPCRebuild(old, nw *config) bool {
+func needsTransportRebuild(old, nw *config) bool {
 	if old == nil || nw == nil {
 		return true
 	}
 	return old.Endpoint != nw.Endpoint ||
 		old.Protocol != nw.Protocol ||
+		old.Compression != nw.Compression ||
 		!old.TLS.Equal(nw.TLS)
 }

--- a/pkg/outputs/otlp_output/otlp_output_test.go
+++ b/pkg/outputs/otlp_output/otlp_output_test.go
@@ -9,19 +9,26 @@
 package otlp_output
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"io"
 	"net"
+	"net/http"
 	"regexp"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metricsv1 "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/logging"
@@ -41,8 +48,8 @@ func newTestOutput(cfg *config) *otlpOutput {
 		cfg.counterRegexes = append(cfg.counterRegexes, regexp.MustCompile(p))
 	}
 	o := &otlpOutput{}
-	o.cfg = new(atomic.Pointer[config])
-	o.cfg.Store(cfg)
+	o.state = new(atomic.Pointer[outputState])
+	o.state.Store(&outputState{cfg: cfg, transport: &transportState{}})
 	o.logger = logging.DiscardLogger()
 	return o
 }
@@ -69,7 +76,7 @@ func TestOTLP_MessageStructure(t *testing.T) {
 	output := newTestOutput(&config{
 		Endpoint: "localhost:4317",
 	})
-	otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+	otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 	// Then: Should have proper OTLP structure
 	require.NotNil(t, otlpMetrics)
@@ -106,7 +113,7 @@ func TestOTLP_ResourceAttributes(t *testing.T) {
 
 	// When: Converting to OTLP
 	output := newTestOutput(&config{})
-	otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+	otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 	// Then: Resource attributes should match metadata
 	resource := otlpMetrics.ResourceMetrics[0].Resource
@@ -136,7 +143,7 @@ func TestOTLP_PathKeysAsAttributes(t *testing.T) {
 
 	// When: Converting to OTLP
 	output := newTestOutput(&config{})
-	otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+	otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 	// Then: Path key becomes attribute
 	dataPoint := otlpMetrics.ResourceMetrics[0].ScopeMetrics[0].Metrics[0].GetSum().DataPoints[0]
@@ -188,7 +195,7 @@ func TestOTLP_MetricTypeDetection(t *testing.T) {
 			}
 
 			output := newTestOutput(&config{})
-			otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+			otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 			metric := otlpMetrics.ResourceMetrics[0].ScopeMetrics[0].Metrics[0]
 
 			switch tt.expectedType {
@@ -202,7 +209,11 @@ func TestOTLP_MetricTypeDetection(t *testing.T) {
 	}
 }
 
-func TestOTLP_InitCompilesCounterPatterns(t *testing.T) {
+// Renamed from TestOTLP_InitCompilesCounterPatterns: upstream carries two
+// tests with that name (one here, one near the end of the file) from the
+// #886/#887 merge; this one keeps the end-to-end conversion angle under a
+// distinct name.
+func TestOTLP_InitCounterPatternsClassifyAsSum(t *testing.T) {
 	server, endpoint := startMockOTLPServer(t)
 	defer server.Stop()
 
@@ -222,7 +233,7 @@ func TestOTLP_InitCompilesCounterPatterns(t *testing.T) {
 	require.NoError(t, err)
 	defer output.Close()
 
-	stored := output.cfg.Load()
+	stored := output.loadCfg()
 	require.Len(t, stored.counterRegexes, 2)
 
 	event := &formatters.EventMsg{
@@ -235,7 +246,7 @@ func TestOTLP_InitCompilesCounterPatterns(t *testing.T) {
 			"/interfaces/interface/state/counters/out-octets": int64(1000),
 		},
 	}
-	otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+	otlpMetrics := output.convertToOTLP(stored, []*formatters.EventMsg{event})
 	require.NotNil(t, otlpMetrics)
 	require.Len(t, otlpMetrics.ResourceMetrics, 1)
 	metric := otlpMetrics.ResourceMetrics[0].ScopeMetrics[0].Metrics[0]
@@ -353,7 +364,7 @@ func TestOTLP_StringValuesAsAttributes(t *testing.T) {
 
 	// When: Converting with strings-as-attributes enabled
 	output := newTestOutput(&config{StringsAsAttributes: true})
-	otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+	otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 	// Then: Should create gauge with value=1 and status as attribute
 	metric := otlpMetrics.ResourceMetrics[0].ScopeMetrics[0].Metrics[0]
@@ -385,7 +396,7 @@ func TestOTLP_SubscriptionNameMapping(t *testing.T) {
 
 	// When: Converting with append-subscription-name enabled
 	output := newTestOutput(&config{AppendSubscriptionName: true})
-	otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+	otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 	// Then: subscription_name should be in attributes
 	dataPoint := otlpMetrics.ResourceMetrics[0].ScopeMetrics[0].Metrics[0].GetSum().DataPoints[0]
@@ -910,7 +921,7 @@ func TestOTLP_ResourceTagKeys(t *testing.T) {
 			output := newTestOutput(&config{
 				ResourceTagKeys: tt.resourceTagKeys,
 			})
-			otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+			otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 			require.NotNil(t, otlpMetrics)
 			require.Len(t, otlpMetrics.ResourceMetrics, 1)
@@ -996,7 +1007,7 @@ func TestOTLP_ResourceAttributesBehavior(t *testing.T) {
 			output := newTestOutput(&config{
 				ResourceTagKeys: tt.resourceTagKeys,
 			})
-			otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+			otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 			require.NotNil(t, otlpMetrics)
 			resource := otlpMetrics.ResourceMetrics[0].Resource
@@ -1033,7 +1044,7 @@ func TestOTLP_ConfiguredResourceAttributesAlwaysIncluded(t *testing.T) {
 			"service.version": "0.42.0",
 		},
 	})
-	otlpMetrics := output.convertToOTLP([]*formatters.EventMsg{event})
+	otlpMetrics := output.convertToOTLP(output.state.Load().cfg, []*formatters.EventMsg{event})
 
 	resource := otlpMetrics.ResourceMetrics[0].Resource
 	resourceAttrs := extractAttributesMap(resource.Attributes)
@@ -1058,7 +1069,9 @@ func TestOTLP_InitSucceedsWithUnreachableEndpoint(t *testing.T) {
 	)
 	assert.NoError(t, err, "Init should succeed even with unreachable endpoint")
 
-	gs := output.grpcState.Load()
+	state := output.state.Load()
+	require.NotNil(t, state, "outputState should be created")
+	gs := state.transport.grpcState
 	assert.NotNil(t, gs, "gRPC state should be created")
 	assert.NotNil(t, gs.conn, "gRPC connection should be created")
 	assert.NotNil(t, gs.client, "gRPC client should be created")
@@ -1257,7 +1270,7 @@ func TestOTLP_InitCompilesCounterPatterns(t *testing.T) {
 	require.NoError(t, err, "Init should succeed with valid counter-patterns")
 	defer output.Close()
 
-	stored := output.cfg.Load()
+	stored := output.loadCfg()
 	require.NotNil(t, stored)
 	require.NotNil(t, stored.counterRegexes, "counterRegexes should be compiled by Init")
 	assert.Len(t, stored.counterRegexes, 2)
@@ -1283,7 +1296,7 @@ func TestOTLP_InitEmptyCounterPatterns(t *testing.T) {
 	require.NoError(t, err)
 	defer output.Close()
 
-	stored := output.cfg.Load()
+	stored := output.loadCfg()
 	require.NotNil(t, stored)
 	require.NotNil(t, stored.counterRegexes)
 	assert.Len(t, stored.counterRegexes, 0)
@@ -1307,6 +1320,76 @@ func TestOTLP_InitInvalidCounterPattern(t *testing.T) {
 	assert.Error(t, err, "Init should fail on an invalid counter-pattern")
 }
 
+// Decision-path: PartialSuccess on gRPC must NOT be retried (parity with HTTP).
+// Drives the public sendBatch path through the gRPC mock server.
+func TestSendBatch_GRPCPartialSuccessNotRetried(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	mock := &mockPartialSuccessServer{rejected: 5}
+	metricsv1.RegisterMetricsServiceServer(server, mock)
+	go server.Serve(listener)
+	defer server.Stop()
+
+	o := &otlpOutput{}
+	cfgMap := map[string]interface{}{
+		"type":        "otlp",
+		"endpoint":    listener.Addr().String(),
+		"protocol":    "grpc",
+		"max-retries": 5,
+		"timeout":     "2s",
+		"batch-size":  1,
+		"interval":    "50ms",
+	}
+	require.NoError(t, o.Init(context.Background(), "test-otlp", cfgMap,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	event := &formatters.EventMsg{
+		Name:      "test",
+		Timestamp: time.Now().UnixNano(),
+		Tags:      map[string]string{"source": "10.1.1.1:6030"},
+		Values:    map[string]interface{}{"value": int64(1)},
+	}
+	o.WriteEvent(context.Background(), event)
+
+	// Poll up to 1s for at least one Export call.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if mock.callCount() > 0 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	// Give a generous additional 200ms to detect any retry.
+	time.Sleep(200 * time.Millisecond)
+
+	require.Equal(t, int32(1), mock.callCount(), "gRPC PartialSuccess must not retry")
+}
+
+type mockPartialSuccessServer struct {
+	metricsv1.UnimplementedMetricsServiceServer
+	rejected int64
+	calls    atomic.Int32
+}
+
+func (m *mockPartialSuccessServer) Export(ctx context.Context, req *metricsv1.ExportMetricsServiceRequest) (*metricsv1.ExportMetricsServiceResponse, error) {
+	m.calls.Add(1)
+	return &metricsv1.ExportMetricsServiceResponse{
+		PartialSuccess: &metricsv1.ExportMetricsPartialSuccess{
+			RejectedDataPoints: m.rejected,
+			ErrorMessage:       "schema validation failed",
+		},
+	}, nil
+}
+
+func (m *mockPartialSuccessServer) callCount() int32 {
+	return m.calls.Load()
+}
+
 // Helper to extract attributes map from KeyValue slice
 func extractAttributesMap(attrs []*commonpb.KeyValue) map[string]string {
 	result := make(map[string]string)
@@ -1316,4 +1399,716 @@ func extractAttributesMap(attrs []*commonpb.KeyValue) map[string]string {
 		}
 	}
 	return result
+}
+
+// ---------------------------------------------------------------------------
+// Public Update() reload-path tests (Tasks 16c)
+//
+// These tests drive the real Update(ctx, cfg) API end-to-end. The existing
+// reload tests use withCfg / direct state.Swap shortcuts that bypass Update.
+// ---------------------------------------------------------------------------
+
+// TestUpdate_EndpointChange_RebuildsTransport verifies the rebuild path
+// (needsTransportRebuild == true). The endpoint change forces a new transport
+// to be allocated; the old transport pointer must differ from the new one, and
+// data sent after the Update reaches server2, not server1.
+func TestUpdate_EndpointChange_RebuildsTransport(t *testing.T) {
+	server1, endpoint1 := startMockOTLPServer(t)
+	defer server1.Stop()
+	server2, endpoint2 := startMockOTLPServer(t)
+	defer server2.Stop()
+
+	cfg1 := map[string]interface{}{
+		"endpoint":   endpoint1,
+		"protocol":   "grpc",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+	}
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-rebuild", cfg1,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	s1 := o.state.Load()
+	require.NotNil(t, s1)
+	transport1 := s1.transport
+
+	cfg2 := map[string]interface{}{
+		"endpoint":   endpoint2,
+		"protocol":   "grpc",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+	}
+	require.NoError(t, o.Update(context.Background(), cfg2))
+
+	s2 := o.state.Load()
+	require.NotNil(t, s2)
+	require.NotSame(t, s1, s2, "Update must publish a new outputState")
+	require.NotSame(t, transport1, s2.transport, "endpoint change must allocate a new transportState")
+
+	// A batch sent after the Update must reach server2.
+	o.WriteEvent(context.Background(), &formatters.EventMsg{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags: map[string]string{"source": "x"}, Values: map[string]interface{}{"value": int64(1)},
+	})
+	require.Eventually(t, func() bool {
+		return server2.ReceivedMetricsCount() > 0
+	}, 2*time.Second, 20*time.Millisecond, "data must reach server2 after endpoint Update")
+
+	// server1 must not have received the post-reload batch.
+	require.Equal(t, 0, server1.ReceivedMetricsCount(), "server1 must not receive data after endpoint Update")
+}
+
+// TestUpdate_TwoStepReload_RealUpdateRespectsInFlightAcrossConfigOnly is the
+// regression test for the WaitGroup-on-fresh-state bug (Tasks 15d/16a), driven
+// via the public Update() API rather than direct state.Swap shortcuts. This
+// ensures Update's branch logic, its Swap block, and its async cleanup goroutine
+// are all exercised together.
+//
+// Step 1: cfg-only reload (no transport rebuild) → new outputState, same transport.
+// Step 2: endpoint change (rebuild) → new transport. The cleanup goroutine for
+// the original transport must block on inFlight until we release it.
+func TestUpdate_TwoStepReload_RealUpdateRespectsInFlightAcrossConfigOnly(t *testing.T) {
+	server1, endpoint1 := startMockOTLPServer(t)
+	defer server1.Stop()
+	server2, endpoint2 := startMockOTLPServer(t)
+	defer server2.Stop()
+
+	cfg1 := map[string]interface{}{
+		"endpoint":   endpoint1,
+		"protocol":   "grpc",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+	}
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-two-step", cfg1,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	s1 := o.state.Load()
+	T1 := s1.transport
+
+	// Simulate an in-flight batch holding T1's WaitGroup counter.
+	o.stateMu.Lock()
+	T1.inFlight.Add(1)
+	o.stateMu.Unlock()
+
+	// Step 1: cfg-only reload (header change only → needsTransportRebuild == false).
+	cfgOnly := map[string]interface{}{
+		"endpoint":   endpoint1,
+		"protocol":   "grpc",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+		"headers":    map[string]interface{}{"X-Scope-OrgID": "step1"},
+	}
+	require.NoError(t, o.Update(context.Background(), cfgOnly))
+
+	s2 := o.state.Load()
+	require.NotSame(t, s1, s2, "cfg-only reload must publish a new outputState")
+	require.Same(t, T1, s2.transport, "cfg-only reload must share the original transport")
+
+	// Step 2: rebuild reload (endpoint changes → needsTransportRebuild == true).
+	cfg2 := map[string]interface{}{
+		"endpoint":   endpoint2,
+		"protocol":   "grpc",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+	}
+	require.NoError(t, o.Update(context.Background(), cfg2))
+
+	s3 := o.state.Load()
+	require.NotSame(t, T1, s3.transport, "rebuild reload must allocate a new transport")
+
+	// T1 is being cleaned up asynchronously, but inFlight is still 1.
+	// Give the cleanup goroutine a brief window to start, then assert the
+	// connection is NOT yet closed (blocked on inFlight.Wait).
+	time.Sleep(100 * time.Millisecond)
+	connState := T1.grpcState.conn.GetState()
+	require.NotEqual(t, connectivity.Shutdown, connState,
+		"T1 conn must not be closed while inFlight > 0")
+
+	// Release the in-flight hold — cleanup goroutine should now drain.
+	T1.inFlight.Done()
+
+	// Poll for Shutdown with a generous timeout.
+	require.Eventually(t, func() bool {
+		return T1.grpcState.conn.GetState() == connectivity.Shutdown
+	}, 2*time.Second, 25*time.Millisecond, "T1 conn must transition to Shutdown after inFlight drains")
+}
+
+// TestUpdate_BufferSizeChange_SwapsEventChannel verifies that
+// channelNeedsSwap == true when buffer-size changes: the event channel must be
+// replaced with one of the new capacity.
+func TestUpdate_BufferSizeChange_SwapsEventChannel(t *testing.T) {
+	server, endpoint := startMockOTLPServer(t)
+	defer server.Stop()
+
+	cfg1 := map[string]interface{}{
+		"endpoint":    endpoint,
+		"protocol":    "grpc",
+		"timeout":     "2s",
+		"batch-size":  1,
+		"interval":    "50ms",
+		"buffer-size": 10,
+	}
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-buf-swap", cfg1,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	oldCh := *o.eventCh.Load()
+	require.Equal(t, 10, cap(oldCh), "initial channel capacity must match buffer-size")
+
+	cfg2 := map[string]interface{}{
+		"endpoint":    endpoint,
+		"protocol":    "grpc",
+		"timeout":     "2s",
+		"batch-size":  1,
+		"interval":    "50ms",
+		"buffer-size": 32,
+	}
+	require.NoError(t, o.Update(context.Background(), cfg2))
+
+	newCh := *o.eventCh.Load()
+	require.Equal(t, 32, cap(newCh), "channel capacity must update to new buffer-size")
+	// Capacity change is the load-bearing assertion; different cap guarantees
+	// a new channel was allocated.
+	require.NotEqual(t, cap(oldCh), cap(newCh), "Update must allocate a new channel when buffer-size changes")
+}
+
+// TestUpdate_NumWorkersChange_RestartsWorkers verifies needsWorkerRestart == true
+// when num-workers changes. After the Update the pipeline must still be
+// functional (data flows end-to-end).
+func TestUpdate_NumWorkersChange_RestartsWorkers(t *testing.T) {
+	server, endpoint := startMockOTLPServer(t)
+	defer server.Stop()
+
+	cfg1 := map[string]interface{}{
+		"endpoint":    endpoint,
+		"protocol":    "grpc",
+		"timeout":     "2s",
+		"batch-size":  1,
+		"interval":    "50ms",
+		"num-workers": 2,
+	}
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-worker-restart", cfg1,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	cfg2 := map[string]interface{}{
+		"endpoint":    endpoint,
+		"protocol":    "grpc",
+		"timeout":     "2s",
+		"batch-size":  1,
+		"interval":    "50ms",
+		"num-workers": 4,
+	}
+	require.NoError(t, o.Update(context.Background(), cfg2))
+
+	// cancelFn must not be nil after worker restart.
+	require.NotNil(t, o.cancelFn, "cancelFn must not be nil after worker restart")
+
+	// Pipeline must still work after the restart — data flows end-to-end.
+	countBefore := server.ReceivedMetricsCount()
+	o.WriteEvent(context.Background(), &formatters.EventMsg{
+		Name: "test", Timestamp: time.Now().UnixNano(),
+		Tags: map[string]string{"source": "x"}, Values: map[string]interface{}{"value": int64(1)},
+	})
+	require.Eventually(t, func() bool {
+		return server.ReceivedMetricsCount() > countBefore
+	}, 2*time.Second, 20*time.Millisecond, "data must flow end-to-end after worker-count Update")
+}
+
+// TestOTLP_HTTPTransport_EndToEnd verifies that configuring protocol: http
+// results in a working mTLS-authenticated POST to /v1/metrics carrying a
+// valid ExportMetricsServiceRequest built from a real gnmi Event.
+//
+// Default-on gzip is exercised: the body arrives Content-Encoding: gzip and
+// the test decompresses before unmarshal — same path real receivers use.
+func TestOTLP_HTTPTransport_EndToEnd(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		gotBody     []byte
+		gotEncoding string
+	)
+	srv := newMTLSTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/metrics", r.URL.Path)
+		require.Equal(t, "application/x-protobuf", r.Header.Get("Content-Type"))
+		mu.Lock()
+		defer mu.Unlock()
+		gotEncoding = r.Header.Get("Content-Encoding")
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotBody = b
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	o := &otlpOutput{}
+	cfgMap := map[string]interface{}{
+		"type":       "otlp",
+		"endpoint":   srv.URL,
+		"protocol":   "http",
+		"batch-size": 1,
+		"interval":   "50ms",
+		"timeout":    "2s",
+		"tls": map[string]interface{}{
+			"ca-file":   srv.CAPath(),
+			"cert-file": srv.ClientCertPath(),
+			"key-file":  srv.ClientKeyPath(),
+		},
+	}
+	require.NoError(t, o.Init(context.Background(), "test-otlp", cfgMap,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	event := &formatters.EventMsg{
+		Name:      "interfaces_interface_state_counters_in_octets",
+		Timestamp: time.Now().UnixNano(),
+		Tags:      map[string]string{"interface_name": "Ethernet1", "source": "10.1.1.1:6030"},
+		Values:    map[string]interface{}{"value": int64(1234567890)},
+	}
+	// WriteEvent (not Write) — Write takes proto.Message and handles SubscribeResponse;
+	// EventMsg is the input form for the batching pipeline.
+	o.WriteEvent(context.Background(), event)
+
+	// Poll up to 2 seconds for the body to arrive.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := gotBody != nil
+		mu.Unlock()
+		if got {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	mu.Lock()
+	body := gotBody
+	encoding := gotEncoding
+	mu.Unlock()
+	require.NotNil(t, body, "server did not receive a request within deadline")
+
+	// Default compression for protocol:http is gzip — decompress before unmarshal.
+	if encoding == "gzip" {
+		gr, err := gzip.NewReader(bytes.NewReader(body))
+		require.NoError(t, err)
+		body, err = io.ReadAll(gr)
+		require.NoError(t, err)
+	}
+
+	var req metricsv1.ExportMetricsServiceRequest
+	require.NoError(t, proto.Unmarshal(body, &req))
+	require.NotEmpty(t, req.ResourceMetrics, "ResourceMetrics must be populated")
+}
+
+// TestInit_FailureAfterRegisterMetrics_UnregistersCleanly verifies that when
+// Init fails after registerMetrics succeeds, the collectors are unregistered so
+// that a subsequent Init retry on the same *otlpOutput and same registry does
+// not collide.
+func TestInit_FailureAfterRegisterMetrics_UnregistersCleanly(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	// A bad TLS path causes buildOutputState→initHTTPFor to fail after
+	// registerMetrics has already registered the four collectors.
+	badCfg := map[string]interface{}{
+		"endpoint": "http://127.0.0.1:9999",
+		"protocol": "http",
+		"tls": map[string]interface{}{
+			"ca-file": "/nonexistent/ca.pem", // guaranteed to fail
+		},
+		"enable-metrics": true,
+	}
+
+	o := &otlpOutput{}
+
+	// First Init: must fail (bad TLS).
+	err := o.Init(context.Background(), "test-cleanup", badCfg,
+		outputs.WithRegistry(reg),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	)
+	require.Error(t, err, "first Init must fail (bad TLS path)")
+
+	// After failure the collectors must NOT still be registered.
+	// If they are, reg.Register would return an AlreadyRegisteredError.
+	require.NoError(t, reg.Register(otlpNumberOfSentEvents),
+		"otlpNumberOfSentEvents must be unregistered after Init failure")
+	// Clean up so the package-level variable is not left registered in this registry.
+	reg.Unregister(otlpNumberOfSentEvents)
+
+	// Second Init with a valid config on the same *otlpOutput must succeed.
+	server, endpoint := startMockOTLPServer(t)
+	defer server.Stop()
+
+	goodCfg := map[string]interface{}{
+		"endpoint":       endpoint,
+		"protocol":       "grpc",
+		"enable-metrics": true,
+	}
+	reg2 := prometheus.NewRegistry()
+	err = o.Init(context.Background(), "test-cleanup", goodCfg,
+		outputs.WithRegistry(reg2),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	)
+	require.NoError(t, err, "second Init retry must succeed without duplicate-registration error")
+	defer o.Close()
+}
+
+// TestRegisterMetrics_PartialFailure_DoesNotRemoveExternallyOwnedCollectors
+// verifies that the per-instance ownership tracking means rollback only removes
+// collectors this instance registered — not the externally pre-registered one
+// that caused the failure.
+func TestRegisterMetrics_PartialFailure_DoesNotRemoveExternallyOwnedCollectors(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	// Pre-register otlpSendDuration (the third collector in registerMetrics order)
+	// to simulate another owner having registered it before us.
+	require.NoError(t, reg.Register(otlpSendDuration))
+
+	o := &otlpOutput{}
+	o.reg = reg
+
+	err := o.registerMetrics(&config{EnableMetrics: true, Name: "x"})
+	require.Error(t, err, "registerMetrics must fail because otlpSendDuration is pre-registered")
+
+	// 1. The first two collectors (which this instance registered) must have been
+	//    rolled back — re-registering them must succeed.
+	require.NoError(t, reg.Register(otlpNumberOfSentEvents),
+		"otlpNumberOfSentEvents must be unregistered after partial failure (owned by this instance)")
+	require.NoError(t, reg.Register(otlpNumberOfFailedEvents),
+		"otlpNumberOfFailedEvents must be unregistered after partial failure (owned by this instance)")
+
+	// 2. otlpSendDuration was NOT registered by this instance, so the rollback
+	//    must NOT have removed it — re-registering it must return AlreadyRegisteredError.
+	err = reg.Register(otlpSendDuration)
+	require.Error(t, err, "otlpSendDuration must still be registered (externally owned, rollback must not touch it)")
+	var alreadyErr prometheus.AlreadyRegisteredError
+	require.ErrorAs(t, err, &alreadyErr,
+		"error must be AlreadyRegisteredError — otlpSendDuration survived the rollback")
+
+	// 3. registeredMetrics must be nil after rollback (drained).
+	require.Nil(t, o.registeredMetrics, "registeredMetrics must be nil after rollback")
+
+	// Cleanup.
+	reg.Unregister(otlpNumberOfSentEvents)
+	reg.Unregister(otlpNumberOfFailedEvents)
+	reg.Unregister(otlpSendDuration)
+}
+
+// TestClose_WaitsForInFlightBatchBeforeCleanup verifies that Close blocks on
+// transport.inFlight.Wait() before calling cleanup(). This ensures a future
+// sendBatch caller outside the worker path cannot observe a torn-down transport.
+func TestClose_WaitsForInFlightBatchBeforeCleanup(t *testing.T) {
+	server, endpoint := startMockOTLPServer(t)
+	defer server.Stop()
+
+	cfg := map[string]interface{}{
+		"endpoint":   endpoint,
+		"protocol":   "grpc",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+	}
+
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-close-inflight", cfg,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+
+	// Simulate an in-flight batch by manually incrementing inFlight under stateMu
+	// (the same protocol sendBatch uses).
+	o.stateMu.Lock()
+	state := o.state.Load()
+	state.transport.inFlight.Add(1)
+	o.stateMu.Unlock()
+
+	// Call Close in a goroutine; it should block on inFlight.Wait().
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		o.Close()
+	}()
+
+	// Assert Close has NOT returned within 50 ms (it must be blocked on Wait).
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned before inFlight was drained — Wait is not load-bearing")
+	case <-time.After(50 * time.Millisecond):
+		// expected: Close is still blocked
+	}
+
+	// Release the in-flight hold — Close must now proceed.
+	state.transport.inFlight.Done()
+
+	// Assert Close returns within 2 s.
+	select {
+	case <-closeDone:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return within 2s after inFlight was drained")
+	}
+}
+
+// TestClose_UnregistersMetrics verifies that after a successful Init+Close cycle
+// the collectors are unregistered, so a subsequent Init does not hit a
+// duplicate-registration error.
+func TestClose_UnregistersMetrics(t *testing.T) {
+	server, endpoint := startMockOTLPServer(t)
+	defer server.Stop()
+
+	reg := prometheus.NewRegistry()
+
+	cfg := map[string]interface{}{
+		"endpoint":       endpoint,
+		"protocol":       "grpc",
+		"enable-metrics": true,
+	}
+
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-close-metrics", cfg,
+		outputs.WithRegistry(reg),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+
+	require.NoError(t, o.Close())
+
+	// After Close, all four collectors must be unregistered.
+	require.NoError(t, reg.Register(otlpNumberOfSentEvents),
+		"otlpNumberOfSentEvents must be unregistered after Close")
+	require.NoError(t, reg.Register(otlpNumberOfFailedEvents),
+		"otlpNumberOfFailedEvents must be unregistered after Close")
+	require.NoError(t, reg.Register(otlpSendDuration),
+		"otlpSendDuration must be unregistered after Close")
+	require.NoError(t, reg.Register(otlpRejectedDataPoints),
+		"otlpRejectedDataPoints must be unregistered after Close")
+	// Cleanup.
+	reg.Unregister(otlpNumberOfSentEvents)
+	reg.Unregister(otlpNumberOfFailedEvents)
+	reg.Unregister(otlpSendDuration)
+	reg.Unregister(otlpRejectedDataPoints)
+}
+
+// TestUpdate_TransportRebuildFailure_DoesNotApplyProcessors verifies that when
+// Update's buildOutputState fails, o.dynCfg is NOT updated. In the buggy code,
+// o.dynCfg.Store(dc) ran before buildOutputState, so a new dc pointer was always
+// published regardless of whether the transport build succeeded.
+//
+// We test with a protocol change (grpc → http) and an ftp:// endpoint that passes
+// validateConfig but is rejected by initHTTPFor's resolveMetricsURL (unsupported
+// scheme). Event-processors remain unchanged so rebuildProcessors is false — the
+// test focuses on the transport-failure branch.
+func TestUpdate_TransportRebuildFailure_DoesNotApplyProcessors(t *testing.T) {
+	server, endpoint := startMockOTLPServer(t)
+	defer server.Stop()
+
+	cfg1 := map[string]interface{}{
+		"endpoint":   endpoint,
+		"protocol":   "grpc",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+	}
+
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "test-dynCfg-no-apply", cfg1,
+		outputs.WithLogger(logging.DiscardLogger()),
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+	defer o.Close()
+
+	// Capture baseline state pointer and dynCfg pointer.
+	s1 := o.state.Load()
+	prevDC := o.dynCfg.Load()
+	require.NotNil(t, s1)
+	require.NotNil(t, prevDC)
+
+	// Attempt Update: switch to http with an ftp:// endpoint.
+	// This passes validateConfig (protocol "http" is valid) but fails in
+	// initHTTPFor → resolveMetricsURL with "unsupported endpoint scheme".
+	badCfg := map[string]interface{}{
+		"endpoint":   "ftp://127.0.0.1:4318",
+		"protocol":   "http",
+		"timeout":    "2s",
+		"batch-size": 1,
+		"interval":   "50ms",
+	}
+	err := o.Update(context.Background(), badCfg)
+
+	// 1. Update must return an error.
+	require.Error(t, err, "Update must fail on ftp:// endpoint scheme")
+	require.Contains(t, err.Error(), "unsupported endpoint scheme")
+
+	// 2. dynCfg must NOT have been updated — pointer identity must be preserved.
+	require.Same(t, prevDC, o.dynCfg.Load(),
+		"dynCfg must not be updated when transport rebuild fails")
+
+	// 3. state must NOT have been updated — original state pointer must be preserved.
+	require.Same(t, s1, o.state.Load(),
+		"state must not be updated when transport rebuild fails")
+}
+
+// TestInit_GRPCBareEndpointWithoutPortRejected verifies that gRPC's bare-endpoint
+// form requires an explicit port, mirroring the HTTP path's resolveMetricsURL
+// discipline. A bare host like "panoptes" with no scheme and no port is rejected
+// at Init rather than passed through to grpc.NewClient where it would silently
+// resolve via the default resolver and dial the wrong port.
+func TestInit_GRPCBareEndpointWithoutPortRejected(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+	}{
+		{"no_port", "panoptes"},
+		{"trailing_colon", "panoptes:"},
+		{"port_only", ":4317"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &otlpOutput{}
+			err := o.Init(context.Background(), "test-grpc-bare", map[string]any{
+				"endpoint": tc.endpoint,
+				"protocol": "grpc",
+			},
+				outputs.WithLogger(logging.DiscardLogger()),
+				outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "must be host:port")
+		})
+	}
+}
+
+// Security: String() feeds the reload log (Update logs the marshaled config
+// at Info level), and Headers carries credentials such as Authorization
+// bearer tokens. Values must be redacted — for every header, not just a
+// blocklist — while key names stay visible for debugging. The live config
+// must not be mutated by the redaction.
+func TestString_RedactsHeaderValues(t *testing.T) {
+	o := &otlpOutput{}
+	o.initFields()
+	headers := map[string]string{
+		"Authorization": "Bearer super-secret-token",
+		"X-Api-Key":     "another-secret-value",
+		"X-Scope-OrgID": "tenant-1",
+	}
+	cfg := &config{Name: "redaction-test", Endpoint: "collector:4318", Headers: headers}
+	o.state.Store(&outputState{cfg: cfg})
+
+	s := o.String()
+	require.NotEmpty(t, s)
+	for k := range headers {
+		require.Contains(t, s, k, "header names must stay visible")
+	}
+	for _, v := range headers {
+		require.NotContains(t, s, v, "header values must never appear in String()")
+	}
+	require.Contains(t, s, "***")
+
+	// The redaction must operate on a copy.
+	require.Equal(t, "Bearer super-secret-token", cfg.Headers["Authorization"],
+		"live config must not be mutated")
+}
+
+// Config guard: a negative numeric value would otherwise panic at runtime —
+// buffer-size in make(chan) and num-workers in wg.Add at Init; batch-size in
+// make([]) and interval in time.NewTicker inside the worker goroutine, where
+// an unrecovered panic kills the process. Negative timeout disables deadlines
+// and negative max-retries silently drops every batch. All must be rejected
+// at validation time. Zero is not covered here: setDefaultsFor replaces zero
+// with the default before validateConfig runs.
+func TestValidateConfig_RejectsInvalidNumerics(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*config)
+		want   string
+	}{
+		{"negative batch-size", func(c *config) { c.BatchSize = -1 }, "batch-size"},
+		{"negative buffer-size", func(c *config) { c.BufferSize = -1 }, "buffer-size"},
+		{"negative num-workers", func(c *config) { c.NumWorkers = -1 }, "num-workers"},
+		{"negative interval", func(c *config) { c.Interval = -time.Second }, "interval"},
+		{"negative timeout", func(c *config) { c.Timeout = -time.Second }, "timeout"},
+		{"negative max-retries", func(c *config) { c.MaxRetries = -1 }, "max-retries"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &otlpOutput{}
+			c := &config{Endpoint: "collector:4317"}
+			tc.mutate(c)
+			o.setDefaultsFor(c)
+			err := o.validateConfig(c)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+
+	// Sanity: defaults alone validate cleanly.
+	o := &otlpOutput{}
+	c := &config{Endpoint: "collector:4317"}
+	o.setDefaultsFor(c)
+	require.NoError(t, o.validateConfig(c))
+}
+
+// Race regression: the outputs manager dispatches Write/WriteEvent goroutines
+// without synchronizing against Close (go mgr.write(e) in outputs_manager.go),
+// so producers can still be sending while — and after — Close runs. Close
+// must not close the event channel (send on closed channel panics the whole
+// process even inside a select) and Write/WriteEvent must tolerate the
+// post-Close nil state. Run under -race, this also proves the paths are
+// data-race free.
+func TestClose_ConcurrentWriteEventDoesNotPanic(t *testing.T) {
+	server, endpoint := startMockOTLPServer(t)
+	defer server.Stop()
+
+	cfg := map[string]interface{}{
+		"endpoint": endpoint,
+		"protocol": "grpc",
+		"interval": "50ms",
+	}
+	o := &otlpOutput{}
+	require.NoError(t, o.Init(context.Background(), "close-race", cfg,
+		outputs.WithConfigStore(gomap.NewMemStore(store.StoreOptions[any]{})),
+	))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ev := createTestEvent()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					o.WriteEvent(context.Background(), ev)
+				}
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, o.Close())
+	// Producers keep hammering after Close — must neither panic nor race.
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	require.NoError(t, o.Close(), "Close must stay idempotent")
 }

--- a/pkg/outputs/otlp_output/otlp_output_test.go
+++ b/pkg/outputs/otlp_output/otlp_output_test.go
@@ -1726,7 +1726,7 @@ func TestInit_FailureAfterRegisterMetrics_UnregistersCleanly(t *testing.T) {
 	reg := prometheus.NewRegistry()
 
 	// A bad TLS path causes buildOutputState→initHTTPFor to fail after
-	// registerMetrics has already registered the four collectors.
+	// registerMetrics has already registered the collectors.
 	badCfg := map[string]interface{}{
 		"endpoint": "http://127.0.0.1:9999",
 		"protocol": "http",
@@ -1889,7 +1889,7 @@ func TestClose_UnregistersMetrics(t *testing.T) {
 
 	require.NoError(t, o.Close())
 
-	// After Close, all four collectors must be unregistered.
+	// After Close, all collectors must be unregistered.
 	require.NoError(t, reg.Register(otlpNumberOfSentEvents),
 		"otlpNumberOfSentEvents must be unregistered after Close")
 	require.NoError(t, reg.Register(otlpNumberOfFailedEvents),
@@ -1898,11 +1898,14 @@ func TestClose_UnregistersMetrics(t *testing.T) {
 		"otlpSendDuration must be unregistered after Close")
 	require.NoError(t, reg.Register(otlpRejectedDataPoints),
 		"otlpRejectedDataPoints must be unregistered after Close")
+	require.NoError(t, reg.Register(otlpMalformedResponses),
+		"otlpMalformedResponses must be unregistered after Close")
 	// Cleanup.
 	reg.Unregister(otlpNumberOfSentEvents)
 	reg.Unregister(otlpNumberOfFailedEvents)
 	reg.Unregister(otlpSendDuration)
 	reg.Unregister(otlpRejectedDataPoints)
+	reg.Unregister(otlpMalformedResponses)
 }
 
 // TestUpdate_TransportRebuildFailure_DoesNotApplyProcessors verifies that when


### PR DESCRIPTION
## Summary

Adds an OTLP/HTTP transport to the `otlp` output, complementing the existing gRPC path, plus lifecycle and correctness hardening that applies to both transports.

### OTLP/HTTP transport

- New `protocol: http` (default remains `grpc`). Endpoints accept either a bare `host:port` (port required, scheme derived from whether `tls` is configured, path defaults to `/v1/metrics`) or a full URL (scheme and path preserved; empty or `/` path defaults to `/v1/metrics`).
- mTLS via the existing `tls` block. `http://` combined with a `tls` block is rejected at Init to prevent a silent mTLS bypass.
- Per-request body compression (`compression: gzip|none`), default `gzip`; ignored by gRPC. `Content-Type`/`Content-Encoding` are protocol-owned and cannot be set or leaked through user headers in either direction.
- Error classification per the OTLP spec: `429/502/503/504` retryable, other `4xx/5xx` permanent, transport-level errors retryable. `Retry-After` honored up to a 30s cap; otherwise exponential backoff with full jitter (`math/rand/v2`).
- HTTP redirects are never followed (`ErrUseLastResponse`); a redirect classifies as a permanent error. Go forwards user-defined headers cross-host and 307/308 replay the body, so following redirects would allow a redirecting collector to receive the payload and headers at another origin.
- `PartialSuccess` (both transports) is never retried — retrying would duplicate the accepted points. Accounting is request-level: the batch counts as sent; rejected points are counted by the new `gnmic_otlp_output_rejected_data_points_total`, which is the data-loss signal to alert on.

### Lifecycle hardening (both transports)

- Live reload can no longer tear the config/transport pair mid-batch: an `atomic.Pointer` bundles `(cfg, transport)`, and transport teardown waits on a per-transport in-flight WaitGroup instead of wall-clock heuristics — including across config-only reloads layered on the same transport.
- `Update` publishes nothing until all fallible work has succeeded, so a failed reload leaves the previous state fully intact. Header-only reloads take effect on the next batch without a transport rebuild.
- `Close` no longer closes the event channel (producers dispatched by the outputs manager are not synchronized with `Close`; a send on a closed channel would panic the process). Workers exit via context cancellation; `Write`/`WriteEvent` tolerate post-`Close` state.
- Numeric config options are validated at Init/reload; previously a negative `batch-size`/`interval`/`buffer-size`/`num-workers` panicked at runtime (in a worker goroutine for the first two, killing the process).
- Bare endpoints on both transports must carry an explicit port (`net.SplitHostPort`), failing at Init instead of on first dial; gRPC schemed forms (`dns:///`, `unix:///`, `xds:///`) pass through unchanged.
- Config-reload logging redacts header values (`Authorization` bearer tokens etc.); key names stay visible.
- Prometheus collectors are tracked per instance: a failed Init rolls back only its own registrations, and Close unregisters them so a later Init on the same registry succeeds.

### Docs

`docs/user_guide/outputs/otlp_output.md` rewritten example-first (gRPC, HTTP, HTTP+mTLS), with a full configuration reference and sections for transport behavior, TLS/compression, metric naming, resource attributes, headers, retries/partial-success accounting.

### Tests

New coverage: end-to-end OTLP/HTTP delivery against a real mTLS server; endpoint validation (scheme/userinfo/port/TLS-coherence); Retry-After parsing and backoff capping; PartialSuccess on both transports including the accounting semantics; gzip compression and Content-Encoding ownership (including the `compression: none` strip); redirect refusal; header redaction; numeric config validation; race regressions for worker restart, two-step reload transport sharing, concurrent `WriteEvent`-vs-`Close`, and reload-path coverage through real `Update()` calls. The package passes `go test -race`.

### Known follow-ups (pre-existing, observed while developing — happy to file issues)

- The outputs manager never passes `WithRegistry` to outputs, so per-output `enable-metrics` has no scrapeable registry when driven through the manager.
- The manager dispatches `Write` goroutines unsynchronized with `Close` for all output types; this PR makes the `otlp` output itself safe against that, but the contract may be worth tightening centrally.
- The shared TLS helper does not set an explicit `MinVersion` (currently inherits Go's 1.2 default).
- A `buffer-size` reload swaps the event channel and can drop events still buffered in the old one (documented).
