### PR TITLE
cmd: Report missing explicit config files

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -11,7 +11,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/signal"
 	"syscall"
@@ -105,11 +104,7 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	err := gApp.Config.Load(gApp.Context())
-	if err == nil {
-		return
-	}
-	if _, ok := err.(*fs.PathError); !ok {
+	if err := gApp.Config.Load(gApp.Context()); err != nil {
 		fmt.Fprintf(os.Stderr, "failed loading config file: %v\n", err)
 	}
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openconfig/gnmic/pkg/config"
+)
+
+// captureStderr redirects os.Stderr for the duration of f and returns
+// everything written to it.
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	f()
+
+	w.Close()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed reading captured stderr: %v", err)
+	}
+	r.Close()
+	return buf.String()
+}
+
+// TestInitConfigReportsExplicitMissingConfig is a regression test for
+// https://github.com/openconfig/gnmic/issues/772: when the user explicitly
+// points --config at a file that does not exist, initConfig() must report
+// the load failure on stderr instead of silently continuing as if no config
+// file had been requested.
+//
+// This exercises initConfig() itself (the code that changed), not
+// Config.Load() in isolation.
+func TestInitConfigReportsExplicitMissingConfig(t *testing.T) {
+	origConfig := gApp.Config
+	gApp.Config = config.New()
+	t.Cleanup(func() {
+		gApp.Config = origConfig
+	})
+
+	missing := filepath.Join(t.TempDir(), "tunnel_server_config.yaml")
+	gApp.Config.CfgFile = missing
+
+	out := captureStderr(t, initConfig)
+
+	if !strings.Contains(out, "failed loading config file") {
+		t.Errorf("initConfig() with a missing explicit --config produced no error message; got stderr: %q", out)
+	}
+	if !strings.Contains(out, missing) {
+		t.Errorf("initConfig() error message does not reference the missing config path %q; got: %q", missing, out)
+	}
+}


### PR DESCRIPTION
An explicitly provided `--config` path that did not exist returned a filesystem error from `Config.Load`, but `initConfig` suppressed all `*fs.PathError` values. As a result, gNMIc continued silently even though the user had requested a specific config file.

Report any error that `Config.Load` returns. The config loader already ignores a missing auto-discovered/default config file, so that behavior remains unchanged.

Add a regression test verifying that a missing explicitly configured file is reported. This change only surfaces the existing load error; it does not change command exit behavior.

Testing:
- `go test ./pkg/cmd/... -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`

Fixes #772
