### PR TITLE
feat(target): expose gRPC state metric

### DIFF
--- a/.github/workflows/close_state_issues.yml
+++ b/.github/workflows/close_state_issues.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           days-before-issue-stale: 365
           days-before-issue-close: 30

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,5 +25,5 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - run: docker run -v $(pwd):/docs --entrypoint ash squidfunk/mkdocs-material:${MKDOCS_MATERIAL_VER} -c 'git config --global --add safe.directory /docs; mkdocs gh-deploy --force --strict'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,12 +28,12 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GOVER }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.46

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GOVER }}
       - run: ./tests/run_tests.sh
@@ -41,26 +41,26 @@ jobs:
     needs:
       - test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GOVER }}
 
       - name: Login to github container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Release with goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: ${{ env.GORELEASER_VER }}
           args: release --clean --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GOVER }}
       - run: ./tests/run_tests.sh

--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -52,6 +52,19 @@ var targetConnStateMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help:      "The current gRPC connection state to the target. The value can be one of the following: 0(UNKNOWN), 1 (IDLE), 2 (CONNECTING), 3 (READY), 4 (TRANSIENT_FAILURE), or 5 (SHUTDOWN).",
 }, []string{"name"})
 
+// targetGrpcStateMetric tracks the last gRPC status code received from each target.
+// See https://pkg.go.dev/google.golang.org/grpc/codes for the full reference.
+var targetGrpcStateMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "gnmic",
+	Subsystem: "target",
+	Name:      "grpc_status_code",
+	Help: "The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. " +
+		"See https://pkg.go.dev/google.golang.org/grpc/codes. " +
+		"Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, " +
+		"6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, " +
+		"11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.",
+}, []string{"name"})
+
 // cluster
 var clusterNumberOfLockedTargets = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: "gnmic",
@@ -75,10 +88,15 @@ func (a *App) registerTargetMetrics() {
 	if err != nil {
 		logging.LogErrUnlessCanceled(a.Logger, err, "failed to register target connection state metric")
 	}
+	err = a.reg.Register(targetGrpcStateMetric)
+	if err != nil {
+		a.Logger.Info("failed to register target grpc state metric", "err", err)
+	}
 	a.configLock.RLock()
 	for _, t := range a.Config.Targets {
 		targetUPMetric.WithLabelValues(t.Name).Set(0)
 		targetConnStateMetric.WithLabelValues(t.Name).Set(0)
+		targetGrpcStateMetric.WithLabelValues(t.Name).Set(2) // Unknown until first response
 	}
 	a.configLock.RUnlock()
 	go func() {

--- a/pkg/app/subscribe.go
+++ b/pkg/app/subscribe.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openconfig/grpctunnel/tunnel"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/openconfig/gnmic/pkg/api/target"
@@ -292,6 +293,7 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 					}
 
 					a.export(ctx, rsp.Response, m, outs...)
+					targetGrpcStateMetric.WithLabelValues(t.Config.Name).Set(0)
 					if remainingOnceSubscriptions > 0 {
 						if a.subscriptionMode(rsp.SubscriptionName) == subscriptionModeONCE {
 							switch rsp.Response.Response.(type) {
@@ -309,9 +311,13 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 				case tErr := <-errChan:
 					if errors.Is(tErr.Err, io.EOF) {
 						a.Logger.Info("subscription closed stream (EOF)", "target", t.Config.Name, "subscription", tErr.SubscriptionName)
+						targetGrpcStateMetric.WithLabelValues(t.Config.Name).Set(0) // OK
 					} else {
 						subscribeResponseFailedCounter.WithLabelValues(t.Config.Name, tErr.SubscriptionName).Inc()
 						logging.LogErrUnlessCanceled(a.Logger, tErr.Err, "subscription receive error", "target", t.Config.Name, "subscription", tErr.SubscriptionName)
+						if st, ok := status.FromError(tErr.Err); ok {
+							targetGrpcStateMetric.WithLabelValues(t.Config.Name).Set(float64(st.Code()))
+						}
 					}
 					if remainingOnceSubscriptions > 0 {
 						if a.subscriptionMode(tErr.SubscriptionName) == subscriptionModeONCE {

--- a/pkg/collector/managers/targets/metrics.go
+++ b/pkg/collector/managers/targets/metrics.go
@@ -72,6 +72,7 @@ type targetsStats struct {
 	subscriptionFailedCount   *prometheus.CounterVec
 	targetUPMetric            *prometheus.GaugeVec
 	targetConnStateMetric     *prometheus.GaugeVec
+	targetGrpcStateMetric     *prometheus.GaugeVec
 }
 
 const (
@@ -112,6 +113,18 @@ func newTargetsStats() *targetsStats {
 			Name:      "connection_state",
 			Help:      "The current gRPC connection state to the target. The value can be one of the following: 0(UNKNOWN), 1 (IDLE), 2 (CONNECTING), 3 (READY), 4 (TRANSIENT_FAILURE), or 5 (SHUTDOWN).",
 		}, []string{"name"}),
+		// targetGrpcStateMetric tracks the last gRPC status code received from each target.
+		// See https://pkg.go.dev/google.golang.org/grpc/codes for the full reference.
+		targetGrpcStateMetric: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "gnmic",
+			Subsystem: "target",
+			Name:      "grpc_status_code",
+			Help: "The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. " +
+				"See https://pkg.go.dev/google.golang.org/grpc/codes. " +
+				"Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, " +
+				"6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, " +
+				"11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.",
+		}, []string{"name"}),
 	}
 }
 
@@ -121,6 +134,7 @@ func (tm *TargetsManager) registerMetrics() {
 	tm.reg.MustRegister(tm.stats.subscribeResponseReceived)
 	tm.reg.MustRegister(tm.stats.droppedSubscribeResponses)
 	tm.reg.MustRegister(tm.stats.subscriptionFailedCount)
+	tm.reg.MustRegister(tm.stats.targetGrpcStateMetric)
 
 	tm.mu.RLock()
 	for _, mt := range tm.targets {
@@ -150,6 +164,7 @@ func (tm *TargetsManager) updateTargetMetrics(mt *ManagedTarget) {
 	if mt.T == nil {
 		tm.stats.targetUPMetric.WithLabelValues(mt.Name).Set(0)
 		tm.stats.targetConnStateMetric.WithLabelValues(mt.Name).Set(0)
+		tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(2) // Unknown until first response
 		return
 	}
 	tm.stats.targetUPMetric.WithLabelValues(mt.Name).Set(1)

--- a/pkg/collector/managers/targets/targets_manager.go
+++ b/pkg/collector/managers/targets/targets_manager.go
@@ -3,8 +3,10 @@ package targets_manager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"log/slog"
 	"maps"
 	"net"
@@ -28,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/zestor-dev/zestor/store"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
 )
 
 type ManagedTarget struct {
@@ -855,6 +858,7 @@ func (tm *TargetsManager) startTargetSubscription(mt *ManagedTarget, cfg *types.
 					mt.clearLastError()
 					tm.setTargetState(mt.Name, collstore.StateRunning)
 				}
+				tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(2) // start with 2 = UNKNOWN
 				tm.stats.subscribeResponseReceived.WithLabelValues(mt.Name, resp.SubscriptionName).Inc()
 				outs := func() map[string]struct{} {
 					if len(subscriptionOutputs) > 0 {
@@ -892,16 +896,31 @@ func (tm *TargetsManager) startTargetSubscription(mt *ManagedTarget, cfg *types.
 				// triggers a state update back to "running".
 				initialResponse = true
 				mt.setLastError(err.Err.Error())
-				currentState := tm.getTargetStateStr(mt.Name)
-				if currentState != "" {
-					tm.setTargetState(mt.Name, currentState)
-				}
-				tm.stats.subscriptionFailedCount.WithLabelValues(mt.Name, err.SubscriptionName, subscriptionRequestErrorTypeGRPC).Inc()
-				tm.logger.Error("subscription error", "error", err)
+				tm.handleSubscriptionError(mt, err)
 			}
 		}
 	}()
 	return nil
+}
+
+func (tm *TargetsManager) handleSubscriptionError(mt *ManagedTarget, err *target.TargetError) {
+	if errors.Is(err.Err, io.EOF) {
+		tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(0) // OK
+		tm.logger.Info("subscription closed stream (EOF)", "target", mt.Name, "subscription", err.SubscriptionName)
+		return
+	}
+
+	mt.setLastError(err.Err.Error())
+	if currentState := tm.getTargetStateStr(mt.Name); currentState != "" {
+		tm.setTargetState(mt.Name, currentState)
+	}
+	tm.stats.subscriptionFailedCount.WithLabelValues(mt.Name, err.SubscriptionName, subscriptionRequestErrorTypeGRPC).Inc()
+
+	if st, ok := status.FromError(err.Err); ok {
+		grpcCode := float64(st.Code())
+		tm.stats.targetGrpcStateMetric.WithLabelValues(mt.Name).Set(grpcCode)
+	}
+	tm.logger.Error("subscription error", "error", err)
 }
 
 func shouldReconnect(old, new *types.TargetConfig) bool {


### PR DESCRIPTION
Introduces gnmic_target_grpc_status_code metric to reflect grpc status code at runtime

```
# HELP gnmic_target_grpc_status_code The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. See https://pkg.go.dev/google.golang.org/grpc/codes. Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, 6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, 11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.
# TYPE gnmic_target_grpc_status_code gauge
gnmic_target_grpc_status_code{name="test-sim-amps-device-1"} 0
```

During authentication error:

gnmic log
`
 time=2026-07-22T09:33:39.375+05:30 level=INFO msg="subscription receive error" target=test.device.net subscription=test-sample-5m err="rpc error: code = Unauthenticated desc = Authentication has failed"`

Generated metric
```

# HELP gnmic_target_grpc_status_code The last gRPC status code received from the target. Default is 2 (Unknown) until the first response is received. See https://pkg.go.dev/google.golang.org/grpc/codes. Values: 0=OK, 1=Canceled, 2=Unknown, 3=InvalidArgument, 4=DeadlineExceeded, 5=NotFound, 6=AlreadyExists, 7=PermissionDenied, 8=ResourceExhausted, 9=FailedPrecondition, 10=Aborted, 11=OutOfRange, 12=Unimplemented, 13=Internal, 14=Unavailable, 15=DataLoss, 16=Unauthenticated.
# TYPE gnmic_target_grpc_status_code gauge
gnmic_target_grpc_status_code{name="test.device.net"} 16
```