### PR TITLE
feat(processor): add event field allow-list

### DIFF
--- a/docs/user_guide/event_processors/event_keep.md
+++ b/docs/user_guide/event_processors/event_keep.md
@@ -2,6 +2,9 @@ The `event-keep` processor removes tags or values that do not match the configur
 
 Selectors for names and values use OR semantics. Tags are filtered only when `tag-names` or `tags` is configured; values are filtered only when `value-names` or `values` is configured. An unconfigured category is left unchanged.
 
+`values` regular expressions match string values only. Retain numeric, boolean, structured,
+or other non-string values with `value-names`.
+
 ```yaml
 processors:
   keep-interface-counters:

--- a/docs/user_guide/event_processors/event_keep.md
+++ b/docs/user_guide/event_processors/event_keep.md
@@ -1,0 +1,32 @@
+The `event-keep` processor removes tags or values that do not match the configured regular expressions. It complements `event-delete` and is useful when an event contains many fields but only a small allow-list is needed.
+
+Selectors for names and values use OR semantics. Tags are filtered only when `tag-names` or `tags` is configured; values are filtered only when `value-names` or `values` is configured. An unconfigured category is left unchanged.
+
+```yaml
+processors:
+  keep-interface-counters:
+    event-keep:
+      value-names:
+        - '^/interfaces/[^/]+/(in-octets|out-octets)$'
+      tag-names:
+        - '^(resource_id|source)$'
+```
+
+Given the following event:
+
+```json
+{
+  "tags": {
+    "resource_id": "leaf-1",
+    "source": "192.0.2.1:57400",
+    "subscription-name": "interfaces"
+  },
+  "values": {
+    "/interfaces/ethernet-1/in-octets": 42,
+    "/interfaces/ethernet-1/out-octets": 24,
+    "/vendor/debug": "ignored"
+  }
+}
+```
+
+the processor keeps the two interface counters and the `resource_id` and `source` tags.

--- a/docs/user_guide/event_processors/event_keep.md
+++ b/docs/user_guide/event_processors/event_keep.md
@@ -2,6 +2,8 @@ The `event-keep` processor removes tags or values that do not match the configur
 
 Selectors for names and values use OR semantics. Tags are filtered only when `tag-names` or `tags` is configured; values are filtered only when `value-names` or `values` is configured. An unconfigured category is left unchanged.
 
+Events left without values, tags, or delete paths are discarded. Delete-only events are preserved.
+
 `values` regular expressions match string values only. Retain numeric, boolean, structured,
 or other non-string values with `value-names`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
           - Group by: user_guide/event_processors/event_group_by.md
           - IEEE Float32: user_guide/event_processors/event_ieeefloat32.md
           - JQ: user_guide/event_processors/event_jq.md
+          - Keep: user_guide/event_processors/event_keep.md
           - Merge: user_guide/event_processors/event_merge.md
           - Override TS: user_guide/event_processors/event_override_ts.md
           - Plugin: user_guide/event_processors/event_plugin.md

--- a/pkg/config/processors_test.go
+++ b/pkg/config/processors_test.go
@@ -39,6 +39,11 @@ processors:
     event-delete:
       value-names:
         - ".*out-unicast-packets"
+
+  proc-keep-value-name:
+    event-keep:
+      value-names:
+        - ".*in-octets"
 `),
 		out: map[string]map[string]interface{}{
 			"proc-convert-integer": {
@@ -55,6 +60,11 @@ processors:
 			"proc-delete-value-name": {
 				"event-delete": map[string]interface{}{
 					"value-names": []interface{}{".*out-unicast-packets"},
+				},
+			},
+			"proc-keep-value-name": {
+				"event-keep": map[string]interface{}{
+					"value-names": []interface{}{".*in-octets"},
 				},
 			},
 		},
@@ -80,6 +90,11 @@ processors:
     event-delete:
       value-names:
         - ".*out-unicast-packets"
+
+  proc-keep-value-name:
+    event-keep:
+      value-names:
+        - ".*in-octets"
 `),
 		out: map[string]map[string]interface{}{
 			"proc-convert-integer": {
@@ -96,6 +111,11 @@ processors:
 			"proc-delete-value-name": {
 				"event-delete": map[string]interface{}{
 					"value-names": []interface{}{".*out-unicast-packets"},
+				},
+			},
+			"proc-keep-value-name": {
+				"event-keep": map[string]interface{}{
+					"value-names": []interface{}{".*in-octets"},
 				},
 			},
 		},

--- a/pkg/formatters/all/all.go
+++ b/pkg/formatters/all/all.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_group_by"
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_ieeefloat32"
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_jq"
+	_ "github.com/openconfig/gnmic/pkg/formatters/event_keep"
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_merge"
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_override_ts"
 	_ "github.com/openconfig/gnmic/pkg/formatters/event_rate_limit"

--- a/pkg/formatters/event_keep/event_keep.go
+++ b/pkg/formatters/event_keep/event_keep.go
@@ -95,8 +95,13 @@ func compilePatterns(field string, patterns []string) ([]*regexp.Regexp, error) 
 func (p *keep) Apply(events ...*formatters.EventMsg) []*formatters.EventMsg {
 	filterValues := len(p.valueNames) > 0 || len(p.values) > 0
 	filterTags := len(p.tagNames) > 0 || len(p.tags) > 0
+	if !filterValues && !filterTags {
+		return events
+	}
+	kept := events[:0]
 	for _, event := range events {
 		if event == nil {
+			kept = append(kept, event)
 			continue
 		}
 		removedValues, removedTags := 0, 0
@@ -121,8 +126,14 @@ func (p *keep) Apply(events ...*formatters.EventMsg) []*formatters.EventMsg {
 		if removedValues > 0 || removedTags > 0 {
 			p.Logger.Debug("removed unmatched event fields", "values", removedValues, "tags", removedTags)
 		}
+		if len(event.Values) == 0 && len(event.Tags) == 0 && len(event.Deletes) == 0 {
+			p.Logger.Debug("removed empty event")
+			continue
+		}
+		kept = append(kept, event)
 	}
-	return events
+	clear(events[len(kept):])
+	return kept
 }
 
 func matchesString(value any, patterns []*regexp.Regexp) bool {

--- a/pkg/formatters/event_keep/event_keep.go
+++ b/pkg/formatters/event_keep/event_keep.go
@@ -1,0 +1,147 @@
+// © 2026 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package event_keep implements an event processor that retains matching
+// values and tags while removing the rest.
+package event_keep
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"github.com/openconfig/gnmic/pkg/formatters"
+	"github.com/openconfig/gnmic/pkg/logging"
+)
+
+const processorType = "event-keep"
+
+type keep struct {
+	formatters.BaseProcessor
+
+	Tags       []string `mapstructure:"tags,omitempty" json:"tags,omitempty"`
+	Values     []string `mapstructure:"values,omitempty" json:"values,omitempty"`
+	TagNames   []string `mapstructure:"tag-names,omitempty" json:"tag-names,omitempty"`
+	ValueNames []string `mapstructure:"value-names,omitempty" json:"value-names,omitempty"`
+	Debug      bool     `mapstructure:"debug,omitempty" json:"debug,omitempty"`
+
+	tags       []*regexp.Regexp
+	values     []*regexp.Regexp
+	tagNames   []*regexp.Regexp
+	valueNames []*regexp.Regexp
+}
+
+func init() {
+	formatters.Register(processorType, func() formatters.EventProcessor {
+		return &keep{}
+	})
+}
+
+func (p *keep) Init(cfg any, opts ...formatters.Option) error {
+	if err := formatters.DecodeConfig(cfg, p); err != nil {
+		return err
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.Logger == nil {
+		p.Logger = logging.DiscardLogger()
+	}
+	p.Logger = p.Logger.With("processor", processorType)
+
+	var err error
+	if p.tags, err = compilePatterns("tags", p.Tags); err != nil {
+		return err
+	}
+	if p.values, err = compilePatterns("values", p.Values); err != nil {
+		return err
+	}
+	if p.tagNames, err = compilePatterns("tag-names", p.TagNames); err != nil {
+		return err
+	}
+	if p.valueNames, err = compilePatterns("value-names", p.ValueNames); err != nil {
+		return err
+	}
+
+	if p.Logger.Enabled(context.Background(), slog.LevelDebug) {
+		if b, err := json.Marshal(p); err == nil {
+			p.Logger.Debug("initialized processor", "config", string(b))
+		} else {
+			p.Logger.Debug("initialized processor", "config", p)
+		}
+	}
+	return nil
+}
+
+func compilePatterns(field string, patterns []string) ([]*regexp.Regexp, error) {
+	result := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s pattern %q: %w", field, pattern, err)
+		}
+		result = append(result, re)
+	}
+	return result, nil
+}
+
+func (p *keep) Apply(events ...*formatters.EventMsg) []*formatters.EventMsg {
+	filterValues := len(p.valueNames) > 0 || len(p.values) > 0
+	filterTags := len(p.tagNames) > 0 || len(p.tags) > 0
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		removedValues, removedTags := 0, 0
+		if filterValues {
+			for name, value := range event.Values {
+				if matchesAny(name, p.valueNames) || matchesString(value, p.values) {
+					continue
+				}
+				delete(event.Values, name)
+				removedValues++
+			}
+		}
+		if filterTags {
+			for name, value := range event.Tags {
+				if matchesAny(name, p.tagNames) || matchesAny(value, p.tags) {
+					continue
+				}
+				delete(event.Tags, name)
+				removedTags++
+			}
+		}
+		if removedValues > 0 || removedTags > 0 {
+			p.Logger.Debug("removed unmatched event fields", "values", removedValues, "tags", removedTags)
+		}
+	}
+	return events
+}
+
+func matchesString(value any, patterns []*regexp.Regexp) bool {
+	text, ok := value.(string)
+	return ok && matchesAny(text, patterns)
+}
+
+func matchesAny(value string, patterns []*regexp.Regexp) bool {
+	for _, pattern := range patterns {
+		if pattern.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *keep) WithLogger(logger *slog.Logger) {
+	if !p.Debug {
+		logger = nil
+	}
+	p.BaseProcessor.WithLogger(logger)
+}

--- a/pkg/formatters/event_keep/event_keep_test.go
+++ b/pkg/formatters/event_keep/event_keep_test.go
@@ -1,0 +1,145 @@
+// © 2026 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package event_keep
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/openconfig/gnmic/pkg/formatters"
+)
+
+func TestKeepApply(t *testing.T) {
+	tests := map[string]struct {
+		config map[string]any
+		event  *formatters.EventMsg
+		want   *formatters.EventMsg
+	}{
+		"no selectors is a no-op": {
+			event: &formatters.EventMsg{
+				Values: map[string]any{"a": 1},
+				Tags:   map[string]string{"source": "leaf-1"},
+			},
+			want: &formatters.EventMsg{
+				Values: map[string]any{"a": 1},
+				Tags:   map[string]string{"source": "leaf-1"},
+			},
+		},
+		"value names retain matching fields": {
+			config: map[string]any{"value-names": []string{"^/interfaces/", "^/system/uptime$"}},
+			event: &formatters.EventMsg{
+				Values: map[string]any{
+					"/interfaces/ethernet-1/in-octets": 42,
+					"/system/uptime":                   10,
+					"/vendor/debug":                    "ignored",
+				},
+				Tags: map[string]string{"source": "leaf-1"},
+			},
+			want: &formatters.EventMsg{
+				Values: map[string]any{
+					"/interfaces/ethernet-1/in-octets": 42,
+					"/system/uptime":                   10,
+				},
+				Tags: map[string]string{"source": "leaf-1"},
+			},
+		},
+		"name and value selectors use OR semantics": {
+			config: map[string]any{
+				"value-names": []string{"^state$"},
+				"values":      []string{"^UP$"},
+			},
+			event: &formatters.EventMsg{Values: map[string]any{
+				"state":  1,
+				"status": "UP",
+				"count":  2,
+			}},
+			want: &formatters.EventMsg{Values: map[string]any{
+				"state":  1,
+				"status": "UP",
+			}},
+		},
+		"tag selectors do not filter values": {
+			config: map[string]any{
+				"tag-names": []string{"^resource_id$"},
+				"tags":      []string{"^leaf-"},
+			},
+			event: &formatters.EventMsg{
+				Values: map[string]any{"state": 1},
+				Tags: map[string]string{
+					"resource_id": "resource-1",
+					"source":      "leaf-1",
+					"internal":    "drop",
+				},
+			},
+			want: &formatters.EventMsg{
+				Values: map[string]any{"state": 1},
+				Tags: map[string]string{
+					"resource_id": "resource-1",
+					"source":      "leaf-1",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			processor := &keep{}
+			if err := processor.Init(test.config); err != nil {
+				t.Fatalf("Init() error = %v", err)
+			}
+			got := processor.Apply(test.event)
+			if len(got) != 1 || !reflect.DeepEqual(got[0], test.want) {
+				t.Fatalf("Apply() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestKeepApplyNil(t *testing.T) {
+	processor := &keep{}
+	if err := processor.Init(map[string]any{"value-names": []string{".*"}}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if got := processor.Apply(nil); len(got) != 1 || got[0] != nil {
+		t.Fatalf("Apply(nil) = %#v, want [nil]", got)
+	}
+}
+
+func TestKeepInitRejectsInvalidPattern(t *testing.T) {
+	processor := &keep{}
+	err := processor.Init(map[string]any{"value-names": []string{"["}})
+	if err == nil {
+		t.Fatal("Init() error = nil, want invalid regular expression")
+	}
+}
+
+func BenchmarkKeepWideEventValueNames(b *testing.B) {
+	processor := &keep{}
+	if err := processor.Init(map[string]any{
+		"value-names": []string{`^/COUNTERS/[^/]+/(SAI_PORT_STAT_IF_IN_OCTETS|SAI_PORT_STAT_IF_OUT_OCTETS)$`},
+	}); err != nil {
+		b.Fatal(err)
+	}
+	template := make(map[string]any, 34_014)
+	for i := range 34_012 {
+		template["/COUNTERS/oid:0x1/VENDOR_FIELD_"+strconv.Itoa(i)] = i
+	}
+	template["/COUNTERS/oid:0x1/SAI_PORT_STAT_IF_IN_OCTETS"] = 1
+	template["/COUNTERS/oid:0x1/SAI_PORT_STAT_IF_OUT_OCTETS"] = 2
+
+	b.ReportAllocs()
+	for b.Loop() {
+		values := make(map[string]any, len(template))
+		for key, value := range template {
+			values[key] = value
+		}
+		processor.Apply(&formatters.EventMsg{Values: values})
+	}
+}

--- a/pkg/formatters/event_keep/event_keep_test.go
+++ b/pkg/formatters/event_keep/event_keep_test.go
@@ -122,6 +122,35 @@ func TestKeepApplyNil(t *testing.T) {
 	}
 }
 
+func TestKeepApplyFiltersEmptyEvents(t *testing.T) {
+	processor := &keep{}
+	if err := processor.Init(map[string]any{
+		"value-names": []string{"^keep$"},
+		"tag-names":   []string{"^keep$"},
+	}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	empty := &formatters.EventMsg{
+		Values: map[string]any{"drop": 1},
+		Tags:   map[string]string{"drop": "tag"},
+	}
+	deleted := &formatters.EventMsg{
+		Tags:    map[string]string{"drop": "tag"},
+		Deletes: []string{"/interfaces/interface[name=ethernet-1]"},
+	}
+	retained := &formatters.EventMsg{
+		Values: map[string]any{"keep": 1},
+		Tags:   map[string]string{"drop": "tag"},
+	}
+
+	got := processor.Apply(empty, deleted, retained)
+	want := []*formatters.EventMsg{deleted, retained}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Apply() = %#v, want %#v", got, want)
+	}
+}
+
 func TestKeepInitRejectsInvalidPattern(t *testing.T) {
 	processor := &keep{}
 	err := processor.Init(map[string]any{"value-names": []string{"["}})

--- a/pkg/formatters/event_keep/event_keep_test.go
+++ b/pkg/formatters/event_keep/event_keep_test.go
@@ -65,6 +65,16 @@ func TestKeepApply(t *testing.T) {
 				"status": "UP",
 			}},
 		},
+		"value selectors match strings only": {
+			config: map[string]any{"values": []string{"^2$"}},
+			event: &formatters.EventMsg{Values: map[string]any{
+				"string": "2",
+				"number": 2,
+			}},
+			want: &formatters.EventMsg{Values: map[string]any{
+				"string": "2",
+			}},
+		},
 		"tag selectors do not filter values": {
 			config: map[string]any{
 				"tag-names": []string{"^resource_id$"},

--- a/pkg/formatters/processors.go
+++ b/pkg/formatters/processors.go
@@ -35,6 +35,7 @@ var EventProcessorTypes = []string{
 	"event-group-by",
 	"event-ieeefloat32",
 	"event-jq",
+	"event-keep",
 	"event-merge",
 	"event-override-ts",
 	"event-rate-limit",


### PR DESCRIPTION
## What changed

- add an `event-keep` processor that retains matching value/tag names or values
  and removes unmatched entries in place
- leave values or tags untouched when that category has no configured selectors
- discard events left without values, tags, or delete paths while preserving
  delete-only events
- define `values` matching as string-only; non-string fields can be selected by
  `value-names`
- register and document the processor
- cover no-op, name matching, string value matching, OR semantics, independent
  tag/value filtering, empty and delete-only events, nil events, invalid regexes,
  config loading, and numeric value behavior
- add a 34,014-field benchmark matching the production-shaped wide-event case

## Why

`event-allow` filters whole events and `event-delete` requires enumerating every
unwanted field. Wide telemetry events need a native allow-list before
Starlark/JQ transformations so their cost scales with exported fields instead
of the full vendor payload.

Benchmark on the submitted implementation:

```text
BenchmarkKeepWideEventValueNames-16  385  2941781 ns/op  2624901 B/op  131 allocs/op
BenchmarkKeepWideEventValueNames-16  416  2783426 ns/op  2624813 B/op  130 allocs/op
BenchmarkKeepWideEventValueNames-16  435  2715901 ns/op  2624811 B/op  130 allocs/op
```

The benchmark includes cloning the 34,014-entry input map on every iteration;
the processor then reduces it to two retained fields.

## Validation

- `go test -race ./pkg/formatters/... ./pkg/config`
- `git diff --check`

Closes #950.
