### PR TITLE
Fix concurrent map read/write on Target.Subscriptions

### DIFF
--- a/pkg/api/target/subscribe.go
+++ b/pkg/api/target/subscribe.go
@@ -532,6 +532,26 @@ func (t *Target) DeleteSubscription(name string) {
 	delete(t.Subscriptions, name)
 }
 
+// SetSubscriptionConfig stores a subscription config under the target's lock.
+// Callers outside this package must use this method instead of writing to
+// t.Subscriptions directly: the map is read concurrently (under the same
+// lock) by SubscribeClientStates and the subscription goroutines.
+func (t *Target) SetSubscriptionConfig(cfg *types.SubscriptionConfig) {
+	t.m.Lock()
+	defer t.m.Unlock()
+	t.Subscriptions[cfg.Name] = cfg
+}
+
+// DeleteSubscriptionConfig removes only the subscription config entry under
+// the target's lock. Unlike DeleteSubscription, it does not cancel the
+// running subscription or remove the subscribe client; use it when the
+// caller manages the subscription lifecycle itself.
+func (t *Target) DeleteSubscriptionConfig(name string) {
+	t.m.Lock()
+	defer t.m.Unlock()
+	delete(t.Subscriptions, name)
+}
+
 func (t *Target) StopSubscription(name string) {
 	t.m.Lock()
 	defer t.m.Unlock()

--- a/pkg/api/target/subscribe_test.go
+++ b/pkg/api/target/subscribe_test.go
@@ -1,0 +1,51 @@
+// © 2022 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/openconfig/gnmic/pkg/api/types"
+)
+
+// TestSubscriptionsConcurrentAccess is a regression test for
+// https://github.com/openconfig/gnmic/issues/835: concurrent writes to
+// Target.Subscriptions (from the collector's targets manager) raced with
+// locked reads in SubscribeClientStates. Run with -race.
+func TestSubscriptionsConcurrentAccess(t *testing.T) {
+	tg := NewTarget(&types.TargetConfig{Name: "t1"})
+
+	var wg sync.WaitGroup
+	const iterations = 1000
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			tg.SetSubscriptionConfig(&types.SubscriptionConfig{
+				Name: fmt.Sprintf("sub%d", i%10),
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			tg.DeleteSubscriptionConfig(fmt.Sprintf("sub%d", i%10))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = tg.SubscribeClientStates()
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/collector/managers/targets/targets_manager.go
+++ b/pkg/collector/managers/targets/targets_manager.go
@@ -384,7 +384,7 @@ func (tm *TargetsManager) apply(name string, cfg *types.TargetConfig) {
 					mt.mu.Unlock()
 					tm.logger.Info("stopping target subscription", "name", sub, "target", name)
 					mt.T.StopSubscription(sub)
-					delete(mt.T.Subscriptions, sub)
+					mt.T.DeleteSubscriptionConfig(sub)
 					mt.appliedSubscriptions = slices.DeleteFunc(mt.appliedSubscriptions, func(s string) bool {
 						return s == sub
 					})
@@ -658,7 +658,7 @@ func (tm *TargetsManager) applySubscription(name string, cfg types.SubscriptionC
 		mt.T.StopSubscription(name)
 		tm.logger.Info("stopped target subscription", "name", name, "target", mt.Name)
 		// Wait for the reader goroutine to finish
-		mt.T.Subscriptions[name] = &cfg
+		mt.T.SetSubscriptionConfig(&cfg)
 		err := tm.startTargetSubscription(mt, &cfg)
 		if err != nil {
 			tm.logger.Error("failed to start target subscription", "subscription", name, "target", mt.Name, "error", err)
@@ -680,7 +680,7 @@ func (tm *TargetsManager) removeSubscription(name string) {
 		}
 		mt.mu.Unlock()
 		mt.T.StopSubscription(name)
-		delete(mt.T.Subscriptions, name)
+		mt.T.DeleteSubscriptionConfig(name)
 	}
 	tm.mu.Unlock()
 }
@@ -817,7 +817,7 @@ func (tm *TargetsManager) startTargetSubscription(mt *ManagedTarget, cfg *types.
 	}
 	tm.logger.Info("starting target Subscribe RPC", "name", cfg.Name, "target", mt.Name)
 
-	mt.T.Subscriptions[cfg.Name] = cfg
+	mt.T.SetSubscriptionConfig(cfg)
 	mt.readerWG.Add(1)
 	sctx, cfn := context.WithCancel(tm.ctx)
 	mt.mu.Lock()


### PR DESCRIPTION
The collector targets manager wrote to and deleted from Target.Subscriptions directly, racing with locked reads in SubscribeClientStates and the subscription goroutines, causing "concurrent map read and map write" panics.

Add locked SetSubscriptionConfig/DeleteSubscriptionConfig accessors to the target package and use them at the four unguarded call sites, plus a -race regression test.

Fixes #835 and #894