### PR TITLE
fix(influxdb_output): use-after-close on client rebuild

### DIFF
--- a/pkg/outputs/influxdb_output/influxdb_output.go
+++ b/pkg/outputs/influxdb_output/influxdb_output.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"text/template"
 	"time"
@@ -65,8 +66,18 @@ type influxDBOutput struct {
 	client *atomic.Pointer[influxdb2.Client]
 
 	logger    *slog.Logger
-	cancelFn  context.CancelFunc
 	eventChan chan *formatters.EventMsg
+
+	// rootCtx is the context Init was called with. Each worker generation runs
+	// under a context derived from it, so a client rebuild can cancel and wait
+	// for the previous generation without tearing down the output.
+	rootCtx  context.Context
+	cancelFn context.CancelFunc
+	// wg tracks the current worker generation. It is replaced together with
+	// cancelFn whenever workers are restarted; each worker is handed the wg it
+	// was started with so Done() always targets the right generation.
+	wg        *sync.WaitGroup
+	closeOnce sync.Once
 
 	reset    *atomic.Pointer[chan struct{}]
 	startSig *atomic.Pointer[chan struct{}]
@@ -89,6 +100,7 @@ func (i *influxDBOutput) init() {
 	i.eventChan = make(chan *formatters.EventMsg)
 	i.reset = new(atomic.Pointer[chan struct{}])
 	i.startSig = new(atomic.Pointer[chan struct{}])
+	i.wg = new(sync.WaitGroup)
 	i.logger = logging.DiscardLogger()
 }
 
@@ -225,27 +237,29 @@ func (i *influxDBOutput) Init(ctx context.Context, name string, cfg map[string]i
 	startSigChan := make(chan struct{})
 	i.startSig.Store(&startSigChan)
 
+	i.rootCtx = ctx
 	ctx, i.cancelFn = context.WithCancel(ctx)
 
 	influxOpts, err := clientOptsFor(newCfg)
 	if err != nil {
 		return err
 	}
-	// initialize influxdb client
-CRCLIENT:
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+	// initialize influxdb client. NewClientWithOptions performs no I/O, so it
+	// cannot fail because the server is unreachable.
 	newClient := influxdb2.NewClientWithOptions(newCfg.URL, newCfg.Token, influxOpts)
 	i.client.Store(&newClient)
 
 	// start influx health check
 	if newCfg.HealthCheckPeriod > 0 {
-		err = i.health(ctx)
-		if err != nil {
-			i.logger.Error("failed to check influxdb health", "err", err)
-			time.Sleep(2 * time.Second)
-			goto CRCLIENT
+		// Probe once so an unreachable server is visible in the logs at
+		// startup, but do not block on it: Init previously retried here
+		// forever, so gnmic never finished starting while influx was down.
+		// Recovery is the health check goroutine's job, matching Update().
+		if err := i.health(ctx); err != nil {
+			i.logger.Warn("influxdb health probe failed at init (continuing)", "err", err)
 		}
 		hcCtx, hcCancel := context.WithCancel(ctx)
 		i.healthCancel = hcCancel
@@ -255,11 +269,15 @@ CRCLIENT:
 	i.wasUP.Store(true)
 	i.logger.Info("initialized influxdb client", slog.Any("config", i.String()))
 
+	i.wg.Add(numWorkers)
 	for k := 0; k < numWorkers; k++ {
-		go i.worker(ctx, k)
+		go i.worker(ctx, i.wg, k)
 	}
+	// Watch the root context, not the worker-generation context: Update()
+	// cancels the latter to drain the previous worker generation, which must
+	// not be mistaken for the output shutting down.
 	go func() {
-		<-ctx.Done()
+		<-i.rootCtx.Done()
 		i.Close()
 	}()
 	return nil
@@ -414,20 +432,39 @@ func (i *influxDBOutput) Update(ctx context.Context, cfg map[string]any) error {
 			}
 		}
 
-		// swap client
+		// Publish the new client before starting the new workers so they pick
+		// it up at their START label.
 		oldClientPtr := i.client.Swap(&newClient)
-		oldClient := *oldClientPtr
 
-		// close old client
-		if oldClient != nil {
-			oldClient.Close()
+		// Restart the workers rather than signalling them through the reset
+		// channel. Workers capture the client once and hold it for the whole
+		// select loop, so the old client cannot be closed until every worker
+		// that captured it has exited -- closing it first is a use-after-close.
+		oldWG := i.wg
+		oldCancel := i.cancelFn
+
+		newWG := new(sync.WaitGroup)
+		i.wg = newWG
+		runCtx, cancel := context.WithCancel(i.rootCtx)
+		i.cancelFn = cancel
+
+		// Start the new generation first so eventChan always has a consumer and
+		// Write() never blocks during the swap.
+		newWG.Add(numWorkers)
+		for k := 0; k < numWorkers; k++ {
+			go i.worker(runCtx, newWG, k)
 		}
 
-		// signal workers to rebuild their write APIs
-		oldReset := i.reset.Load()
-		newResetChan := make(chan struct{})
-		i.reset.Store(&newResetChan)
-		close(*oldReset)
+		// Now drain the old generation, and only then close the client it held.
+		if oldCancel != nil {
+			oldCancel()
+		}
+		if oldWG != nil {
+			oldWG.Wait()
+		}
+		if oldClientPtr != nil && *oldClientPtr != nil {
+			(*oldClientPtr).Close()
+		}
 	}
 
 	// cache toggle
@@ -583,31 +620,41 @@ func (i *influxDBOutput) WriteEvent(ctx context.Context, ev *formatters.EventMsg
 }
 
 func (i *influxDBOutput) Close() error {
-	i.logger.Info("closing client")
+	i.closeOnce.Do(func() {
+		i.logger.Info("closing client")
 
-	cfg := i.cfg.Load()
-	if cfg != nil && cfg.CacheConfig != nil {
-		i.stopCache()
-	}
-	if i.healthCancel != nil {
-		i.healthCancel()
-		i.healthCancel = nil
-	}
-	i.cancelFn()
-
-	clientPtr := i.client.Load()
-	if *clientPtr != nil {
-		(*clientPtr).Close()
-	}
-	reset := i.reset.Load()
-	if reset != nil {
-		select {
-		case <-*reset:
-		default:
-			close(*reset) // unblock Write() and WriteEvent()
+		cfg := i.cfg.Load()
+		if cfg != nil && cfg.CacheConfig != nil {
+			i.stopCache()
 		}
-	}
-	i.logger.Info("closed")
+		if i.healthCancel != nil {
+			i.healthCancel()
+			i.healthCancel = nil
+		}
+		if i.cancelFn != nil {
+			i.cancelFn()
+		}
+
+		reset := i.reset.Load()
+		if reset != nil {
+			select {
+			case <-*reset:
+			default:
+				close(*reset) // unblock Write() and WriteEvent()
+			}
+		}
+
+		// Wait for the workers to release the client before closing it.
+		if i.wg != nil {
+			i.wg.Wait()
+		}
+
+		clientPtr := i.client.Load()
+		if clientPtr != nil && *clientPtr != nil {
+			(*clientPtr).Close()
+		}
+		i.logger.Info("closed")
+	})
 	return nil
 }
 
@@ -681,7 +728,8 @@ func (i *influxDBOutput) health(ctx context.Context) error {
 	return nil
 }
 
-func (i *influxDBOutput) worker(ctx context.Context, idx int) {
+func (i *influxDBOutput) worker(ctx context.Context, wg *sync.WaitGroup, idx int) {
+	defer wg.Done()
 	firstStart := true
 START:
 	if ctx.Err() != nil {
@@ -699,7 +747,15 @@ START:
 		i.logger.Info("worker waiting for client recovery", "worker", idx)
 		startSigChan := i.startSig.Load()
 		if startSigChan != nil {
-			<-*startSigChan
+			// Must stay cancellable: Close() waits on the worker WaitGroup, so a
+			// worker parked here while influx is down would otherwise hang
+			// shutdown until the health check recovers.
+			select {
+			case <-ctx.Done():
+				i.logger.Info("worker terminating", "worker", idx)
+				return
+			case <-*startSigChan:
+			}
 		}
 	}
 

--- a/pkg/outputs/influxdb_output/influxdb_output_test.go
+++ b/pkg/outputs/influxdb_output/influxdb_output_test.go
@@ -6,8 +6,16 @@ package influxdb_output
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/openconfig/gnmic/pkg/formatters"
 
 	"github.com/openconfig/gnmic/pkg/api/types"
 	"github.com/openconfig/gnmic/pkg/outputs"
@@ -97,5 +105,141 @@ func TestClientOptsFor(t *testing.T) {
 	}
 	if _, err := clientOptsFor(&Config{TLS: &types.TLSConfig{CaFile: "/no/such/file.pem"}}); err == nil {
 		t.Fatal("expected TLS config error")
+	}
+}
+
+// TestInfluxDBOutput_UpdateUnderConcurrentWrites is a regression test for the
+// use-after-close on client rebuild: Update() used to close the old influx
+// client immediately after swapping the pointer, while workers were still
+// holding it and calling client.WriteAPI(). Run with -race.
+func TestInfluxDBOutput_UpdateUnderConcurrentWrites(t *testing.T) {
+	i := &influxDBOutput{}
+	base := func(org string) map[string]any {
+		return map[string]any{
+			"url":                 "http://127.0.0.1:9",
+			"org":                 org,
+			"bucket":              "b",
+			"token":               "t",
+			"health-check-period": "0",
+			"flush-timer":         "1h",
+			"batch-size":          10,
+		}
+	}
+	if err := i.Init(context.Background(), "in1", base("o0"),
+		outputs.WithConfigStore(memStore())); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = i.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	// writers feeding the worker while the client is rebuilt underneath them
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				i.WriteEvent(ctx, &formatters.EventMsg{
+					Name:      "m",
+					Timestamp: time.Now().UnixNano(),
+					Tags:      map[string]string{"t": "v"},
+					Values:    map[string]any{"v": 1},
+				})
+			}
+		}()
+	}
+
+	// force a client rebuild on every Update by changing the token
+	for n := 0; n < 12; n++ {
+		cfg := base("o0")
+		cfg["token"] = fmt.Sprintf("tok%d", n)
+		if err := i.Update(context.Background(), cfg); err != nil {
+			cancel()
+			wg.Wait()
+			t.Fatalf("Update %d: %v", n, err)
+		}
+	}
+
+	cancel()
+	wg.Wait()
+}
+
+// Close() waits on the worker WaitGroup, so every blocking point inside a
+// worker must observe context cancellation. A worker parked waiting for health
+// recovery previously had an unconditional receive on the startSig channel,
+// which would hang shutdown until influx came back.
+func TestInfluxDBOutput_CloseReturnsWhileWorkerAwaitsRecovery(t *testing.T) {
+	var healthy atomic.Bool
+	healthy.Store(true)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !healthy.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"influxdb","status":"pass","version":"2.0.0"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	i := &influxDBOutput{}
+	cfg := map[string]any{
+		"url":                 srv.URL,
+		"org":                 "o",
+		"bucket":              "b",
+		"token":               "t",
+		"health-check-period": "50ms",
+		"flush-timer":         "1h",
+		"batch-size":          10,
+	}
+	if err := i.Init(context.Background(), "in2", cfg,
+		outputs.WithConfigStore(memStore())); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Take influx away so the health check fails and the worker parks on
+	// startSig waiting for recovery.
+	healthy.Store(false)
+	time.Sleep(300 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() { _ = i.Close(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close() hung waiting for a worker parked on startSig")
+	}
+}
+
+// Init used to retry the health probe in a `goto CRCLIENT` loop with a 2s
+// sleep, so it never returned while influx was unreachable and gnmic hung at
+// startup. It must now start and let the health check goroutine recover.
+func TestInfluxDBOutput_InitDoesNotBlockOnDeadServer(t *testing.T) {
+	i := &influxDBOutput{}
+	cfg := map[string]any{
+		"url":                 "http://127.0.0.1:9",
+		"org":                 "o",
+		"bucket":              "b",
+		"token":               "t",
+		"health-check-period": "50ms",
+		"flush-timer":         "1h",
+		"batch-size":          10,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- i.Init(context.Background(), "dead", cfg,
+			outputs.WithConfigStore(memStore()))
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Init returned an error instead of starting: %v", err)
+		}
+		t.Cleanup(func() { _ = i.Close() })
+	case <-time.After(10 * time.Second):
+		t.Fatal("Init blocked while the influx server was unreachable")
 	}
 }


### PR DESCRIPTION
Update() closed the old influx client immediately after swapping the pointer, while workers still held it and kept calling client.WriteAPI() Workers now run under a per-generation context and WaitGroup, so a rebuild starts the new generation, drains the old one, and only then closes the client it held.