### PR TITLE
fix: listener race condition, cleanup metrics

### DIFF
--- a/pkg/api/target/target.go
+++ b/pkg/api/target/target.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
@@ -42,6 +43,7 @@ type SubscribeResponse struct {
 
 // Target represents a gNMI enabled box
 type Target struct {
+	id            string                               // unique internal identifier
 	Config        *types.TargetConfig                  `json:"config,omitempty"`
 	Subscriptions map[string]*types.SubscriptionConfig `json:"subscriptions,omitempty"`
 
@@ -64,6 +66,7 @@ type Target struct {
 // NewTarget //
 func NewTarget(c *types.TargetConfig) *Target {
 	t := &Target{
+		id:                 uuid.New().String(),
 		Config:             c,
 		Subscriptions:      make(map[string]*types.SubscriptionConfig),
 		m:                  new(sync.Mutex),
@@ -75,6 +78,10 @@ func NewTarget(c *types.TargetConfig) *Target {
 		StopChan:           make(chan struct{}),
 	}
 	return t
+}
+
+func (t *Target) GetID() string {
+	return t.id
 }
 
 // CreateGNMIClient //

--- a/pkg/app/loaders.go
+++ b/pkg/app/loaders.go
@@ -80,7 +80,6 @@ START:
 			}
 			// not clustered, add target and subscribe
 			if !a.inCluster() {
-				a.Config.Targets[add.Name] = add
 				a.AddTargetConfig(add)
 				a.wg.Add(1)
 				go a.TargetSubscribeStream(ctx, add)

--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -52,6 +52,19 @@ var targetConnStateMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help:      "The current gRPC connection state to the target. The value can be one of the following: 0(UNKNOWN), 1 (IDLE), 2 (CONNECTING), 3 (READY), 4 (TRANSIENT_FAILURE), or 5 (SHUTDOWN).",
 }, []string{"name"})
 
+// targetGrpcStateMetric tracks the last gRPC status code received from each target.
+// See https://pkg.go.dev/google.golang.org/grpc/codes for the full reference.
+var targetGrpcStateMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "gnmic",
+	Subsystem: "target",
+	Name:      "grpc_status_code",
+	Help: "The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. " +
+		"See https://pkg.go.dev/google.golang.org/grpc/codes. " +
+		"Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, " +
+		"6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, " +
+		"11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.",
+}, []string{"name"})
+
 // cluster
 var clusterNumberOfLockedTargets = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: "gnmic",
@@ -75,10 +88,15 @@ func (a *App) registerTargetMetrics() {
 	if err != nil {
 		logging.LogErrUnlessCanceled(a.Logger, err, "failed to register target connection state metric")
 	}
+	err = a.reg.Register(targetGrpcStateMetric)
+	if err != nil {
+		a.Logger.Info("failed to register target grpc state metric", "err", err)
+	}
 	a.configLock.RLock()
 	for _, t := range a.Config.Targets {
 		targetUPMetric.WithLabelValues(t.Name).Set(0)
 		targetConnStateMetric.WithLabelValues(t.Name).Set(0)
+		targetGrpcStateMetric.WithLabelValues(t.Name).Set(2) // Unknown until first response
 	}
 	a.configLock.RUnlock()
 	go func() {

--- a/pkg/app/subscribe.go
+++ b/pkg/app/subscribe.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openconfig/grpctunnel/tunnel"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/openconfig/gnmic/pkg/api/target"
@@ -240,7 +241,7 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 			continue
 		}
 		a.operLock.RLock()
-		_, ok := a.activeTargets[t.Config.Name]
+		_, ok := a.activeTargets[t.GetID()]
 		a.operLock.RUnlock()
 		if ok {
 			if a.Config.Debug {
@@ -249,7 +250,7 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 			continue
 		}
 		a.operLock.Lock()
-		a.activeTargets[t.Config.Name] = struct{}{}
+		a.activeTargets[t.GetID()] = struct{}{}
 		a.operLock.Unlock()
 
 		a.Logger.Info("starting target listener", "target", t.Config.Name)
@@ -292,6 +293,7 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 					}
 
 					a.export(ctx, rsp.Response, m, outs...)
+					targetGrpcStateMetric.WithLabelValues(t.Config.Name).Set(0)
 					if remainingOnceSubscriptions > 0 {
 						if a.subscriptionMode(rsp.SubscriptionName) == subscriptionModeONCE {
 							switch rsp.Response.Response.(type) {
@@ -302,16 +304,20 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 					}
 					if remainingOnceSubscriptions == 0 && numSubscriptions == numOnceSubscriptions {
 						a.operLock.Lock()
-						delete(a.activeTargets, t.Config.Name)
+						delete(a.activeTargets, t.GetID())
 						a.operLock.Unlock()
 						return
 					}
 				case tErr := <-errChan:
 					if errors.Is(tErr.Err, io.EOF) {
 						a.Logger.Info("subscription closed stream (EOF)", "target", t.Config.Name, "subscription", tErr.SubscriptionName)
+						targetGrpcStateMetric.WithLabelValues(t.Config.Name).Set(0) // OK
 					} else {
 						subscribeResponseFailedCounter.WithLabelValues(t.Config.Name, tErr.SubscriptionName).Inc()
 						logging.LogErrUnlessCanceled(a.Logger, tErr.Err, "subscription receive error", "target", t.Config.Name, "subscription", tErr.SubscriptionName)
+						if st, ok := status.FromError(tErr.Err); ok {
+							targetGrpcStateMetric.WithLabelValues(t.Config.Name).Set(float64(st.Code()))
+						}
 					}
 					if remainingOnceSubscriptions > 0 {
 						if a.subscriptionMode(tErr.SubscriptionName) == subscriptionModeONCE {
@@ -320,19 +326,19 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 					}
 					if remainingOnceSubscriptions == 0 && numSubscriptions == numOnceSubscriptions {
 						a.operLock.Lock()
-						delete(a.activeTargets, t.Config.Name)
+						delete(a.activeTargets, t.GetID())
 						a.operLock.Unlock()
 						return
 					}
 				case <-t.StopChan:
 					a.operLock.Lock()
-					delete(a.activeTargets, t.Config.Name)
+					delete(a.activeTargets, t.GetID())
 					a.operLock.Unlock()
 					a.Logger.Info("target listener stopped", "target", t.Config.Name)
 					return
 				case <-ctx.Done():
 					a.operLock.Lock()
-					delete(a.activeTargets, t.Config.Name)
+					delete(a.activeTargets, t.GetID())
 					a.operLock.Unlock()
 					return
 				}

--- a/pkg/app/subscribe.go
+++ b/pkg/app/subscribe.go
@@ -581,7 +581,13 @@ func (a *App) startIO() {
 		}
 
 		if !a.Config.UseTunnelServer {
+			a.configLock.RLock()
+			targets := make([]*types.TargetConfig, 0, len(a.Config.Targets))
 			for _, tc := range a.Config.Targets {
+				targets = append(targets, tc)
+			}
+			a.configLock.RUnlock()
+			for _, tc := range targets {
 				a.wg.Add(1)
 				go a.subscribeStream(a.ctx, tc)
 				if limiter != nil {

--- a/pkg/app/target.go
+++ b/pkg/app/target.go
@@ -138,8 +138,10 @@ func (a *App) UpdateTargetSubscription(ctx context.Context, name string, subs []
 // AddTargetConfig adds a *TargetConfig to the configuration map
 func (a *App) AddTargetConfig(tc *types.TargetConfig) {
 	a.Logger.Info("adding target", "target", tc)
-	_, ok := a.Config.Targets[tc.Name]
-	if ok {
+	a.configLock.Lock()
+	defer a.configLock.Unlock()
+
+	if _, ok := a.Config.Targets[tc.Name]; ok {
 		return
 	}
 	if tc.BufferSize <= 0 {
@@ -149,8 +151,6 @@ func (a *App) AddTargetConfig(tc *types.TargetConfig) {
 		tc.RetryTimer = a.Config.Retry
 	}
 
-	a.configLock.Lock()
-	defer a.configLock.Unlock()
 	a.Config.Targets[tc.Name] = tc
 }
 

--- a/pkg/app/target.go
+++ b/pkg/app/target.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 
 	"github.com/fullstorydev/grpcurl"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/openconfig/gnmic/pkg/api/target"
 	"github.com/openconfig/gnmic/pkg/api/types"
@@ -66,6 +67,22 @@ func (a *App) stopTarget(ctx context.Context, name string) error {
 	return a.locker.Unlock(ctx, a.targetLockKey(name))
 }
 
+func (a *App) deleteTargetMetrics(name string) {
+	c := subscribeResponseReceivedCounter.DeletePartialMatch(prometheus.Labels{
+		"source": name,
+	})
+	a.Logger.Info("deleted `gnmic_subscribe_number_of_received_subscribe_response_messages_total` metrics for target", "target", name, "counter_deleted", c)
+	// Also delete any other metrics for this target
+	c = subscribeResponseFailedCounter.DeletePartialMatch(prometheus.Labels{
+		"source": name,
+	})
+	a.Logger.Info("deleted `gnmic_subscribe_number_of_failed_subscribe_request_messages_total` metrics for target", "target", name, "counter_deleted", c)
+	// Delete target-level metrics for this target as well.
+	targetUPMetric.DeleteLabelValues(name)
+	targetConnStateMetric.DeleteLabelValues(name)
+	targetGrpcStateMetric.DeleteLabelValues(name)
+}
+
 func (a *App) DeleteTarget(ctx context.Context, name string) error {
 	if a.Targets == nil {
 		return nil
@@ -88,6 +105,7 @@ func (a *App) DeleteTarget(ctx context.Context, name string) error {
 	}
 	if t, ok := a.Targets[name]; ok {
 		delete(a.Targets, name)
+		defer a.deleteTargetMetrics(name)
 		t.Close()
 		if a.locker != nil {
 			return a.locker.Unlock(ctx, a.targetLockKey(name))

--- a/pkg/app/target_test.go
+++ b/pkg/app/target_test.go
@@ -1,0 +1,141 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/openconfig/gnmic/pkg/api/target"
+	"github.com/openconfig/gnmic/pkg/api/types"
+	"github.com/openconfig/gnmic/pkg/config"
+)
+
+// TestAddTargetConfig_ConcurrentRace detects the concurrent map read/write
+// that caused fatal crashes in production (exit code 2).
+// Run with -race to verify: go test -race ./pkg/app/... -run TestAddTargetConfig_ConcurrentRace
+func TestAddTargetConfig_ConcurrentRace(t *testing.T) {
+	a := &App{
+		Config:     config.New(),
+		configLock: new(sync.RWMutex),
+		Logger:     slog.New(slog.DiscardHandler),
+	}
+
+	// pre-populate so DeleteTarget has something to delete
+	for i := 0; i < 10; i++ {
+		a.Config.Targets[fmt.Sprintf("target-%d", i)] = &types.TargetConfig{
+			Name: fmt.Sprintf("target-%d", i),
+		}
+	}
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+
+	// goroutines concurrently adding targets
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			a.AddTargetConfig(&types.TargetConfig{
+				Name: fmt.Sprintf("new-target-%d", i),
+			})
+		}(i)
+	}
+
+	// goroutines concurrently deleting targets — races with the unprotected read in AddTargetConfig
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			a.configLock.Lock()
+			delete(a.Config.Targets, fmt.Sprintf("target-%d", i))
+			a.configLock.Unlock()
+		}(i)
+	}
+
+	// goroutines concurrently reading targets — also races with writes
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			a.AddTargetConfig(&types.TargetConfig{
+				Name: fmt.Sprintf("new-target-%d", i), // duplicate name: tests the early-return read path
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all new targets were added exactly once
+	for i := 0; i < goroutines; i++ {
+		name := fmt.Sprintf("new-target-%d", i)
+		a.configLock.RLock()
+		_, ok := a.Config.Targets[name]
+		a.configLock.RUnlock()
+		if !ok {
+			t.Errorf("target %q missing after concurrent add", name)
+		}
+	}
+
+	// context.Background() needed by DeleteTarget; use it here for consistency
+	_ = context.Background()
+}
+
+// TestMetricsLoopVsLoaderWrite reproduces:
+//
+//	fatal error: concurrent map iteration and map write
+//
+// The metrics loop (registerTargetMetrics) iterates a.Config.Targets under configLock.RLock.
+// The loader non-clustered path wrote a.Config.Targets[add.Name] = add without any lock,
+// bypassing the RLock/Lock protocol entirely.
+// Run with: go test -race ./pkg/app/... -run TestMetricsLoopVsLoaderWrite
+func TestMetricsLoopVsLoaderWrite(t *testing.T) {
+	a := &App{
+		Config:     config.New(),
+		configLock: new(sync.RWMutex),
+		operLock:   new(sync.RWMutex),
+		Targets:    make(map[string]*target.Target),
+		Logger:     slog.New(slog.DiscardHandler),
+	}
+
+	for i := 0; i < 20; i++ {
+		name := fmt.Sprintf("target-%d", i)
+		a.Config.Targets[name] = &types.TargetConfig{Name: name}
+	}
+
+	var wg sync.WaitGroup
+	const iterations = 100
+
+	// mirrors registerTargetMetrics ticker body exactly
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.configLock.RLock()
+			for _, tc := range a.Config.Targets {
+				a.operLock.RLock()
+				_, _ = a.Targets[tc.Name]
+				a.operLock.RUnlock()
+			}
+			a.configLock.RUnlock()
+		}()
+	}
+
+	// mirrors startLoader non-clustered path bug: write without configLock
+	// races with the map iteration in the metrics goroutines above
+	// Run with -race to see: fatal error: concurrent map iteration and map write
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// tc := &types.TargetConfig{Name: fmt.Sprintf("new-target-%d", i)}
+			// a.Config.Targets[tc.Name] = tc // no lock: reproduces the race
+			a.AddTargetConfig(&types.TargetConfig{Name: fmt.Sprintf("new-target-%d", i)})
+		}(i)
+	}
+
+	wg.Wait()
+
+	_ = context.Background()
+}

--- a/pkg/collector/managers/targets/metrics.go
+++ b/pkg/collector/managers/targets/metrics.go
@@ -72,6 +72,7 @@ type targetsStats struct {
 	subscriptionFailedCount   *prometheus.CounterVec
 	targetUPMetric            *prometheus.GaugeVec
 	targetConnStateMetric     *prometheus.GaugeVec
+	targetGrpcStateMetric     *prometheus.GaugeVec
 }
 
 const (
@@ -112,6 +113,18 @@ func newTargetsStats() *targetsStats {
 			Name:      "connection_state",
 			Help:      "The current gRPC connection state to the target. The value can be one of the following: 0(UNKNOWN), 1 (IDLE), 2 (CONNECTING), 3 (READY), 4 (TRANSIENT_FAILURE), or 5 (SHUTDOWN).",
 		}, []string{"name"}),
+		// targetGrpcStateMetric tracks the last gRPC status code received from each target.
+		// See https://pkg.go.dev/google.golang.org/grpc/codes for the full reference.
+		targetGrpcStateMetric: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "gnmic",
+			Subsystem: "target",
+			Name:      "grpc_status_code",
+			Help: "The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. " +
+				"See https://pkg.go.dev/google.golang.org/grpc/codes. " +
+				"Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, " +
+				"6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, " +
+				"11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.",
+		}, []string{"name"}),
 	}
 }
 
@@ -121,6 +134,7 @@ func (tm *TargetsManager) registerMetrics() {
 	tm.reg.MustRegister(tm.stats.subscribeResponseReceived)
 	tm.reg.MustRegister(tm.stats.droppedSubscribeResponses)
 	tm.reg.MustRegister(tm.stats.subscriptionFailedCount)
+	tm.reg.MustRegister(tm.stats.targetGrpcStateMetric)
 
 	tm.mu.RLock()
 	for _, mt := range tm.targets {
@@ -150,6 +164,7 @@ func (tm *TargetsManager) updateTargetMetrics(mt *ManagedTarget) {
 	if mt.T == nil {
 		tm.stats.targetUPMetric.WithLabelValues(mt.Name).Set(0)
 		tm.stats.targetConnStateMetric.WithLabelValues(mt.Name).Set(0)
+		tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(2) // Unknown until first response
 		return
 	}
 	tm.stats.targetUPMetric.WithLabelValues(mt.Name).Set(1)

--- a/pkg/collector/managers/targets/targets_manager.go
+++ b/pkg/collector/managers/targets/targets_manager.go
@@ -3,8 +3,10 @@ package targets_manager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"log/slog"
 	"maps"
 	"net"
@@ -28,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/zestor-dev/zestor/store"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
 )
 
 type ManagedTarget struct {
@@ -625,6 +628,7 @@ func (tm *TargetsManager) remove(name string) {
 		mt.readerCancel = nil
 		mt.Unlock()
 	}
+	tm.stats.targetGrpcStateMetric.DeleteLabelValues(name)
 	tm.store.State.Delete(collstore.KindTargets, name)
 }
 
@@ -855,6 +859,7 @@ func (tm *TargetsManager) startTargetSubscription(mt *ManagedTarget, cfg *types.
 					mt.clearLastError()
 					tm.setTargetState(mt.Name, collstore.StateRunning)
 				}
+				tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(2) // start with 2 = UNKNOWN
 				tm.stats.subscribeResponseReceived.WithLabelValues(mt.Name, resp.SubscriptionName).Inc()
 				outs := func() map[string]struct{} {
 					if len(subscriptionOutputs) > 0 {
@@ -891,17 +896,31 @@ func (tm *TargetsManager) startTargetSubscription(mt *ManagedTarget, cfg *types.
 				// Reset so the next successful response after retry
 				// triggers a state update back to "running".
 				initialResponse = true
-				mt.setLastError(err.Err.Error())
-				currentState := tm.getTargetStateStr(mt.Name)
-				if currentState != "" {
-					tm.setTargetState(mt.Name, currentState)
-				}
-				tm.stats.subscriptionFailedCount.WithLabelValues(mt.Name, err.SubscriptionName, subscriptionRequestErrorTypeGRPC).Inc()
-				tm.logger.Error("subscription error", "error", err)
+				tm.handleSubscriptionError(mt, err)
 			}
 		}
 	}()
 	return nil
+}
+
+func (tm *TargetsManager) handleSubscriptionError(mt *ManagedTarget, err *target.TargetError) {
+	if errors.Is(err.Err, io.EOF) {
+		tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(0) // OK
+		tm.logger.Info("subscription closed stream (EOF)", "target", mt.Name, "subscription", err.SubscriptionName)
+		return
+	}
+
+	mt.setLastError(err.Err.Error())
+	if currentState := tm.getTargetStateStr(mt.Name); currentState != "" {
+		tm.setTargetState(mt.Name, currentState)
+	}
+	tm.stats.subscriptionFailedCount.WithLabelValues(mt.Name, err.SubscriptionName, subscriptionRequestErrorTypeGRPC).Inc()
+
+	if st, ok := status.FromError(err.Err); ok {
+		grpcCode := float64(st.Code())
+		tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(grpcCode)
+	}
+	tm.logger.Error("subscription error", "error", err)
 }
 
 func shouldReconnect(old, new *types.TargetConfig) bool {


### PR DESCRIPTION
Fixed:
- Target listener getting stuck during a race condition
    Introduces uuid as an internal identifier for a target, so even if we remove and add quickly each time it will generate a new id, and we wil never end up gettign listener struck due to name
- Clean target metrics when it's removed

- Introduces gnmic_target_grpc_status_code gauge (app + collector paths) and registers it with the relevant registries.
- Updates target subscription loops to set the metric to OK (0) on successful responses and to a non-OK code on subscription errors (when available).
- Ensures the new per-target metric series is deleted when a target is removed.
Metric Output:

Positive case
```

# HELP gnmic_target_grpc_status_code The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. See https://pkg.go.dev/google.golang.org/grpc/codes. Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, 6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, 11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.
# TYPE gnmic_target_grpc_status_code gauge
gnmic_target_grpc_status_code{name="test-sim-amps-device-1"} 0
```
During authentication error:

gnmic log
`
time=2026-07-22T09:33:39.375+05:30 level=INFO msg="subscription receive error" target=test.device.net subscription=test-sample-5m err="rpc error: code = Unauthenticated desc = Authentication has failed"`
Generated metric
```

# HELP gnmic_target_grpc_status_code The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. See https://pkg.go.dev/google.golang.org/grpc/codes. Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, 6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, 11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.
# TYPE gnmic_target_grpc_status_code gauge
gnmic_target_grpc_status_code{name="test.device.net"} 16
```