### PR TITLE
perf(processor): avoid condition JSON round trip

### DIFF
--- a/pkg/formatters/condition.go
+++ b/pkg/formatters/condition.go
@@ -1,0 +1,136 @@
+// © 2026 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package formatters
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/itchyny/gojq"
+)
+
+func CheckCondition(code *gojq.Code, event *EventMsg) (bool, error) {
+	if code == nil {
+		return true, nil
+	}
+
+	input, err := conditionInput(event)
+	if err != nil {
+		return false, err
+	}
+	result, ok := code.Run(input).Next()
+	if !ok {
+		return false, nil
+	}
+	if err, ok := result.(error); ok {
+		return false, err
+	}
+	matched, ok := result.(bool)
+	if !ok {
+		return false, fmt.Errorf("unexpected condition return type: %T | %v", result, result)
+	}
+	return matched, nil
+}
+
+func conditionInput(event *EventMsg) (map[string]interface{}, error) {
+	input := event.ToMap()
+	if input == nil {
+		return nil, nil
+	}
+	cloned, err := cloneConditionValue(input)
+	if err != nil {
+		return nil, err
+	}
+	return cloned.(map[string]interface{}), nil
+}
+
+// cloneConditionValue copies mutable containers and converts values that are
+// not native gojq inputs while preserving encoding/json byte-slice semantics.
+func cloneConditionValue(value interface{}) (interface{}, error) {
+	switch value := value.(type) {
+	case nil, bool, string, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64:
+		return value, nil
+	case float64:
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return cloneConditionValueFallback(value)
+		}
+		return value, nil
+	case float32:
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return cloneConditionValueFallback(value)
+		}
+		return value, nil
+	case []byte:
+		if value == nil {
+			return nil, nil
+		}
+		return base64.StdEncoding.EncodeToString(value), nil
+	case map[string]interface{}:
+		if value == nil {
+			return nil, nil
+		}
+		cloned := make(map[string]interface{}, len(value))
+		for key, child := range value {
+			var err error
+			cloned[key], err = cloneConditionValue(child)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return cloned, nil
+	case map[string]string:
+		if value == nil {
+			return nil, nil
+		}
+		cloned := make(map[string]interface{}, len(value))
+		for key, child := range value {
+			cloned[key] = child
+		}
+		return cloned, nil
+	case []interface{}:
+		if value == nil {
+			return nil, nil
+		}
+		cloned := make([]interface{}, len(value))
+		for index, child := range value {
+			var err error
+			cloned[index], err = cloneConditionValue(child)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return cloned, nil
+	case []string:
+		if value == nil {
+			return nil, nil
+		}
+		cloned := make([]interface{}, len(value))
+		for index, child := range value {
+			cloned[index] = child
+		}
+		return cloned, nil
+	default:
+		return cloneConditionValueFallback(value)
+	}
+}
+
+func cloneConditionValueFallback(value interface{}) (interface{}, error) {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	var cloned interface{}
+	if err := json.Unmarshal(b, &cloned); err != nil {
+		return nil, err
+	}
+	return cloned, nil
+}

--- a/pkg/formatters/processors.go
+++ b/pkg/formatters/processors.go
@@ -109,7 +109,7 @@ func CheckCondition(code *gojq.Code, e *EventMsg) (bool, error) {
 
 	var res interface{}
 
-	iter := code.Run(e.ToMap())
+	iter := code.Run(conditionInput(e))
 	var ok bool
 	res, ok = iter.Next()
 	// iterator not done, so the final result won't be a boolean
@@ -125,6 +125,38 @@ func CheckCondition(code *gojq.Code, e *EventMsg) (bool, error) {
 		return res, nil
 	default:
 		return false, fmt.Errorf("unexpected condition return type: %T | %v", res, res)
+	}
+}
+
+func conditionInput(e *EventMsg) map[string]interface{} {
+	input := e.ToMap()
+	if input == nil {
+		return nil
+	}
+	// gojq normalizes maps and slices in place before evaluation. Conditions
+	// must not change the event observed by subsequent processors or outputs.
+	if values, ok := input["values"].(map[string]interface{}); ok {
+		input["values"] = cloneConditionValue(values)
+	}
+	return input
+}
+
+func cloneConditionValue(value interface{}) interface{} {
+	switch value := value.(type) {
+	case map[string]interface{}:
+		cloned := make(map[string]interface{}, len(value))
+		for key, child := range value {
+			cloned[key] = cloneConditionValue(child)
+		}
+		return cloned
+	case []interface{}:
+		cloned := make([]interface{}, len(value))
+		for index, child := range value {
+			cloned[index] = cloneConditionValue(child)
+		}
+		return cloned
+	default:
+		return value
 	}
 }
 

--- a/pkg/formatters/processors.go
+++ b/pkg/formatters/processors.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/itchyny/gojq"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openconfig/gnmic/pkg/api/types"
 	"github.com/openconfig/gnmic/pkg/logging"
@@ -99,64 +98,6 @@ func WithActions(acts map[string]map[string]interface{}) Option {
 func WithProcessors(procs map[string]map[string]interface{}) Option {
 	return func(p EventProcessor) {
 		p.WithProcessors(procs)
-	}
-}
-
-func CheckCondition(code *gojq.Code, e *EventMsg) (bool, error) {
-	if code == nil {
-		return true, nil
-	}
-
-	var res interface{}
-
-	iter := code.Run(conditionInput(e))
-	var ok bool
-	res, ok = iter.Next()
-	// iterator not done, so the final result won't be a boolean
-	if !ok {
-		return false, nil
-	}
-	if err, ok := res.(error); ok {
-		return false, err
-	}
-
-	switch res := res.(type) {
-	case bool:
-		return res, nil
-	default:
-		return false, fmt.Errorf("unexpected condition return type: %T | %v", res, res)
-	}
-}
-
-func conditionInput(e *EventMsg) map[string]interface{} {
-	input := e.ToMap()
-	if input == nil {
-		return nil
-	}
-	// gojq normalizes maps and slices in place before evaluation. Conditions
-	// must not change the event observed by subsequent processors or outputs.
-	if values, ok := input["values"].(map[string]interface{}); ok {
-		input["values"] = cloneConditionValue(values)
-	}
-	return input
-}
-
-func cloneConditionValue(value interface{}) interface{} {
-	switch value := value.(type) {
-	case map[string]interface{}:
-		cloned := make(map[string]interface{}, len(value))
-		for key, child := range value {
-			cloned[key] = cloneConditionValue(child)
-		}
-		return cloned
-	case []interface{}:
-		cloned := make([]interface{}, len(value))
-		for index, child := range value {
-			cloned[index] = cloneConditionValue(child)
-		}
-		return cloned
-	default:
-		return value
 	}
 }
 

--- a/pkg/formatters/processors.go
+++ b/pkg/formatters/processors.go
@@ -9,7 +9,6 @@
 package formatters
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -110,23 +109,14 @@ func CheckCondition(code *gojq.Code, e *EventMsg) (bool, error) {
 
 	var res interface{}
 
-	input := make(map[string]interface{})
-	b, err := json.Marshal(e)
-	if err != nil {
-		return false, err
-	}
-	err = json.Unmarshal(b, &input)
-	if err != nil {
-		return false, err
-	}
-	iter := code.Run(input)
+	iter := code.Run(e.ToMap())
 	var ok bool
 	res, ok = iter.Next()
 	// iterator not done, so the final result won't be a boolean
 	if !ok {
 		return false, nil
 	}
-	if err, ok = res.(error); ok {
+	if err, ok := res.(error); ok {
 		return false, err
 	}
 

--- a/pkg/formatters/processors_test.go
+++ b/pkg/formatters/processors_test.go
@@ -10,6 +10,8 @@ package formatters
 
 import (
 	"fmt"
+	"math"
+	"reflect"
 	"testing"
 	"time"
 
@@ -97,6 +99,48 @@ func TestCheckCondition(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCheckConditionDoesNotMutateEvent(t *testing.T) {
+	query, err := gojq.Parse(`.name == "port-counters" and .values.counter > 0`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	condition, err := gojq.Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := &EventMsg{
+		Name: "port-counters",
+		Values: map[string]interface{}{
+			"counter": uint64(math.MaxUint64),
+			"nested": []interface{}{
+				int64(1),
+				map[string]interface{}{"value": float32(2)},
+			},
+		},
+	}
+	want := &EventMsg{
+		Name: "port-counters",
+		Values: map[string]interface{}{
+			"counter": uint64(math.MaxUint64),
+			"nested": []interface{}{
+				int64(1),
+				map[string]interface{}{"value": float32(2)},
+			},
+		},
+	}
+
+	matched, err := CheckCondition(condition, event)
+	if err != nil {
+		t.Fatalf("CheckCondition() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("CheckCondition() = false, want true")
+	}
+	if !reflect.DeepEqual(event, want) {
+		t.Fatalf("CheckCondition() mutated event:\n got: %#v\nwant: %#v", event, want)
 	}
 }
 

--- a/pkg/formatters/processors_test.go
+++ b/pkg/formatters/processors_test.go
@@ -9,6 +9,7 @@
 package formatters
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -42,6 +43,30 @@ var testset = map[string]struct {
 		},
 		result: true,
 	},
+	"event_fields": {
+		condition: `.name == "port-counters" and .timestamp == 42 and .tags.resource_id == "device-1" and .values["/COUNTERS/oid:1/packets"] == 7`,
+		input: []*EventMsg{
+			{
+				Name:      "port-counters",
+				Timestamp: 42,
+				Tags:      map[string]string{"resource_id": "device-1"},
+				Values: map[string]interface{}{
+					"/COUNTERS/oid:1/packets": 7,
+				},
+			},
+		},
+		result: true,
+	},
+	"event_fields_no_match": {
+		condition: `.name == "port-counters" and .tags.resource_id == "device-2"`,
+		input: []*EventMsg{
+			{
+				Name: "port-counters",
+				Tags: map[string]string{"resource_id": "device-1"},
+			},
+		},
+		result: false,
+	},
 }
 
 func TestCheckCondition(t *testing.T) {
@@ -72,5 +97,41 @@ func TestCheckCondition(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkCheckConditionLargeEvent(b *testing.B) {
+	query, err := gojq.Parse(`.name == "port-counters"`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	condition, err := gojq.Compile(query)
+	if err != nil {
+		b.Fatal(err)
+	}
+	values := make(map[string]interface{}, 34_014)
+	for index := range 34_014 {
+		values[fmt.Sprintf("/COUNTERS/oid:0x%016x/SAI_PORT_STAT_IF_IN_OCTETS", index)] = index
+	}
+	event := &EventMsg{
+		Name:      "port-counters",
+		Timestamp: time.Now().UnixNano(),
+		Tags: map[string]string{
+			"resource_id":       "network-device-001",
+			"subscription-name": "port-counters",
+		},
+		Values: values,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		matched, err := CheckCondition(condition, event)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !matched {
+			b.Fatal("condition did not match")
+		}
 	}
 }

--- a/pkg/formatters/processors_test.go
+++ b/pkg/formatters/processors_test.go
@@ -9,6 +9,7 @@
 package formatters
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -141,6 +142,71 @@ func TestCheckConditionDoesNotMutateEvent(t *testing.T) {
 	}
 	if !reflect.DeepEqual(event, want) {
 		t.Fatalf("CheckCondition() mutated event:\n got: %#v\nwant: %#v", event, want)
+	}
+}
+
+func TestConditionInputMatchesJSONRoundTrip(t *testing.T) {
+	event := &EventMsg{
+		Name: "binary-state",
+		Tags: map[string]string{"source": "leaf-1"},
+		Values: map[string]interface{}{
+			"bytes":       []byte{0x01, 0x02, 0x03},
+			"nil-bytes":   []byte(nil),
+			"nil-map":     map[string]interface{}(nil),
+			"nil-slice":   []interface{}(nil),
+			"empty-slice": []interface{}{},
+			"nested": []interface{}{
+				[]byte{0xff, 0x00},
+				map[string]interface{}{"labels": map[string]string{"state": "up"}},
+			},
+		},
+		Deletes: []string{"/interfaces/interface[name=ethernet-1]"},
+	}
+
+	b, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := make(map[string]interface{})
+	if err := json.Unmarshal(b, &want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := conditionInput(event)
+	if err != nil {
+		t.Fatalf("conditionInput() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("conditionInput() = %#v, want JSON round trip %#v", got, want)
+	}
+}
+
+func TestCheckConditionBytesUseBase64(t *testing.T) {
+	query, err := gojq.Parse(`.values.bytes == "AQID" and .values.nested[0] == "/wA="`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	condition, err := gojq.Compile(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := &EventMsg{Values: map[string]interface{}{
+		"bytes":  []byte{0x01, 0x02, 0x03},
+		"nested": []interface{}{[]byte{0xff, 0x00}},
+	}}
+
+	matched, err := CheckCondition(condition, event)
+	if err != nil {
+		t.Fatalf("CheckCondition() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("CheckCondition() = false, want true")
+	}
+}
+
+func TestConditionInputRejectsUnsupportedValue(t *testing.T) {
+	_, err := conditionInput(&EventMsg{Values: map[string]interface{}{"invalid": math.NaN()}})
+	if err == nil {
+		t.Fatal("conditionInput() error = nil, want unsupported value error")
 	}
 }
 


### PR DESCRIPTION
## What changed

- remove the full-event JSON marshal/unmarshal round trip from every processor
  condition evaluation
- evaluate compiled conditions against the existing `EventMsg.ToMap()` schema
- clone mutable containers before passing them to `gojq`
- preserve JSON byte-slice semantics by exposing `[]byte` values as Base64
  strings, including nested values
- normalize other non-native gojq values with a localized JSON fallback
- add regression coverage for JSON container semantics, byte values, rejected
  unsupported values, and input immutability
- add a 34,014-value benchmark

## Why

Conditions commonly inspect only `.name` or `.tags`, but the previous path
serialized and decoded the complete event for every conditional processor.
Large telemetry notifications therefore incurred full-payload allocation and GC
cost multiple times before the selected processor ran.

Passing the event directly is unsafe because `gojq` normalizes numbers in maps
and slices in place. Passing `EventMsg.ToMap()` without normalization also
changes the established representation of byte slices from Base64 strings to
raw `[]byte` values. The submitted implementation clones mutable containers,
converts byte slices explicitly, and uses JSON conversion only for uncommon
non-native values.

Production-shaped benchmark on current `main` before the change:

```text
28-31 ms/op
13-14 MB/op
170,380 allocs/op
```

After the safe conversion:

```text
BenchmarkCheckConditionLargeEvent-16  1372  2475615 ns/op  2626553 B/op  152 allocs/op
BenchmarkCheckConditionLargeEvent-16  1489  2474924 ns/op  2626557 B/op  152 allocs/op
BenchmarkCheckConditionLargeEvent-16  1513  2642596 ns/op  2626553 B/op  152 allocs/op
```

## Validation

- `go test -race ./pkg/formatters/...`
- `go test ./pkg/formatters -run '^$' -bench '^BenchmarkCheckConditionLargeEvent$' -benchmem -benchtime=3s -count=3`
- `git diff --check`

Closes #949.
