### PR TITLE
fix: release cluster locks during graceful shutdown

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -122,6 +122,9 @@ type App struct {
 	// processors plugin manager
 	pm *plugin_manager.PluginManager
 
+	shutdownOnce sync.Once
+	shutdownErr  error
+
 	// pprof
 	pprof *pprofServer
 }

--- a/pkg/app/shutdown.go
+++ b/pkg/app/shutdown.go
@@ -1,0 +1,16 @@
+package app
+
+// Shutdown stops application work and releases resources that must not be left
+// to lease expiry. It is safe to call more than once.
+func (a *App) Shutdown() error {
+	a.shutdownOnce.Do(func() {
+		if a.Cfn != nil {
+			a.Cfn()
+		}
+		if a.locker != nil {
+			a.shutdownErr = a.locker.Stop()
+		}
+		a.CleanupPlugins()
+	})
+	return a.shutdownErr
+}

--- a/pkg/app/shutdown.go
+++ b/pkg/app/shutdown.go
@@ -4,13 +4,13 @@ package app
 // to lease expiry. It is safe to call more than once.
 func (a *App) Shutdown() error {
 	a.shutdownOnce.Do(func() {
+		a.CleanupPlugins()
 		if a.Cfn != nil {
 			a.Cfn()
 		}
 		if a.locker != nil {
 			a.shutdownErr = a.locker.Stop()
 		}
-		a.CleanupPlugins()
 	})
 	return a.shutdownErr
 }

--- a/pkg/app/shutdown.go
+++ b/pkg/app/shutdown.go
@@ -1,7 +1,7 @@
 package app
 
-// Shutdown stops application work and releases resources that must not be left
-// to lease expiry. It is safe to call more than once.
+// Shutdown stops application work and releases leased resources.
+// Calls are serialized and idempotent.
 func (a *App) Shutdown() error {
 	a.shutdownOnce.Do(func() {
 		a.CleanupPlugins()

--- a/pkg/app/shutdown_test.go
+++ b/pkg/app/shutdown_test.go
@@ -1,11 +1,8 @@
 package app
 
 import (
-	"context"
 	"errors"
-	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/openconfig/gnmic/pkg/lockers"
 )
@@ -38,58 +35,15 @@ func TestShutdownCancelsContextAndStopsLockerOnce(t *testing.T) {
 }
 
 type shutdownTestLocker struct {
+	lockers.Locker
 	app                   *App
 	stopErr               error
 	stopCalls             int
 	contextCanceledAtStop bool
 }
 
-func (*shutdownTestLocker) Init(context.Context, map[string]any, ...lockers.Option) error {
-	return nil
-}
-
 func (l *shutdownTestLocker) Stop() error {
 	l.stopCalls++
 	l.contextCanceledAtStop = l.app.Context().Err() != nil
 	return l.stopErr
-}
-
-func (*shutdownTestLocker) SetLogger(*slog.Logger) {}
-
-func (*shutdownTestLocker) Lock(context.Context, string, []byte) (bool, error) {
-	return false, nil
-}
-
-func (*shutdownTestLocker) KeepLock(context.Context, string) (chan struct{}, chan error) {
-	return make(chan struct{}), make(chan error)
-}
-
-func (*shutdownTestLocker) IsLocked(context.Context, string) (bool, error) {
-	return false, nil
-}
-
-func (*shutdownTestLocker) Unlock(context.Context, string) error { return nil }
-
-func (*shutdownTestLocker) Register(context.Context, *lockers.ServiceRegistration) error {
-	return nil
-}
-
-func (*shutdownTestLocker) Deregister(string) error { return nil }
-
-func (*shutdownTestLocker) GetServices(context.Context, string, []string) ([]*lockers.Service, error) {
-	return nil, nil
-}
-
-func (*shutdownTestLocker) WatchServices(
-	context.Context,
-	string,
-	[]string,
-	chan<- []*lockers.Service,
-	time.Duration,
-) error {
-	return nil
-}
-
-func (*shutdownTestLocker) List(context.Context, string) (map[string]string, error) {
-	return nil, nil
 }

--- a/pkg/app/shutdown_test.go
+++ b/pkg/app/shutdown_test.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/openconfig/gnmic/pkg/lockers"
+)
+
+func TestShutdownCancelsContextAndStopsLockerOnce(t *testing.T) {
+	a := New()
+	wantErr := errors.New("stop failed")
+	locker := &shutdownTestLocker{app: a, stopErr: wantErr}
+	a.locker = locker
+
+	if err := a.Shutdown(); !errors.Is(err, wantErr) {
+		t.Fatalf("Shutdown() error = %v, want %v", err, wantErr)
+	}
+	if a.Context().Err() == nil {
+		t.Fatal("application context was not canceled")
+	}
+	if !locker.contextCanceledAtStop {
+		t.Fatal("locker stopped before the application context was canceled")
+	}
+	if locker.stopCalls != 1 {
+		t.Fatalf("locker Stop() calls = %d, want 1", locker.stopCalls)
+	}
+
+	if err := a.Shutdown(); !errors.Is(err, wantErr) {
+		t.Fatalf("second Shutdown() error = %v, want %v", err, wantErr)
+	}
+	if locker.stopCalls != 1 {
+		t.Fatalf("locker Stop() calls after second shutdown = %d, want 1", locker.stopCalls)
+	}
+}
+
+type shutdownTestLocker struct {
+	app                   *App
+	stopErr               error
+	stopCalls             int
+	contextCanceledAtStop bool
+}
+
+func (*shutdownTestLocker) Init(context.Context, map[string]any, ...lockers.Option) error {
+	return nil
+}
+
+func (l *shutdownTestLocker) Stop() error {
+	l.stopCalls++
+	l.contextCanceledAtStop = l.app.Context().Err() != nil
+	return l.stopErr
+}
+
+func (*shutdownTestLocker) SetLogger(*slog.Logger) {}
+
+func (*shutdownTestLocker) Lock(context.Context, string, []byte) (bool, error) {
+	return false, nil
+}
+
+func (*shutdownTestLocker) KeepLock(context.Context, string) (chan struct{}, chan error) {
+	return make(chan struct{}), make(chan error)
+}
+
+func (*shutdownTestLocker) IsLocked(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (*shutdownTestLocker) Unlock(context.Context, string) error { return nil }
+
+func (*shutdownTestLocker) Register(context.Context, *lockers.ServiceRegistration) error {
+	return nil
+}
+
+func (*shutdownTestLocker) Deregister(string) error { return nil }
+
+func (*shutdownTestLocker) GetServices(context.Context, string, []string) ([]*lockers.Service, error) {
+	return nil, nil
+}
+
+func (*shutdownTestLocker) WatchServices(
+	context.Context,
+	string,
+	[]string,
+	chan<- []*lockers.Service,
+	time.Duration,
+) error {
+	return nil
+}
+
+func (*shutdownTestLocker) List(context.Context, string) (map[string]string, error) {
+	return nil, nil
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -87,10 +87,13 @@ func newRootCmd() *cobra.Command {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	shutdownStarted, shutdownDone := setupCloseHandler(gApp.Shutdown)
+	shutdownStarted := setupCloseHandler(gApp.Shutdown)
 	err := newRootCmd().Execute()
-	if waitForShutdown(shutdownStarted, shutdownDone) {
+	select {
+	case <-shutdownStarted:
+		_ = gApp.Shutdown()
 		return
+	default:
 	}
 	if err != nil {
 		//fmt.Println(err)
@@ -112,10 +115,9 @@ func initConfig() {
 	}
 }
 
-func setupCloseHandler(shutdownFn func() error) (<-chan struct{}, <-chan struct{}) {
+func setupCloseHandler(shutdownFn func() error) <-chan struct{} {
 	c := make(chan os.Signal, 1)
 	started := make(chan struct{})
-	done := make(chan struct{})
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		sig := <-c
@@ -124,18 +126,7 @@ func setupCloseHandler(shutdownFn func() error) (<-chan struct{}, <-chan struct{
 		if err := shutdownFn(); err != nil {
 			fmt.Fprintf(os.Stderr, "shutdown failed: %v\n", err)
 		}
-		close(done)
 		os.Exit(0)
 	}()
-	return started, done
-}
-
-func waitForShutdown(started, done <-chan struct{}) bool {
-	select {
-	case <-started:
-		<-done
-		return true
-	default:
-		return false
-	}
+	return started
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -87,8 +87,12 @@ func newRootCmd() *cobra.Command {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	setupCloseHandler(gApp.Shutdown)
-	if err := newRootCmd().Execute(); err != nil {
+	shutdownStarted, shutdownDone := setupCloseHandler(gApp.Shutdown)
+	err := newRootCmd().Execute()
+	if waitForShutdown(shutdownStarted, shutdownDone) {
+		return
+	}
+	if err != nil {
 		//fmt.Println(err)
 		os.Exit(1)
 	}
@@ -108,15 +112,30 @@ func initConfig() {
 	}
 }
 
-func setupCloseHandler(shutdownFn func() error) {
+func setupCloseHandler(shutdownFn func() error) (<-chan struct{}, <-chan struct{}) {
 	c := make(chan os.Signal, 1)
+	started := make(chan struct{})
+	done := make(chan struct{})
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		sig := <-c
+		close(started)
 		fmt.Printf("\nreceived signal '%s'. terminating...\n", sig.String())
 		if err := shutdownFn(); err != nil {
 			fmt.Fprintf(os.Stderr, "shutdown failed: %v\n", err)
 		}
+		close(done)
 		os.Exit(0)
 	}()
+	return started, done
+}
+
+func waitForShutdown(started, done <-chan struct{}) bool {
+	select {
+	case <-started:
+		<-done
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -9,7 +9,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -88,7 +87,7 @@ func newRootCmd() *cobra.Command {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	setupCloseHandler(gApp.Cfn)
+	setupCloseHandler(gApp.Shutdown)
 	if err := newRootCmd().Execute(); err != nil {
 		//fmt.Println(err)
 		os.Exit(1)
@@ -109,14 +108,15 @@ func initConfig() {
 	}
 }
 
-func setupCloseHandler(cancelFn context.CancelFunc) {
+func setupCloseHandler(shutdownFn func() error) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		sig := <-c
 		fmt.Printf("\nreceived signal '%s'. terminating...\n", sig.String())
-		gApp.CleanupPlugins()
-		cancelFn()
+		if err := shutdownFn(); err != nil {
+			fmt.Fprintf(os.Stderr, "shutdown failed: %v\n", err)
+		}
 		os.Exit(0)
 	}()
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/openconfig/gnmic/pkg/config"
 )
@@ -35,39 +34,6 @@ func captureStderr(t *testing.T, f func()) string {
 	}
 	r.Close()
 	return buf.String()
-}
-
-func TestWaitForShutdown(t *testing.T) {
-	t.Run("not started", func(t *testing.T) {
-		if waitForShutdown(make(chan struct{}), make(chan struct{})) {
-			t.Fatal("waitForShutdown() = true before shutdown started")
-		}
-	})
-
-	t.Run("waits for completion", func(t *testing.T) {
-		started := make(chan struct{})
-		done := make(chan struct{})
-		close(started)
-		returned := make(chan bool, 1)
-		go func() {
-			returned <- waitForShutdown(started, done)
-		}()
-
-		select {
-		case <-returned:
-			t.Fatal("waitForShutdown returned before shutdown completed")
-		case <-time.After(20 * time.Millisecond):
-		}
-		close(done)
-		select {
-		case waited := <-returned:
-			if !waited {
-				t.Fatal("waitForShutdown() = false after shutdown started")
-			}
-		case <-time.After(time.Second):
-			t.Fatal("waitForShutdown did not return after shutdown completed")
-		}
-	})
 }
 
 // TestInitConfigReportsExplicitMissingConfig is a regression test for

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openconfig/gnmic/pkg/config"
 )
@@ -34,6 +35,39 @@ func captureStderr(t *testing.T, f func()) string {
 	}
 	r.Close()
 	return buf.String()
+}
+
+func TestWaitForShutdown(t *testing.T) {
+	t.Run("not started", func(t *testing.T) {
+		if waitForShutdown(make(chan struct{}), make(chan struct{})) {
+			t.Fatal("waitForShutdown() = true before shutdown started")
+		}
+	})
+
+	t.Run("waits for completion", func(t *testing.T) {
+		started := make(chan struct{})
+		done := make(chan struct{})
+		close(started)
+		returned := make(chan bool, 1)
+		go func() {
+			returned <- waitForShutdown(started, done)
+		}()
+
+		select {
+		case <-returned:
+			t.Fatal("waitForShutdown returned before shutdown completed")
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(done)
+		select {
+		case waited := <-returned:
+			if !waited {
+				t.Fatal("waitForShutdown() = false after shutdown started")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("waitForShutdown did not return after shutdown completed")
+		}
+	})
 }
 
 // TestInitConfigReportsExplicitMissingConfig is a regression test for


### PR DESCRIPTION
## Summary

- centralize process shutdown in an idempotent `App.Shutdown` method
- cancel application work before stopping the configured locker
- release target/leader locks and service registration on `SIGTERM` instead of waiting for lease expiry
- prevent the command goroutine from exiting while signal-triggered cleanup is still running
- preserve lease expiry as the fallback when locker cleanup fails or the process is killed ungracefully

## Tests

- `go test ./...`
- `go test -race ./pkg/app ./pkg/cmd`

Fixes #944