### PR TITLE
fix(tcp): avoid blocking on full output buffer

### DIFF
--- a/docs/user_guide/outputs/tcp_output.md
+++ b/docs/user_guide/outputs/tcp_output.md
@@ -11,7 +11,8 @@ outputs:
     address: IPAddress:Port 
     # maximum sending rate, e.g: 1ns, 10ms
     rate: 10ms 
-    # number of messages to buffer in case of sending failure
+    # number of messages to buffer in case of sending failure.
+    # New messages are dropped when the buffer is full.
     buffer-size:
     # export format. json, protobuf, prototext, protojson, event
     format: json 
@@ -56,8 +57,10 @@ outputs:
 When `enable-metrics` is set to `true`, the TCP output exposes:
 
 - `gnmic_tcp_output_errors_total{name,reason}` for delivery errors. The `reason` label is `dial` or `write`.
-- `gnmic_tcp_output_dropped_messages_total{name,reason}` for messages dropped after the retry budget is exhausted.
+- `gnmic_tcp_output_dropped_messages_total{name,reason}` for dropped messages. The `reason` label is `buffer_full` or `max_retries`.
 
 `max-retries` applies only after a message has been dequeued for delivery. Dial failures while a message is pending count against its retry budget.
+
+When the TCP output buffer is full, new messages are dropped instead of blocking subscription processing. Increase `buffer-size` or `num-workers` when `reason="buffer_full"` increases.
 
 A TCP output can be used to export data to an ELK stack, using [Logstash TCP input](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html)

--- a/pkg/outputs/tcp_output/tcp_output.go
+++ b/pkg/outputs/tcp_output/tcp_output.go
@@ -386,13 +386,15 @@ func (t *tcpOutput) Write(ctx context.Context, m proto.Message, meta outputs.Met
 		}
 		buffer := t.buffer.Load()
 		for _, b := range bb {
-			t.enqueue(cfg, *buffer, b)
+			t.enqueue(ctx, cfg, *buffer, b)
 		}
 	}
 }
 
-func (t *tcpOutput) enqueue(cfg *config, buffer chan<- []byte, payload []byte) {
+func (t *tcpOutput) enqueue(ctx context.Context, cfg *config, buffer chan<- []byte, payload []byte) {
 	select {
+	case <-ctx.Done():
+		return
 	case buffer <- payload:
 	default:
 		t.logger.Warn("dropping TCP message because output buffer is full")

--- a/pkg/outputs/tcp_output/tcp_output.go
+++ b/pkg/outputs/tcp_output/tcp_output.go
@@ -386,7 +386,18 @@ func (t *tcpOutput) Write(ctx context.Context, m proto.Message, meta outputs.Met
 		}
 		buffer := t.buffer.Load()
 		for _, b := range bb {
-			(*buffer) <- b
+			t.enqueue(cfg, *buffer, b)
+		}
+	}
+}
+
+func (t *tcpOutput) enqueue(cfg *config, buffer chan<- []byte, payload []byte) {
+	select {
+	case buffer <- payload:
+	default:
+		t.logger.Warn("dropping TCP message because output buffer is full")
+		if cfg.EnableMetrics {
+			tcpOutputDroppedMessages.WithLabelValues(t.name, "buffer_full").Inc()
 		}
 	}
 }

--- a/pkg/outputs/tcp_output/tcp_output_metrics.go
+++ b/pkg/outputs/tcp_output/tcp_output_metrics.go
@@ -68,6 +68,7 @@ func (t *tcpOutput) registerMetrics(cfg *config) error {
 
 	tcpOutputErrors.WithLabelValues(t.name, "dial").Add(0)
 	tcpOutputErrors.WithLabelValues(t.name, "write").Add(0)
+	tcpOutputDroppedMessages.WithLabelValues(t.name, "buffer_full").Add(0)
 	tcpOutputDroppedMessages.WithLabelValues(t.name, "max_retries").Add(0)
 	return nil
 }

--- a/pkg/outputs/tcp_output/tcp_output_test.go
+++ b/pkg/outputs/tcp_output/tcp_output_test.go
@@ -392,6 +392,31 @@ func TestTCP_WriteDoesNotBlockWhenBufferIsFull(t *testing.T) {
 	}
 }
 
+func TestTCP_EnqueueReturnsWhenContextIsCanceled(t *testing.T) {
+	o := &tcpOutput{}
+	o.init()
+	o.name = t.Name()
+	cfg := &config{EnableMetrics: true}
+	buffer := make(chan []byte, 1)
+	buffer <- []byte("queued")
+	droppedBefore := testutil.ToFloat64(
+		tcpOutputDroppedMessages.WithLabelValues(o.name, "buffer_full"),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	o.enqueue(ctx, cfg, buffer, []byte("new"))
+
+	if got := len(buffer); got != 1 {
+		t.Fatalf("buffer length = %d, want 1", got)
+	}
+	if got := testutil.ToFloat64(
+		tcpOutputDroppedMessages.WithLabelValues(o.name, "buffer_full"),
+	) - droppedBefore; got != 0 {
+		t.Fatalf("buffer-full dropped metric delta = %v, want 0", got)
+	}
+}
+
 func TestTCP_UpdateEnablesMetrics(t *testing.T) {
 	addr, stop := freeTCPListener(t)
 	defer stop()

--- a/pkg/outputs/tcp_output/tcp_output_test.go
+++ b/pkg/outputs/tcp_output/tcp_output_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/outputs"
 	"github.com/zestor-dev/zestor/store"
 	"github.com/zestor-dev/zestor/store/gomap"
@@ -345,6 +347,48 @@ func TestTCP_RegisterMetrics(t *testing.T) {
 		if !got[want] {
 			t.Errorf("registered metrics missing %q", want)
 		}
+	}
+}
+
+func TestTCP_WriteDoesNotBlockWhenBufferIsFull(t *testing.T) {
+	o := &tcpOutput{}
+	o.init()
+	o.name = t.Name()
+	cfg := &config{EnableMetrics: true, Format: "protojson"}
+	o.cfg.Store(cfg)
+	o.dynCfg.Store(&dynConfig{
+		mo: &formatters.MarshalOptions{Format: cfg.Format},
+	})
+	buffer := make(chan []byte, 1)
+	buffer <- []byte("queued")
+	o.buffer.Store(&buffer)
+	droppedBefore := testutil.ToFloat64(
+		tcpOutputDroppedMessages.WithLabelValues(o.name, "buffer_full"),
+	)
+
+	done := make(chan struct{})
+	go func() {
+		o.Write(context.Background(), &gnmi.SubscribeResponse{
+			Response: &gnmi.SubscribeResponse_SyncResponse{SyncResponse: true},
+		}, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		<-buffer
+		<-done
+		t.Fatal("full TCP output buffer blocked the caller")
+	}
+	if got := len(buffer); got != 1 {
+		t.Fatalf("buffer length = %d, want 1", got)
+	}
+
+	if got := testutil.ToFloat64(
+		tcpOutputDroppedMessages.WithLabelValues(o.name, "buffer_full"),
+	) - droppedBefore; got != 1 {
+		t.Fatalf("buffer-full dropped metric delta = %v, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

The TCP output currently performs a blocking send to its internal bounded channel. If the TCP endpoint is unavailable and the buffer fills, `Write` never returns. Because the subscription export path waits for every output, this stalls subsequent subscription processing for the target and can also hold the goroutine after context cancellation.

This change:

- makes TCP output enqueue non-blocking;
- drops new messages when the configured buffer is full;
- records each overflow through `gnmic_tcp_output_dropped_messages_total{name,reason="buffer_full"}` when metrics are enabled;
- documents the buffer overflow behavior and remediation; and
- adds a regression test at the `Write` boundary.

Messages already dequeued by a worker retain the existing `max-retries` delivery behavior. This only changes what happens after the bounded input buffer has exhausted its capacity.

## Testing

- `go test ./pkg/outputs/tcp_output -count=20`
- `go test -race ./pkg/outputs/tcp_output -run 'TestTCP_(WriteDoesNotBlockWhenBufferIsFull|RetriesMessageAfterWriteFailure|DropsMessageAfterRetryLimit|UpdateEnablesMetrics)$' -count=5`
- `go vet ./pkg/outputs/tcp_output`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./pkg/outputs/tcp_output`
- `CGO_ENABLED=0 ./tests/run_tests.sh`

Fixes #942
