### PR TITLE
feat(prometheus-write): add stream-aware sampling before conversion

### DIFF
--- a/docs/user_guide/outputs/prometheus_write_output.md
+++ b/docs/user_guide/outputs/prometheus_write_output.md
@@ -95,9 +95,42 @@ outputs:
     num-workers: 1
     # an integer, sets the number of writers draining the buffer and writing to Prometheus
     num-writers: 1
+    # optional source/subscription sampling performed before event conversion.
+    # A size floor allows narrow incremental updates to bypass sampling.
+    message-sampling:
+      by-subscription:
+        port-counters:
+          interval: 15s
+          minimum-bytes: 262144
+      cache-size: 100000
+      spread: true
 ```
 
 `gnmic` creates the prometheus metric name and its labels from the subscription name, the gnmic path and the value name.
+
+## Message Sampling
+
+`message-sampling.by-subscription` maps subscription names to an interval and an optional
+protobuf message size floor. Matching messages at or above `minimum-bytes` are sampled per
+source and subscription before event conversion and processing. Smaller messages bypass
+sampling and do not consume the sampling window, which preserves narrow incremental updates
+from streams that also emit wide snapshots. A zero `minimum-bytes` samples every matching
+message.
+
+Choose the size floor from observed message sizes and keep it below the smallest wide
+snapshot that must be sampled. Sampling all messages is appropriate only when every message
+is independently complete; partial update streams require a non-zero size floor or must not
+use this option.
+`cache-size` bounds the number of source/subscription timestamps retained in memory and
+defaults to `100000`. Skipped messages are reported by
+`gnmic_prometheus_write_output_messages_skipped_total`.
+
+`spread: true` assigns each source/subscription stream a stable phase inside its interval.
+The first matching wide message is always accepted because it may be the stream's only
+complete baseline. Later wide messages align to the stable phase, avoiding synchronized
+conversion and write bursts. Enforcing the interval while moving to that phase can delay
+the second accepted wide message by less than two intervals; narrow messages still bypass
+sampling throughout that period.
 
 ## Metric Generation
 
@@ -145,7 +178,7 @@ For the previous example the labels would be:
 
 ## Prometheus Write Metrics
 
-When a Prometheus server (gNMI API) is enabled, `gnmic` prometheus write output exposes 4 prometheus counters and 2 prometheus Gauges:
+When a Prometheus server (gNMI API) is enabled, `gnmic` prometheus write output exposes 5 Prometheus counters and 2 Prometheus gauges:
 
 * `number_of_prometheus_write_msgs_sent_success_total`: Number of msgs successfully sent by gnmic prometheus_write output.
 * `number_of_prometheus_write_msgs_sent_fail_total`: Number of failed msgs sent by gnmic prometheus_write output.
@@ -154,3 +187,4 @@ When a Prometheus server (gNMI API) is enabled, `gnmic` prometheus write output 
 * `number_of_prometheus_write_metadata_msgs_sent_success_total`: Number of metadata msgs successfully sent by gnmic prometheus_write output.
 * `number_of_prometheus_write_metadata_msgs_sent_fail_total`: Number of failed metadata msgs sent by gnmic prometheus_write output.
 * `metadata_msg_send_duration_ns`: gnmic prometheus_write output metadata send duration in ns.
+* `messages_skipped_total`: Number of protobuf messages skipped by subscription sampling, labeled by output and subscription.

--- a/docs/user_guide/outputs/prometheus_write_output.md
+++ b/docs/user_guide/outputs/prometheus_write_output.md
@@ -127,8 +127,8 @@ snapshot that should be sampled. Every matching post-sync response at or above t
 must be independently discardable. Do not enable sampling for a stream whose later snapshot
 is split across multiple responses, because a message sampler cannot preserve the group as
 one unit.
-`cache-size` bounds the number of source/subscription timestamps retained in memory and
-defaults to `100000`. Skipped messages are reported by
+`cache-size` bounds the number of source/subscription stream-attempt states retained in
+memory and defaults to `100000`. Skipped messages are reported by
 `gnmic_prometheus_write_output_messages_skipped_total`.
 
 `spread: true` assigns each source/subscription stream a stable phase inside its interval.

--- a/docs/user_guide/outputs/prometheus_write_output.md
+++ b/docs/user_guide/outputs/prometheus_write_output.md
@@ -110,27 +110,32 @@ outputs:
 
 ## Message Sampling
 
-`message-sampling.by-subscription` maps subscription names to an interval and an optional
-protobuf message size floor. Matching messages at or above `minimum-bytes` are sampled per
-source and subscription before event conversion and processing. Smaller messages bypass
-sampling and do not consume the sampling window, which preserves narrow incremental updates
-from streams that also emit wide snapshots. A zero `minimum-bytes` samples every matching
-message.
+`message-sampling.by-subscription` maps STREAM subscription names to an interval and an
+optional protobuf message size floor. Matching Update responses at or above
+`minimum-bytes` are sampled per source and subscription before event conversion and
+processing. Smaller updates bypass sampling and do not consume the sampling window, which
+preserves narrow incremental updates from streams that also emit wide snapshots. A zero
+`minimum-bytes` samples every matching post-sync Update response.
+
+The initial snapshot is never sampled: all Update responses are accepted until the stream's
+first successful SyncResponse. A reconnect starts a new initial snapshot. Control messages,
+ONCE and POLL subscriptions, and messages that did not originate from a managed subscription
+stream also bypass sampling.
 
 Choose the size floor from observed message sizes and keep it below the smallest wide
-snapshot that must be sampled. Sampling all messages is appropriate only when every message
-is independently complete; partial update streams require a non-zero size floor or must not
-use this option.
+snapshot that should be sampled. Every matching post-sync response at or above that floor
+must be independently discardable. Do not enable sampling for a stream whose later snapshot
+is split across multiple responses, because a message sampler cannot preserve the group as
+one unit.
 `cache-size` bounds the number of source/subscription timestamps retained in memory and
 defaults to `100000`. Skipped messages are reported by
 `gnmic_prometheus_write_output_messages_skipped_total`.
 
 `spread: true` assigns each source/subscription stream a stable phase inside its interval.
-The first matching wide message is always accepted because it may be the stream's only
-complete baseline. Later wide messages align to the stable phase, avoiding synchronized
-conversion and write bursts. Enforcing the interval while moving to that phase can delay
-the second accepted wide message by less than two intervals; narrow messages still bypass
-sampling throughout that period.
+The first matching post-sync response is accepted immediately. Later matching responses
+align to the stable phase, avoiding synchronized conversion and write bursts. Enforcing the
+interval while moving to that phase can delay the second accepted response by less than two
+intervals; narrow messages still bypass sampling throughout that period.
 
 ## Metric Generation
 

--- a/pkg/api/target/subscribe.go
+++ b/pkg/api/target/subscribe.go
@@ -13,7 +13,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/jhump/protoreflect/dynamic"
@@ -22,6 +24,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+var subscriptionInstanceCounter atomic.Uint64
+
+func newSubscriptionInstance() string {
+	return strconv.FormatUint(subscriptionInstanceCounter.Add(1), 10)
+}
 
 // Subscribe sends a gnmi.SubscribeRequest to the target *t, responses and error are sent to the target channels
 func (t *Target) Subscribe(ctx context.Context, req *gnmi.SubscribeRequest, subscriptionName string) {
@@ -581,6 +589,8 @@ func (t *Target) listenPolls(ctx context.Context) {
 }
 
 func (t *Target) handleStreamSubscriptionRcv(ctx context.Context, stream gnmi.GNMI_SubscribeClient, subscriptionName string, subConfig *types.SubscriptionConfig, ch chan *SubscribeResponse) error {
+	subscriptionInstance := newSubscriptionInstance()
+	initialSyncComplete := false
 	for {
 		if ctx.Err() != nil {
 			return nil
@@ -589,11 +599,17 @@ func (t *Target) handleStreamSubscriptionRcv(ctx context.Context, stream gnmi.GN
 		if err != nil {
 			return err
 		}
+		if response.GetSyncResponse() {
+			initialSyncComplete = true
+		}
 		select {
 		case ch <- &SubscribeResponse{
-			SubscriptionName:   subscriptionName,
-			SubscriptionConfig: subConfig,
-			Response:           response,
+			SubscriptionName:     subscriptionName,
+			SubscriptionConfig:   subConfig,
+			SubscriptionInstance: subscriptionInstance,
+			SubscriptionMode:     gnmi.SubscriptionList_STREAM,
+			InitialSyncComplete:  initialSyncComplete,
+			Response:             response,
 		}:
 		case <-ctx.Done():
 			return nil
@@ -602,6 +618,8 @@ func (t *Target) handleStreamSubscriptionRcv(ctx context.Context, stream gnmi.GN
 }
 
 func (t *Target) handleONCESubscriptionRcv(ctx context.Context, stream gnmi.GNMI_SubscribeClient, subscriptionName string, subConfig *types.SubscriptionConfig, ch chan *SubscribeResponse) error {
+	subscriptionInstance := newSubscriptionInstance()
+	initialSyncComplete := false
 	for {
 		if ctx.Err() != nil {
 			return nil
@@ -610,12 +628,18 @@ func (t *Target) handleONCESubscriptionRcv(ctx context.Context, stream gnmi.GNMI
 		if err != nil {
 			return err
 		}
+		if response.GetSyncResponse() {
+			initialSyncComplete = true
+		}
 		select {
 		case <-ctx.Done():
 		case ch <- &SubscribeResponse{
-			SubscriptionName:   subscriptionName,
-			SubscriptionConfig: subConfig,
-			Response:           response,
+			SubscriptionName:     subscriptionName,
+			SubscriptionConfig:   subConfig,
+			SubscriptionInstance: subscriptionInstance,
+			SubscriptionMode:     gnmi.SubscriptionList_ONCE,
+			InitialSyncComplete:  initialSyncComplete,
+			Response:             response,
 		}:
 		}
 
@@ -627,6 +651,8 @@ func (t *Target) handleONCESubscriptionRcv(ctx context.Context, stream gnmi.GNMI
 }
 
 func (t *Target) handlePollSubscriptionRcv(ctx context.Context, stream gnmi.GNMI_SubscribeClient, subscriptionName string, subConfig *types.SubscriptionConfig, ch chan *SubscribeResponse) error {
+	subscriptionInstance := newSubscriptionInstance()
+	initialSyncComplete := false
 	for {
 		select {
 		case <-ctx.Done():
@@ -636,13 +662,19 @@ func (t *Target) handlePollSubscriptionRcv(ctx context.Context, stream gnmi.GNMI
 			if err != nil {
 				return err
 			}
+			if response.GetSyncResponse() {
+				initialSyncComplete = true
+			}
 			select {
 			case <-ctx.Done():
 				return nil
 			case ch <- &SubscribeResponse{
-				SubscriptionName:   subscriptionName,
-				SubscriptionConfig: subConfig,
-				Response:           response,
+				SubscriptionName:     subscriptionName,
+				SubscriptionConfig:   subConfig,
+				SubscriptionInstance: subscriptionInstance,
+				SubscriptionMode:     gnmi.SubscriptionList_POLL,
+				InitialSyncComplete:  initialSyncComplete,
+				Response:             response,
 			}:
 			}
 		}

--- a/pkg/api/target/subscribe_test.go
+++ b/pkg/api/target/subscribe_test.go
@@ -1,12 +1,67 @@
 package target
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 
+	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmic/pkg/api/types"
 )
+
+type subscribeClientStub struct {
+	gnmi.GNMI_SubscribeClient
+	responses []*gnmi.SubscribeResponse
+}
+
+func (s *subscribeClientStub) Recv() (*gnmi.SubscribeResponse, error) {
+	if len(s.responses) == 0 {
+		return nil, io.EOF
+	}
+	response := s.responses[0]
+	s.responses = s.responses[1:]
+	return response, nil
+}
+
+func TestStreamSubscriptionResponseInstance(t *testing.T) {
+	target := &Target{}
+	responses := make(chan *SubscribeResponse, 3)
+	stream := &subscribeClientStub{responses: []*gnmi.SubscribeResponse{
+		{Response: &gnmi.SubscribeResponse_Update{Update: &gnmi.Notification{}}},
+		{Response: &gnmi.SubscribeResponse_SyncResponse{SyncResponse: true}},
+	}}
+	if err := target.handleStreamSubscriptionRcv(context.Background(), stream, "sub1", nil, responses); !errors.Is(err, io.EOF) {
+		t.Fatalf("handleStreamSubscriptionRcv() error = %v, want EOF", err)
+	}
+	first := <-responses
+	second := <-responses
+	if first.SubscriptionInstance == "" || first.SubscriptionInstance != second.SubscriptionInstance {
+		t.Fatalf("subscription instance mismatch: %q, %q", first.SubscriptionInstance, second.SubscriptionInstance)
+	}
+	if first.SubscriptionMode != gnmi.SubscriptionList_STREAM || second.SubscriptionMode != gnmi.SubscriptionList_STREAM {
+		t.Fatalf("subscription mode = %v, %v, want STREAM", first.SubscriptionMode, second.SubscriptionMode)
+	}
+	if first.InitialSyncComplete || !second.InitialSyncComplete {
+		t.Fatalf("initial sync state = %v, %v, want false, true", first.InitialSyncComplete, second.InitialSyncComplete)
+	}
+
+	nextStream := &subscribeClientStub{responses: []*gnmi.SubscribeResponse{
+		{Response: &gnmi.SubscribeResponse_Update{Update: &gnmi.Notification{}}},
+	}}
+	if err := target.handleStreamSubscriptionRcv(context.Background(), nextStream, "sub1", nil, responses); !errors.Is(err, io.EOF) {
+		t.Fatalf("second handleStreamSubscriptionRcv() error = %v, want EOF", err)
+	}
+	third := <-responses
+	if third.SubscriptionInstance == first.SubscriptionInstance {
+		t.Fatal("new subscription attempt reused its instance")
+	}
+	if third.InitialSyncComplete {
+		t.Fatal("new subscription attempt inherited initial sync state")
+	}
+}
 
 // TestSubscriptionsConcurrentAccess is a regression test for
 // https://github.com/openconfig/gnmic/issues/835: concurrent writes to

--- a/pkg/api/target/target.go
+++ b/pkg/api/target/target.go
@@ -35,9 +35,12 @@ type TargetError struct {
 
 // SubscribeResponse //
 type SubscribeResponse struct {
-	SubscriptionName   string
-	SubscriptionConfig *types.SubscriptionConfig
-	Response           *gnmi.SubscribeResponse
+	SubscriptionName     string
+	SubscriptionConfig   *types.SubscriptionConfig
+	SubscriptionInstance string
+	SubscriptionMode     gnmi.SubscriptionList_Mode
+	InitialSyncComplete  bool
+	Response             *gnmi.SubscribeResponse
 }
 
 // Target represents a gNMI enabled box

--- a/pkg/app/gnmi_client_subscribe.go
+++ b/pkg/app/gnmi_client_subscribe.go
@@ -289,6 +289,8 @@ OUTER:
 		)
 		rspCh, errCh := t.SubscribeOnceChan(gnmiCtx, sreq.req)
 		subscriptionInfo := outputs.SubscriptionInfo{
+			Source:   t.Config.Name,
+			Name:     sreq.name,
 			Instance: uuid.NewString(),
 			Mode:     sreq.req.GetSubscribe().GetMode(),
 		}

--- a/pkg/app/gnmi_client_subscribe.go
+++ b/pkg/app/gnmi_client_subscribe.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/grpctunnel/tunnel"
 	"google.golang.org/grpc"
@@ -287,6 +288,10 @@ OUTER:
 			"encoding", sreq.req.GetSubscribe().GetEncoding(),
 		)
 		rspCh, errCh := t.SubscribeOnceChan(gnmiCtx, sreq.req)
+		subscriptionInfo := outputs.SubscriptionInfo{
+			Instance: uuid.NewString(),
+			Mode:     sreq.req.GetSubscribe().GetMode(),
+		}
 		for {
 			select {
 			case err := <-errCh:
@@ -298,8 +303,11 @@ OUTER:
 				}
 				return err
 			case rsp := <-rspCh:
+				if rsp.GetSyncResponse() {
+					subscriptionInfo.InitialSyncComplete = true
+				}
 				m := outputs.Meta{"source": t.Config.Name, "format": a.Config.Format, "subscription-name": sreq.name}
-				a.export(ctx, rsp, m, t.Config.Outputs...)
+				a.export(outputs.WithSubscriptionInfo(ctx, subscriptionInfo), rsp, m, t.Config.Outputs...)
 			}
 		}
 	}

--- a/pkg/app/subscribe.go
+++ b/pkg/app/subscribe.go
@@ -275,6 +275,11 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 						"format":            a.Config.Format,
 						"subscription-name": rsp.SubscriptionName,
 					}
+					exportCtx := outputs.WithSubscriptionInfo(ctx, outputs.SubscriptionInfo{
+						Instance:            rsp.SubscriptionInstance,
+						Mode:                rsp.SubscriptionMode,
+						InitialSyncComplete: rsp.InitialSyncComplete,
+					})
 					if rsp.SubscriptionConfig.Target != "" {
 						m["subscription-target"] = rsp.SubscriptionConfig.Target
 					}
@@ -291,7 +296,7 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 						outs = t.Config.Outputs
 					}
 
-					a.export(ctx, rsp.Response, m, outs...)
+					a.export(exportCtx, rsp.Response, m, outs...)
 					if remainingOnceSubscriptions > 0 {
 						if a.subscriptionMode(rsp.SubscriptionName) == subscriptionModeONCE {
 							switch rsp.Response.Response.(type) {

--- a/pkg/app/subscribe.go
+++ b/pkg/app/subscribe.go
@@ -276,6 +276,8 @@ func (a *App) StartTargetsManager(ctx context.Context) {
 						"subscription-name": rsp.SubscriptionName,
 					}
 					exportCtx := outputs.WithSubscriptionInfo(ctx, outputs.SubscriptionInfo{
+						Source:              t.Config.Name,
+						Name:                rsp.SubscriptionName,
 						Instance:            rsp.SubscriptionInstance,
 						Mode:                rsp.SubscriptionMode,
 						InitialSyncComplete: rsp.InitialSyncComplete,

--- a/pkg/collector/managers/outputs/outputs_manager.go
+++ b/pkg/collector/managers/outputs/outputs_manager.go
@@ -173,7 +173,7 @@ func (mgr *OutputsManager) write(e *pipeline.Msg) {
 			}
 		} else {
 			// from targets or inputs
-			mo.Impl.Write(mgr.ctx, e.Msg, e.Meta)
+			mo.Impl.Write(outputs.WithSubscriptionInfo(mgr.ctx, e.Subscription), e.Msg, e.Meta)
 		}
 	}
 }

--- a/pkg/collector/managers/outputs/outputs_manager.go
+++ b/pkg/collector/managers/outputs/outputs_manager.go
@@ -158,6 +158,7 @@ func (mgr *OutputsManager) writeLoop(wg *sync.WaitGroup) {
 
 func (mgr *OutputsManager) write(e *pipeline.Msg) {
 	outs := mgr.getOutputsForTarget(e.Outputs)
+	writeCtx := outputs.WithSubscriptionInfo(mgr.ctx, e.Subscription)
 	outsNames := make([]string, 0, len(outs))
 	if mgr.logger.Enabled(mgr.ctx, slog.LevelDebug) {
 		for _, o := range outs {
@@ -173,7 +174,7 @@ func (mgr *OutputsManager) write(e *pipeline.Msg) {
 			}
 		} else {
 			// from targets or inputs
-			mo.Impl.Write(outputs.WithSubscriptionInfo(mgr.ctx, e.Subscription), e.Msg, e.Meta)
+			mo.Impl.Write(writeCtx, e.Msg, e.Meta)
 		}
 	}
 }

--- a/pkg/collector/managers/outputs/outputs_manager_test.go
+++ b/pkg/collector/managers/outputs/outputs_manager_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openconfig/gnmic/pkg/config"
+	"github.com/openconfig/gnmi/proto/gnmi"
 	collstore "github.com/openconfig/gnmic/pkg/collector/store"
+	"github.com/openconfig/gnmic/pkg/config"
 	"github.com/openconfig/gnmic/pkg/formatters"
 	"github.com/openconfig/gnmic/pkg/outputs"
 	"github.com/openconfig/gnmic/pkg/pipeline"
@@ -18,20 +19,28 @@ import (
 )
 
 type mockOutput struct {
-	mu          sync.Mutex
-	name        string
-	clusterName string
-	initCount   int
-	updateCount int
-	writeCount  int
-	eventCount  int
-	closed      bool
+	mu              sync.Mutex
+	name            string
+	clusterName     string
+	initCount       int
+	updateCount     int
+	writeCount      int
+	eventCount      int
+	closed          bool
+	subscription    outputs.SubscriptionInfo
+	hasSubscription bool
 }
 
 func (m *mockOutput) eventCountSnapshot() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.eventCount
+}
+
+func (m *mockOutput) subscriptionSnapshot() (outputs.SubscriptionInfo, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.subscription, m.hasSubscription
 }
 
 func (m *mockOutput) Init(_ context.Context, name string, _ map[string]any, opts ...outputs.Option) error {
@@ -54,8 +63,9 @@ func (m *mockOutput) Update(_ context.Context, _ map[string]any) error {
 
 func (m *mockOutput) UpdateProcessor(string, map[string]any) error { return nil }
 
-func (m *mockOutput) Write(context.Context, proto.Message, outputs.Meta) {
+func (m *mockOutput) Write(ctx context.Context, _ proto.Message, _ outputs.Meta) {
 	m.mu.Lock()
+	m.subscription, m.hasSubscription = outputs.SubscriptionInfoFromContext(ctx)
 	m.writeCount++
 	m.mu.Unlock()
 }
@@ -284,6 +294,35 @@ func TestOutputsManager_writeDispatchesToOutputs(t *testing.T) {
 	}
 	if b.eventCountSnapshot() != 0 {
 		t.Fatalf("out-b events = %d, want 0", b.eventCountSnapshot())
+	}
+}
+
+func TestOutputsManager_writePropagatesSubscriptionInfo(t *testing.T) {
+	mgr, _, _, cancel := newOutputsTestManager(t)
+	defer cancel()
+
+	mgr.createOutput("out1", map[string]any{"type": "mock"})
+	waitForOutputState(t, mgr, "out1", collstore.StateRunning)
+	want := outputs.SubscriptionInfo{
+		Source:              "leaf-1",
+		Name:                "counters",
+		Instance:            "stream-1",
+		Mode:                gnmi.SubscriptionList_STREAM,
+		InitialSyncComplete: true,
+	}
+	mgr.write(&pipeline.Msg{
+		Msg:          &gnmi.SubscribeResponse{},
+		Meta:         outputs.Meta{"source": "event-tag-source", "subscription-name": "event-tag-subscription"},
+		Subscription: want,
+		Outputs:      map[string]struct{}{"out1": {}},
+	})
+
+	mgr.mu.RLock()
+	impl := mgr.outputs["out1"].Impl.(*mockOutput)
+	mgr.mu.RUnlock()
+	got, ok := impl.subscriptionSnapshot()
+	if !ok || got != want {
+		t.Fatalf("subscription info = (%v, %v), want (%v, true)", got, ok, want)
 	}
 }
 

--- a/pkg/collector/managers/targets/targets_manager.go
+++ b/pkg/collector/managers/targets/targets_manager.go
@@ -938,8 +938,13 @@ func (tm *TargetsManager) startTargetSubscription(mt *ManagedTarget, cfg *types.
 				mt.RUnlock()
 				select {
 				case tm.out <- &pipeline.Msg{
-					Msg:     resp.Response,
-					Meta:    pipelineMeta(mt.Name, resp.SubscriptionName, eventTags),
+					Msg:  resp.Response,
+					Meta: pipelineMeta(mt.Name, resp.SubscriptionName, eventTags),
+					Subscription: outputs.SubscriptionInfo{
+						Instance:            resp.SubscriptionInstance,
+						Mode:                resp.SubscriptionMode,
+						InitialSyncComplete: resp.InitialSyncComplete,
+					},
 					Outputs: outs,
 				}:
 				default:

--- a/pkg/collector/managers/targets/targets_manager.go
+++ b/pkg/collector/managers/targets/targets_manager.go
@@ -941,6 +941,8 @@ func (tm *TargetsManager) startTargetSubscription(mt *ManagedTarget, cfg *types.
 					Msg:  resp.Response,
 					Meta: pipelineMeta(mt.Name, resp.SubscriptionName, eventTags),
 					Subscription: outputs.SubscriptionInfo{
+						Source:              mt.Name,
+						Name:                resp.SubscriptionName,
 						Instance:            resp.SubscriptionInstance,
 						Mode:                resp.SubscriptionMode,
 						InitialSyncComplete: resp.InitialSyncComplete,

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_metrics.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_metrics.go
@@ -63,6 +63,13 @@ var prometheusWriteMetadataSendDuration = prometheus.NewGaugeVec(prometheus.Gaug
 	Help:      "gnmic prometheus_write output metadata send duration in ns",
 }, []string{"name"})
 
+var prometheusWriteMessagesSkipped = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Subsystem: subsystem,
+	Name:      "messages_skipped_total",
+	Help:      "Number of protobuf messages skipped by configured subscription sampling",
+}, []string{"name", "subscription"})
+
 func initMetrics(name string) {
 	// data msgs metrics
 	prometheusWriteNumberOfSentMsgs.WithLabelValues(name).Add(0)
@@ -111,7 +118,16 @@ func (p *promWriteOutput) registerMetrics() error {
 			p.logger.Error("failed to register metric", "err", err)
 			return
 		}
+		if err = p.reg.Register(prometheusWriteMessagesSkipped); err != nil {
+			p.logger.Error("failed to register metric", "err", err)
+			return
+		}
 	})
 	initMetrics(cfg.Name)
+	if cfg.MessageSampling != nil {
+		for subscription := range cfg.MessageSampling.BySubscription {
+			prometheusWriteMessagesSkipped.WithLabelValues(cfg.Name, subscription).Add(0)
+		}
+	}
 	return err
 }

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
@@ -283,12 +283,14 @@ func (p *promWriteOutput) Update(ctx context.Context, cfg map[string]any) error 
 	}
 
 	p.setDefaultsFor(newCfg)
-	newSampler, err := newSubscriptionSampler(newCfg.MessageSampling)
-	if err != nil {
-		return err
-	}
-
 	currCfg := p.cfg.Load()
+	newSampler := p.sampler.Load()
+	if currCfg == nil || !messageSamplingConfigsEqual(currCfg.MessageSampling, newCfg.MessageSampling) {
+		newSampler, err = newSubscriptionSampler(newCfg.MessageSampling)
+		if err != nil {
+			return err
+		}
+	}
 
 	swapChannel := channelNeedsSwap(currCfg, newCfg)
 	restartWorkers := needsWorkerRestart(currCfg, newCfg)
@@ -447,11 +449,15 @@ func (p *promWriteOutput) Write(ctx context.Context, rsp proto.Message, meta out
 	}
 	acceptedAt := time.Now()
 	sampler := p.sampler.Load()
+	var acceptance *sampleAcceptance
 	if sampler != nil {
-		if !sampler.Allow(meta, proto.Size(rsp), acceptedAt) {
+		info, _ := outputs.SubscriptionInfoFromContext(ctx)
+		allowed, recorded := sampler.Allow(info, meta, rsp, acceptedAt)
+		if !allowed {
 			prometheusWriteMessagesSkipped.WithLabelValues(cfg.Name, meta["subscription-name"]).Inc()
 			return
 		}
+		acceptance = recorded
 	}
 
 	wctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
@@ -459,15 +465,11 @@ func (p *promWriteOutput) Write(ctx context.Context, rsp proto.Message, meta out
 
 	select {
 	case <-ctx.Done():
-		if sampler != nil {
-			sampler.Rollback(meta, acceptedAt)
-		}
+		sampler.Rollback(acceptance)
 		return
 	case p.msgChan <- outputs.NewProtoMsg(rsp, meta):
 	case <-wctx.Done():
-		if sampler != nil {
-			sampler.Rollback(meta, acceptedAt)
-		}
+		sampler.Rollback(acceptance)
 		if cfg.Debug {
 			p.logger.Warn("write expired", "timeout", cfg.Timeout)
 		}

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
@@ -447,17 +447,16 @@ func (p *promWriteOutput) Write(ctx context.Context, rsp proto.Message, meta out
 	if cfg == nil {
 		return
 	}
-	acceptedAt := time.Now()
 	sampler := p.sampler.Load()
-	var acceptance *sampleAcceptance
+	var reservation *sampleReservation
 	if sampler != nil {
 		info, _ := outputs.SubscriptionInfoFromContext(ctx)
-		allowed, recorded := sampler.Allow(info, meta, rsp, acceptedAt)
+		allowed, recorded := sampler.Reserve(info, rsp, time.Now())
 		if !allowed {
-			prometheusWriteMessagesSkipped.WithLabelValues(cfg.Name, meta["subscription-name"]).Inc()
+			prometheusWriteMessagesSkipped.WithLabelValues(cfg.Name, info.Name).Inc()
 			return
 		}
-		acceptance = recorded
+		reservation = recorded
 	}
 
 	wctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
@@ -465,11 +464,12 @@ func (p *promWriteOutput) Write(ctx context.Context, rsp proto.Message, meta out
 
 	select {
 	case <-ctx.Done():
-		sampler.Rollback(acceptance)
+		sampler.Rollback(reservation)
 		return
 	case p.msgChan <- outputs.NewProtoMsg(rsp, meta):
+		sampler.Commit(reservation)
 	case <-wctx.Done():
-		sampler.Rollback(acceptance)
+		sampler.Rollback(reservation)
 		if cfg.Debug {
 			p.logger.Warn("write expired", "timeout", cfg.Timeout)
 		}

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output.go
@@ -64,6 +64,7 @@ type promWriteOutput struct {
 	dynCfg       *atomic.Pointer[dynConfig]
 	httpClient   *atomic.Pointer[http.Client]
 	timeSeriesCh *atomic.Pointer[chan *prompb.TimeSeries]
+	sampler      *atomic.Pointer[subscriptionSampler]
 
 	logger      *slog.Logger
 	eventChan   chan *formatters.EventMsg
@@ -96,15 +97,16 @@ type config struct {
 	Metadata              *metadata         `mapstructure:"metadata,omitempty" json:"metadata,omitempty"`
 	Debug                 bool              `mapstructure:"debug,omitempty" json:"debug,omitempty"`
 	//
-	MetricPrefix           string   `mapstructure:"metric-prefix,omitempty" json:"metric-prefix,omitempty"`
-	AppendSubscriptionName bool     `mapstructure:"append-subscription-name,omitempty" json:"append-subscription-name,omitempty"`
-	AddTarget              string   `mapstructure:"add-target,omitempty" json:"add-target,omitempty"`
-	TargetTemplate         string   `mapstructure:"target-template,omitempty" json:"target-template,omitempty"`
-	StringsAsLabels        bool     `mapstructure:"strings-as-labels,omitempty" json:"strings-as-labels,omitempty"`
-	EventProcessors        []string `mapstructure:"event-processors,omitempty" json:"event-processors,omitempty"`
-	NumWorkers             int      `mapstructure:"num-workers,omitempty" json:"num-workers,omitempty"`
-	NumWriters             int      `mapstructure:"num-writers,omitempty" json:"num-writers,omitempty"`
-	EnableMetrics          bool     `mapstructure:"enable-metrics,omitempty" json:"enable-metrics,omitempty"`
+	MetricPrefix           string                 `mapstructure:"metric-prefix,omitempty" json:"metric-prefix,omitempty"`
+	AppendSubscriptionName bool                   `mapstructure:"append-subscription-name,omitempty" json:"append-subscription-name,omitempty"`
+	AddTarget              string                 `mapstructure:"add-target,omitempty" json:"add-target,omitempty"`
+	TargetTemplate         string                 `mapstructure:"target-template,omitempty" json:"target-template,omitempty"`
+	StringsAsLabels        bool                   `mapstructure:"strings-as-labels,omitempty" json:"strings-as-labels,omitempty"`
+	EventProcessors        []string               `mapstructure:"event-processors,omitempty" json:"event-processors,omitempty"`
+	NumWorkers             int                    `mapstructure:"num-workers,omitempty" json:"num-workers,omitempty"`
+	NumWriters             int                    `mapstructure:"num-writers,omitempty" json:"num-writers,omitempty"`
+	EnableMetrics          bool                   `mapstructure:"enable-metrics,omitempty" json:"enable-metrics,omitempty"`
+	MessageSampling        *messageSamplingConfig `mapstructure:"message-sampling,omitempty" json:"message-sampling,omitempty"`
 }
 
 func (c *config) LogValue() slog.Value {
@@ -138,6 +140,7 @@ func (p *promWriteOutput) init() {
 	p.dynCfg = new(atomic.Pointer[dynConfig])
 	p.httpClient = new(atomic.Pointer[http.Client])
 	p.timeSeriesCh = new(atomic.Pointer[chan *prompb.TimeSeries])
+	p.sampler = new(atomic.Pointer[subscriptionSampler])
 	p.wg = new(sync.WaitGroup)
 	p.m = new(sync.Mutex)
 	p.logger = logging.DiscardLogger()
@@ -192,6 +195,11 @@ func (p *promWriteOutput) Init(ctx context.Context, name string, cfg map[string]
 
 	// set defaults
 	p.setDefaultsFor(ncfg)
+	sampler, err := newSubscriptionSampler(ncfg.MessageSampling)
+	if err != nil {
+		return err
+	}
+	p.sampler.Store(sampler)
 
 	p.cfg.Store(ncfg)
 
@@ -275,6 +283,10 @@ func (p *promWriteOutput) Update(ctx context.Context, cfg map[string]any) error 
 	}
 
 	p.setDefaultsFor(newCfg)
+	newSampler, err := newSubscriptionSampler(newCfg.MessageSampling)
+	if err != nil {
+		return err
+	}
 
 	currCfg := p.cfg.Load()
 
@@ -334,6 +346,7 @@ func (p *promWriteOutput) Update(ctx context.Context, cfg map[string]any) error 
 
 	// store new config
 	p.cfg.Store(newCfg)
+	p.sampler.Store(newSampler)
 
 	if swapChannel || restartWorkers {
 		var newChan chan *prompb.TimeSeries
@@ -419,7 +432,9 @@ func (p *promWriteOutput) Validate(cfg map[string]any) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	p.setDefaultsFor(ncfg)
+	_, err = newSubscriptionSampler(ncfg.MessageSampling)
+	return err
 }
 
 func (p *promWriteOutput) Write(ctx context.Context, rsp proto.Message, meta outputs.Meta) {
@@ -427,15 +442,32 @@ func (p *promWriteOutput) Write(ctx context.Context, rsp proto.Message, meta out
 		return
 	}
 	cfg := p.cfg.Load()
+	if cfg == nil {
+		return
+	}
+	acceptedAt := time.Now()
+	sampler := p.sampler.Load()
+	if sampler != nil {
+		if !sampler.Allow(meta, proto.Size(rsp), acceptedAt) {
+			prometheusWriteMessagesSkipped.WithLabelValues(cfg.Name, meta["subscription-name"]).Inc()
+			return
+		}
+	}
 
 	wctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 
 	select {
 	case <-ctx.Done():
+		if sampler != nil {
+			sampler.Rollback(meta, acceptedAt)
+		}
 		return
 	case p.msgChan <- outputs.NewProtoMsg(rsp, meta):
 	case <-wctx.Done():
+		if sampler != nil {
+			sampler.Rollback(meta, acceptedAt)
+		}
 		if cfg.Debug {
 			p.logger.Warn("write expired", "timeout", cfg.Timeout)
 		}

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output_test.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmic/pkg/outputs"
 	"github.com/zestor-dev/zestor/store"
 	"github.com/zestor-dev/zestor/store/gomap"
@@ -30,6 +31,34 @@ func TestPromWriteOutput_Validate(t *testing.T) {
 		{name: "decode buffer-size", cfg: map[string]any{"buffer-size": "x"}, wantErr: true},
 		{name: "missing url", cfg: map[string]any{}, wantErr: true},
 		{name: "bad url", cfg: map[string]any{"url": "://bad"}, wantErr: true},
+		{
+			name: "bad message sampling interval",
+			cfg: map[string]any{
+				"url": "http://localhost:9090",
+				"message-sampling": map[string]any{
+					"by-subscription": map[string]any{
+						"counters": map[string]any{"interval": "invalid"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid message sampling",
+			cfg: map[string]any{
+				"url": "http://localhost:9090",
+				"message-sampling": map[string]any{
+					"by-subscription": map[string]any{
+						"counters": map[string]any{
+							"interval":      "15s",
+							"minimum-bytes": 262144,
+						},
+					},
+					"cache-size": 1000,
+				},
+			},
+			wantErr: false,
+		},
 		{
 			name: "bad target-template",
 			cfg: map[string]any{
@@ -116,5 +145,66 @@ func TestPromWriteOutput_InitErrors(t *testing.T) {
 	p := &promWriteOutput{}
 	if err := p.Init(context.Background(), "pw1", map[string]any{}, outputs.WithConfigStore(memStore())); err == nil {
 		t.Fatal("expected missing url")
+	}
+}
+
+func TestPromWriteOutputSamplingSkipsBeforeInputQueue(t *testing.T) {
+	p := &promWriteOutput{}
+	p.init()
+	p.cfg.Store(&config{Name: "pw1", Timeout: time.Second})
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	p.sampler.Store(sampler)
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	if !sampler.Allow(meta, 0, time.Now()) {
+		t.Fatal("failed to seed sampler")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		p.Write(context.Background(), &gnmi.SubscribeResponse{}, meta)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("sampled message blocked on input queue")
+	}
+}
+
+func TestPromWriteOutputSamplingPreservesNarrowMessages(t *testing.T) {
+	p := &promWriteOutput{}
+	p.init()
+	p.cfg.Store(&config{Name: "pw1", Timeout: time.Second})
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute, MinimumBytes: 1024},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	p.sampler.Store(sampler)
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	if !sampler.Allow(meta, 2048, time.Now()) {
+		t.Fatal("failed to seed sampler")
+	}
+
+	received := make(chan struct{})
+	go func() {
+		<-p.msgChan
+		close(received)
+	}()
+	p.Write(context.Background(), &gnmi.SubscribeResponse{}, meta)
+	select {
+	case <-received:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("narrow message did not bypass sampling")
 	}
 }

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output_test.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmic/pkg/outputs"
 	"github.com/zestor-dev/zestor/store"
 	"github.com/zestor-dev/zestor/store/gomap"
@@ -89,15 +88,21 @@ func TestPromWriteOutput_InitUpdateClose(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	messageSampling := map[string]any{
+		"by-subscription": map[string]any{
+			"counters": map[string]any{"interval": "1m"},
+		},
+	}
 	p := &promWriteOutput{}
 	cfg := map[string]any{
-		"url":         srv.URL + "/api/v1/write",
-		"interval":    "1h",
-		"buffer-size": 8,
-		"num-workers": 1,
-		"num-writers": 1,
-		"max-retries": 1,
-		"timeout":     "500ms",
+		"url":              srv.URL + "/api/v1/write",
+		"interval":         "1h",
+		"buffer-size":      8,
+		"num-workers":      1,
+		"num-writers":      1,
+		"max-retries":      1,
+		"timeout":          "500ms",
+		"message-sampling": messageSampling,
 	}
 	if err := p.Init(context.Background(), "pw1", cfg, outputs.WithConfigStore(memStore())); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -105,26 +110,32 @@ func TestPromWriteOutput_InitUpdateClose(t *testing.T) {
 	if s := p.String(); !strings.Contains(s, srv.URL) {
 		t.Fatalf("String: %s", s)
 	}
+	initialSampler := p.sampler.Load()
 	cfg2 := map[string]any{
-		"url":         srv.URL + "/api/v1/write",
-		"interval":    "2h",
-		"buffer-size": 8,
-		"num-workers": 1,
-		"num-writers": 1,
-		"max-retries": 1,
-		"timeout":     "500ms",
+		"url":              srv.URL + "/api/v1/write",
+		"interval":         "2h",
+		"buffer-size":      8,
+		"num-workers":      1,
+		"num-writers":      1,
+		"max-retries":      1,
+		"timeout":          "500ms",
+		"message-sampling": messageSampling,
 	}
 	if err := p.Update(context.Background(), cfg2); err != nil {
 		t.Fatalf("Update: %v", err)
 	}
+	if p.sampler.Load() != initialSampler {
+		t.Fatal("unchanged message-sampling configuration reset sampler state")
+	}
 	cfg3 := map[string]any{
-		"url":         srv.URL + "/api/v1/write",
-		"interval":    "2h",
-		"buffer-size": 16,
-		"num-workers": 1,
-		"num-writers": 1,
-		"max-retries": 1,
-		"timeout":     "500ms",
+		"url":              srv.URL + "/api/v1/write",
+		"interval":         "2h",
+		"buffer-size":      16,
+		"num-workers":      1,
+		"num-writers":      1,
+		"max-retries":      1,
+		"timeout":          "500ms",
+		"message-sampling": messageSampling,
 	}
 	if err := p.Update(context.Background(), cfg3); err != nil {
 		t.Fatalf("Update swap: %v", err)
@@ -162,13 +173,19 @@ func TestPromWriteOutputSamplingSkipsBeforeInputQueue(t *testing.T) {
 	}
 	p.sampler.Store(sampler)
 	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
-	if !sampler.Allow(meta, 0, time.Now()) {
+	info := streamInfo("stream-1")
+	now := time.Now()
+	if allowed, _ := sampler.Allow(info, meta, syncResponse(), now); !allowed {
+		t.Fatal("failed to observe sync response")
+	}
+	if allowed, _ := sampler.Allow(info, meta, updateResponse(nil), now); !allowed {
 		t.Fatal("failed to seed sampler")
 	}
+	ctx := outputs.WithSubscriptionInfo(context.Background(), info)
 
 	done := make(chan struct{})
 	go func() {
-		p.Write(context.Background(), &gnmi.SubscribeResponse{}, meta)
+		p.Write(ctx, updateResponse(nil), meta)
 		close(done)
 	}()
 	select {
@@ -192,7 +209,12 @@ func TestPromWriteOutputSamplingPreservesNarrowMessages(t *testing.T) {
 	}
 	p.sampler.Store(sampler)
 	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
-	if !sampler.Allow(meta, 2048, time.Now()) {
+	info := streamInfo("stream-1")
+	now := time.Now()
+	if allowed, _ := sampler.Allow(info, meta, syncResponse(), now); !allowed {
+		t.Fatal("failed to observe sync response")
+	}
+	if allowed, _ := sampler.Allow(info, meta, updateResponse(make([]byte, 2048)), now); !allowed {
 		t.Fatal("failed to seed sampler")
 	}
 
@@ -201,7 +223,7 @@ func TestPromWriteOutputSamplingPreservesNarrowMessages(t *testing.T) {
 		<-p.msgChan
 		close(received)
 	}()
-	p.Write(context.Background(), &gnmi.SubscribeResponse{}, meta)
+	p.Write(outputs.WithSubscriptionInfo(context.Background(), info), updateResponse(nil), meta)
 	select {
 	case <-received:
 	case <-time.After(100 * time.Millisecond):

--- a/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output_test.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/prometheus_write_output_test.go
@@ -172,15 +172,10 @@ func TestPromWriteOutputSamplingSkipsBeforeInputQueue(t *testing.T) {
 		t.Fatalf("newSubscriptionSampler() error = %v", err)
 	}
 	p.sampler.Store(sampler)
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	meta := outputs.Meta{"source": "event-tag-source", "subscription-name": "event-tag-subscription"}
 	info := streamInfo("stream-1")
 	now := time.Now()
-	if allowed, _ := sampler.Allow(info, meta, syncResponse(), now); !allowed {
-		t.Fatal("failed to observe sync response")
-	}
-	if allowed, _ := sampler.Allow(info, meta, updateResponse(nil), now); !allowed {
-		t.Fatal("failed to seed sampler")
-	}
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now, true, true)
 	ctx := outputs.WithSubscriptionInfo(context.Background(), info)
 
 	done := make(chan struct{})
@@ -211,12 +206,7 @@ func TestPromWriteOutputSamplingPreservesNarrowMessages(t *testing.T) {
 	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	info := streamInfo("stream-1")
 	now := time.Now()
-	if allowed, _ := sampler.Allow(info, meta, syncResponse(), now); !allowed {
-		t.Fatal("failed to observe sync response")
-	}
-	if allowed, _ := sampler.Allow(info, meta, updateResponse(make([]byte, 2048)), now); !allowed {
-		t.Fatal("failed to seed sampler")
-	}
+	assertSampleDecision(t, sampler, info, updateResponse(make([]byte, 2048)), now, true, true)
 
 	received := make(chan struct{})
 	go func() {
@@ -228,5 +218,34 @@ func TestPromWriteOutputSamplingPreservesNarrowMessages(t *testing.T) {
 	case <-received:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("narrow message did not bypass sampling")
+	}
+}
+
+func TestPromWriteOutputSamplingRollsBackExpiredWrite(t *testing.T) {
+	p := &promWriteOutput{}
+	p.init()
+	p.cfg.Store(&config{Name: "pw1", Timeout: 10 * time.Millisecond})
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	p.sampler.Store(sampler)
+	info := streamInfo("stream-1")
+	ctx := outputs.WithSubscriptionInfo(context.Background(), info)
+	message := updateResponse(nil)
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+
+	p.Write(ctx, message, meta)
+
+	p.msgChan = make(chan *outputs.ProtoMsg, 1)
+	p.Write(ctx, message, meta)
+	select {
+	case <-p.msgChan:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("message after expired write was still sampled")
 	}
 }

--- a/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler.go
@@ -32,24 +32,28 @@ type messageSamplingRule struct {
 	MinimumBytes int           `mapstructure:"minimum-bytes,omitempty" json:"minimum-bytes,omitempty"`
 }
 
+type sampleKey struct {
+	source       string
+	subscription string
+	instance     string
+}
+
 type sampleState struct {
-	instance   string
 	acceptedAt time.Time
 	next       time.Time
 }
 
-type sampleAcceptance struct {
-	key        string
-	instance   string
-	acceptedAt time.Time
-	previous   sampleState
+type sampleReservation struct {
+	key   sampleKey
+	state sampleState
 }
 
 type subscriptionSampler struct {
 	mu       sync.Mutex
 	rules    map[string]messageSamplingRule
 	spread   bool
-	accepted *lru.Cache[string, sampleState]
+	accepted *lru.Cache[sampleKey, sampleState]
+	pending  map[sampleKey]*sampleReservation
 }
 
 func newSubscriptionSampler(cfg *messageSamplingConfig) (*subscriptionSampler, error) {
@@ -71,7 +75,7 @@ func newSubscriptionSampler(cfg *messageSamplingConfig) (*subscriptionSampler, e
 	if cacheSize < 0 {
 		return nil, errors.New("message-sampling cache-size cannot be negative")
 	}
-	accepted, err := lru.New[string, sampleState](cacheSize)
+	accepted, err := lru.New[sampleKey, sampleState](cacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("create message-sampling cache: %w", err)
 	}
@@ -79,6 +83,7 @@ func newSubscriptionSampler(cfg *messageSamplingConfig) (*subscriptionSampler, e
 		rules:    maps.Clone(cfg.BySubscription),
 		spread:   cfg.Spread,
 		accepted: accepted,
+		pending:  make(map[sampleKey]*sampleReservation),
 	}, nil
 }
 
@@ -101,31 +106,41 @@ func messageSamplingCacheSize(cfg *messageSamplingConfig) int {
 	return cfg.CacheSize
 }
 
-func (s *subscriptionSampler) Rollback(acceptance *sampleAcceptance) {
-	if s == nil || acceptance == nil {
+func (s *subscriptionSampler) Commit(reservation *sampleReservation) {
+	if s == nil || reservation == nil {
 		return
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	state, ok := s.accepted.Peek(acceptance.key)
-	if !ok || state.instance != acceptance.instance || !state.acceptedAt.Equal(acceptance.acceptedAt) {
+	if s.pending[reservation.key] != reservation {
 		return
 	}
-	s.accepted.Add(acceptance.key, acceptance.previous)
+	delete(s.pending, reservation.key)
+	s.accepted.Add(reservation.key, reservation.state)
 }
 
-func (s *subscriptionSampler) Allow(
+func (s *subscriptionSampler) Rollback(reservation *sampleReservation) {
+	if s == nil || reservation == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pending[reservation.key] == reservation {
+		delete(s.pending, reservation.key)
+	}
+}
+
+func (s *subscriptionSampler) Reserve(
 	info outputs.SubscriptionInfo,
-	meta outputs.Meta,
 	message proto.Message,
 	now time.Time,
-) (bool, *sampleAcceptance) {
-	if s == nil || info.Instance == "" || info.Mode != gnmi.SubscriptionList_STREAM {
+) (bool, *sampleReservation) {
+	if s == nil || info.Source == "" || info.Name == "" || info.Instance == "" || info.Mode != gnmi.SubscriptionList_STREAM {
 		return true, nil
 	}
-	subscription := meta["subscription-name"]
-	rule, ok := s.rules[subscription]
+	rule, ok := s.rules[info.Name]
 	if !ok {
 		return true, nil
 	}
@@ -141,23 +156,21 @@ func (s *subscriptionSampler) Allow(
 	if !info.InitialSyncComplete {
 		return true, nil
 	}
-	source := meta["source"]
-	if source == "" {
-		return true, nil
-	}
 	if proto.Size(message) < rule.MinimumBytes {
 		return true, nil
 	}
-	key := source + "\x00" + subscription
+	key := sampleKey{
+		source:       info.Source,
+		subscription: info.Name,
+		instance:     info.Instance,
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	state, ok := s.accepted.Get(key)
-	if !ok || state.instance != info.Instance {
-		state = sampleState{instance: info.Instance}
+	if _, ok := s.pending[key]; ok {
+		return false, nil
 	}
-
-	previous := state
+	state, _ := s.accepted.Peek(key)
 	if s.spread {
 		if state.acceptedAt.IsZero() {
 			state.next = nextSpreadTime(key, now.Add(rule.Interval), rule.Interval)
@@ -170,18 +183,19 @@ func (s *subscriptionSampler) Allow(
 		return false, nil
 	}
 	state.acceptedAt = now
-	s.accepted.Add(key, state)
-	return true, &sampleAcceptance{
-		key:        key,
-		instance:   info.Instance,
-		acceptedAt: now,
-		previous:   previous,
+	reservation := &sampleReservation{
+		key:   key,
+		state: state,
 	}
+	s.pending[key] = reservation
+	return true, reservation
 }
 
-func nextSpreadTime(key string, now time.Time, interval time.Duration) time.Time {
+func nextSpreadTime(key sampleKey, now time.Time, interval time.Duration) time.Time {
 	hash := fnv.New64a()
-	_, _ = hash.Write([]byte(key))
+	_, _ = hash.Write([]byte(key.source))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(key.subscription))
 	phase := time.Duration(hash.Sum64() % uint64(interval))
 	remainder := time.Duration(now.UnixNano() % int64(interval))
 	if remainder < 0 {

--- a/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler.go
@@ -1,0 +1,155 @@
+// © 2026 Nokia.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheus_write_output
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/openconfig/gnmic/pkg/outputs"
+)
+
+const defaultMessageSamplingCacheSize = 100_000
+
+type messageSamplingConfig struct {
+	BySubscription map[string]messageSamplingRule `mapstructure:"by-subscription,omitempty" json:"by-subscription,omitempty"`
+	CacheSize      int                            `mapstructure:"cache-size,omitempty" json:"cache-size,omitempty"`
+	Spread         bool                           `mapstructure:"spread,omitempty" json:"spread,omitempty"`
+}
+
+type messageSamplingRule struct {
+	Interval     time.Duration `mapstructure:"interval" json:"interval"`
+	MinimumBytes int           `mapstructure:"minimum-bytes,omitempty" json:"minimum-bytes,omitempty"`
+}
+
+type sampleState struct {
+	acceptedAt time.Time
+	next       time.Time
+}
+
+type subscriptionSampler struct {
+	mu       sync.Mutex
+	rules    map[string]messageSamplingRule
+	spread   bool
+	accepted *lru.Cache[string, sampleState]
+}
+
+func newSubscriptionSampler(cfg *messageSamplingConfig) (*subscriptionSampler, error) {
+	if cfg == nil || len(cfg.BySubscription) == 0 {
+		return nil, nil
+	}
+	for subscription, rule := range cfg.BySubscription {
+		if subscription == "" {
+			return nil, errors.New("message-sampling subscription cannot be empty")
+		}
+		if rule.Interval <= 0 {
+			return nil, fmt.Errorf("message-sampling interval for %q must be positive", subscription)
+		}
+		if rule.MinimumBytes < 0 {
+			return nil, fmt.Errorf("message-sampling minimum-bytes for %q cannot be negative", subscription)
+		}
+	}
+	cacheSize := cfg.CacheSize
+	if cacheSize < 0 {
+		return nil, errors.New("message-sampling cache-size cannot be negative")
+	}
+	if cacheSize == 0 {
+		cacheSize = defaultMessageSamplingCacheSize
+	}
+	accepted, err := lru.New[string, sampleState](cacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("create message-sampling cache: %w", err)
+	}
+	return &subscriptionSampler{
+		rules:    cfg.BySubscription,
+		spread:   cfg.Spread,
+		accepted: accepted,
+	}, nil
+}
+
+func (s *subscriptionSampler) Rollback(meta outputs.Meta, acceptedAt time.Time) {
+	if s == nil {
+		return
+	}
+	subscription := meta["subscription-name"]
+	if _, ok := s.rules[subscription]; !ok {
+		return
+	}
+	source := meta["source"]
+	if source == "" {
+		return
+	}
+	key := source + "\x00" + subscription
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.accepted.Peek(key)
+	if !ok || !state.acceptedAt.Equal(acceptedAt) {
+		return
+	}
+	if s.spread {
+		state.acceptedAt = time.Time{}
+		state.next = acceptedAt
+		s.accepted.Add(key, state)
+	} else {
+		s.accepted.Remove(key)
+	}
+}
+
+func (s *subscriptionSampler) Allow(meta outputs.Meta, messageBytes int, now time.Time) bool {
+	if s == nil {
+		return true
+	}
+	subscription := meta["subscription-name"]
+	rule, ok := s.rules[subscription]
+	if !ok {
+		return true
+	}
+	if messageBytes < rule.MinimumBytes {
+		return true
+	}
+	source := meta["source"]
+	if source == "" {
+		return true
+	}
+	key := source + "\x00" + subscription
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.accepted.Get(key)
+	if s.spread {
+		if !ok || state.acceptedAt.IsZero() {
+			// The first wide message may be the only complete baseline before a
+			// stream switches to narrow deltas, so it must not be discarded.
+			state.next = nextSpreadTime(key, now.Add(rule.Interval), rule.Interval)
+		} else if now.Before(state.next) {
+			return false
+		} else {
+			state.next = state.next.Add((now.Sub(state.next)/rule.Interval + 1) * rule.Interval)
+		}
+	} else if ok && now.Sub(state.acceptedAt) < rule.Interval {
+		return false
+	}
+	state.acceptedAt = now
+	s.accepted.Add(key, state)
+	return true
+}
+
+func nextSpreadTime(key string, now time.Time, interval time.Duration) time.Time {
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(key))
+	phase := time.Duration(hash.Sum64() % uint64(interval))
+	remainder := time.Duration(now.UnixNano() % int64(interval))
+	if remainder < 0 {
+		remainder += interval
+	}
+	delay := (phase - remainder + interval) % interval
+	return now.Add(delay)
+}

--- a/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler.go
@@ -8,10 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/openconfig/gnmic/pkg/outputs"
 )
@@ -30,8 +33,16 @@ type messageSamplingRule struct {
 }
 
 type sampleState struct {
+	instance   string
 	acceptedAt time.Time
 	next       time.Time
+}
+
+type sampleAcceptance struct {
+	key        string
+	instance   string
+	acceptedAt time.Time
+	previous   sampleState
 }
 
 type subscriptionSampler struct {
@@ -42,7 +53,7 @@ type subscriptionSampler struct {
 }
 
 func newSubscriptionSampler(cfg *messageSamplingConfig) (*subscriptionSampler, error) {
-	if cfg == nil || len(cfg.BySubscription) == 0 {
+	if messageSamplingDisabled(cfg) {
 		return nil, nil
 	}
 	for subscription, rule := range cfg.BySubscription {
@@ -56,90 +67,116 @@ func newSubscriptionSampler(cfg *messageSamplingConfig) (*subscriptionSampler, e
 			return nil, fmt.Errorf("message-sampling minimum-bytes for %q cannot be negative", subscription)
 		}
 	}
-	cacheSize := cfg.CacheSize
+	cacheSize := messageSamplingCacheSize(cfg)
 	if cacheSize < 0 {
 		return nil, errors.New("message-sampling cache-size cannot be negative")
-	}
-	if cacheSize == 0 {
-		cacheSize = defaultMessageSamplingCacheSize
 	}
 	accepted, err := lru.New[string, sampleState](cacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("create message-sampling cache: %w", err)
 	}
 	return &subscriptionSampler{
-		rules:    cfg.BySubscription,
+		rules:    maps.Clone(cfg.BySubscription),
 		spread:   cfg.Spread,
 		accepted: accepted,
 	}, nil
 }
 
-func (s *subscriptionSampler) Rollback(meta outputs.Meta, acceptedAt time.Time) {
-	if s == nil {
+func messageSamplingConfigsEqual(a, b *messageSamplingConfig) bool {
+	if messageSamplingDisabled(a) || messageSamplingDisabled(b) {
+		return messageSamplingDisabled(a) == messageSamplingDisabled(b)
+	}
+	return messageSamplingCacheSize(a) == messageSamplingCacheSize(b) &&
+		a.Spread == b.Spread && maps.Equal(a.BySubscription, b.BySubscription)
+}
+
+func messageSamplingDisabled(cfg *messageSamplingConfig) bool {
+	return cfg == nil || len(cfg.BySubscription) == 0
+}
+
+func messageSamplingCacheSize(cfg *messageSamplingConfig) int {
+	if cfg.CacheSize == 0 {
+		return defaultMessageSamplingCacheSize
+	}
+	return cfg.CacheSize
+}
+
+func (s *subscriptionSampler) Rollback(acceptance *sampleAcceptance) {
+	if s == nil || acceptance == nil {
 		return
 	}
-	subscription := meta["subscription-name"]
-	if _, ok := s.rules[subscription]; !ok {
-		return
-	}
-	source := meta["source"]
-	if source == "" {
-		return
-	}
-	key := source + "\x00" + subscription
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	state, ok := s.accepted.Peek(key)
-	if !ok || !state.acceptedAt.Equal(acceptedAt) {
+	state, ok := s.accepted.Peek(acceptance.key)
+	if !ok || state.instance != acceptance.instance || !state.acceptedAt.Equal(acceptance.acceptedAt) {
 		return
 	}
-	if s.spread {
-		state.acceptedAt = time.Time{}
-		state.next = acceptedAt
-		s.accepted.Add(key, state)
-	} else {
-		s.accepted.Remove(key)
-	}
+	s.accepted.Add(acceptance.key, acceptance.previous)
 }
 
-func (s *subscriptionSampler) Allow(meta outputs.Meta, messageBytes int, now time.Time) bool {
-	if s == nil {
-		return true
+func (s *subscriptionSampler) Allow(
+	info outputs.SubscriptionInfo,
+	meta outputs.Meta,
+	message proto.Message,
+	now time.Time,
+) (bool, *sampleAcceptance) {
+	if s == nil || info.Instance == "" || info.Mode != gnmi.SubscriptionList_STREAM {
+		return true, nil
 	}
 	subscription := meta["subscription-name"]
 	rule, ok := s.rules[subscription]
 	if !ok {
-		return true
+		return true, nil
 	}
-	if messageBytes < rule.MinimumBytes {
-		return true
+	response, ok := message.(*gnmi.SubscribeResponse)
+	if !ok {
+		return true, nil
+	}
+	if _, ok := response.Response.(*gnmi.SubscribeResponse_Update); !ok {
+		return true, nil
+	}
+	// Initial synchronization may span multiple Update responses. Preserve
+	// every one until the server marks the snapshot complete.
+	if !info.InitialSyncComplete {
+		return true, nil
 	}
 	source := meta["source"]
 	if source == "" {
-		return true
+		return true, nil
+	}
+	if proto.Size(message) < rule.MinimumBytes {
+		return true, nil
 	}
 	key := source + "\x00" + subscription
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	state, ok := s.accepted.Get(key)
+	if !ok || state.instance != info.Instance {
+		state = sampleState{instance: info.Instance}
+	}
+
+	previous := state
 	if s.spread {
-		if !ok || state.acceptedAt.IsZero() {
-			// The first wide message may be the only complete baseline before a
-			// stream switches to narrow deltas, so it must not be discarded.
+		if state.acceptedAt.IsZero() {
 			state.next = nextSpreadTime(key, now.Add(rule.Interval), rule.Interval)
 		} else if now.Before(state.next) {
-			return false
+			return false, nil
 		} else {
 			state.next = state.next.Add((now.Sub(state.next)/rule.Interval + 1) * rule.Interval)
 		}
-	} else if ok && now.Sub(state.acceptedAt) < rule.Interval {
-		return false
+	} else if !state.acceptedAt.IsZero() && now.Sub(state.acceptedAt) < rule.Interval {
+		return false, nil
 	}
 	state.acceptedAt = now
 	s.accepted.Add(key, state)
-	return true
+	return true, &sampleAcceptance{
+		key:        key,
+		instance:   info.Instance,
+		acceptedAt: now,
+		previous:   previous,
+	}
 }
 
 func nextSpreadTime(key string, now time.Time, interval time.Duration) time.Time {

--- a/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler_test.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler_test.go
@@ -10,92 +10,131 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/openconfig/gnmic/pkg/outputs"
 )
 
 func TestSubscriptionSampler(t *testing.T) {
-	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
 		BySubscription: map[string]messageSamplingRule{
 			"counters": {Interval: 10 * time.Second},
 		},
 		CacheSize: 2,
 	})
-	if err != nil {
-		t.Fatalf("newSubscriptionSampler() error = %v", err)
-	}
 	now := time.Unix(100, 0)
+	leaf1 := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	leaf2 := outputs.Meta{"source": "leaf-2", "subscription-name": "counters"}
+	info := streamInfo("stream-1")
 
-	tests := []struct {
-		name string
-		meta outputs.Meta
-		at   time.Time
-		want bool
-	}{
-		{
-			name: "unconfigured subscription",
-			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "state"},
-			at:   now,
-			want: true,
-		},
-		{
-			name: "missing source",
-			meta: outputs.Meta{"subscription-name": "counters"},
-			at:   now,
-			want: true,
-		},
-		{
-			name: "first message",
-			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "counters"},
-			at:   now,
-			want: true,
-		},
-		{
-			name: "same stream inside interval",
-			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "counters"},
-			at:   now.Add(9 * time.Second),
-			want: false,
-		},
-		{
-			name: "different source",
-			meta: outputs.Meta{"source": "leaf-2", "subscription-name": "counters"},
-			at:   now.Add(9 * time.Second),
-			want: true,
-		},
-		{
-			name: "interval elapsed",
-			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "counters"},
-			at:   now.Add(10 * time.Second),
-			want: true,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := sampler.Allow(test.meta, 0, test.at); got != test.want {
-				t.Fatalf("Allow() = %v, want %v", got, test.want)
-			}
-		})
-	}
+	assertSampleDecision(t, sampler, info, leaf1, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, leaf1, updateResponse(nil), now, true, true)
+	assertSampleDecision(t, sampler, info, leaf1, updateResponse(nil), now.Add(9*time.Second), false, false)
+	assertSampleDecision(t, sampler, info, leaf1, updateResponse(nil), now.Add(10*time.Second), true, true)
+
+	assertSampleDecision(t, sampler, info, leaf2, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, leaf2, updateResponse(nil), now.Add(time.Second), true, true)
+	assertSampleDecision(t, sampler, info, outputs.Meta{
+		"source": "leaf-1", "subscription-name": "state",
+	}, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, info, outputs.Meta{
+		"subscription-name": "counters",
+	}, updateResponse(nil), now, true, false)
 }
 
-func TestSubscriptionSamplerAllowsOneConcurrentMessage(t *testing.T) {
-	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+func TestSubscriptionSamplerPreservesInitialSync(t *testing.T) {
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
 		BySubscription: map[string]messageSamplingRule{
 			"counters": {Interval: time.Minute},
 		},
 	})
-	if err != nil {
-		t.Fatalf("newSubscriptionSampler() error = %v", err)
-	}
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	initialInfo := initialStreamInfo("stream-1")
+	info := streamInfo("stream-1")
+	now := time.Unix(100, 0)
+
+	assertSampleDecision(t, sampler, initialInfo, meta, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, initialInfo, meta, updateResponse(nil), now.Add(time.Second), true, false)
+	assertSampleDecision(t, sampler, initialInfo, meta, syncResponse(), now.Add(2*time.Second), true, false)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(3*time.Second), true, true)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(4*time.Second), false, false)
+}
+
+func TestSubscriptionSamplerResetsAfterReconnect(t *testing.T) {
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
 	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	now := time.Unix(100, 0)
+
+	assertSampleDecision(t, sampler, streamInfo("stream-1"), meta, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, streamInfo("stream-1"), meta, updateResponse(nil), now, true, true)
+	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), meta, updateResponse(nil), now.Add(time.Second), true, false)
+	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), meta, updateResponse(nil), now.Add(2*time.Second), true, false)
+	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), meta, syncResponse(), now.Add(3*time.Second), true, false)
+	assertSampleDecision(t, sampler, streamInfo("stream-2"), meta, updateResponse(nil), now.Add(4*time.Second), true, true)
+}
+
+func TestSubscriptionSamplerControlMessagesDoNotConsumeWindow(t *testing.T) {
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	info := streamInfo("stream-1")
+	now := time.Unix(100, 0)
+
+	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now, true, true)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(time.Second), false, false)
+}
+
+func TestSubscriptionSamplerOnlySamplesKnownStreamUpdates(t *testing.T) {
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	now := time.Unix(100, 0)
+
+	assertSampleDecision(t, sampler, outputs.SubscriptionInfo{}, meta, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, outputs.SubscriptionInfo{
+		Instance: "once-1", Mode: gnmi.SubscriptionList_ONCE,
+	}, meta, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, outputs.SubscriptionInfo{
+		Instance: "poll-1", Mode: gnmi.SubscriptionList_POLL,
+	}, meta, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, streamInfo("stream-1"), meta, &gnmi.GetResponse{}, now, true, false)
+}
+
+func TestSubscriptionSamplerAllowsOneConcurrentMessage(t *testing.T) {
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	info := streamInfo("stream-1")
+	now := time.Unix(100, 0)
+	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+
 	var accepted atomic.Int64
 	var wg sync.WaitGroup
 	for range 100 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if sampler.Allow(meta, 0, now) {
+			allowed, acceptance := sampler.Allow(info, meta, updateResponse(nil), now)
+			if allowed {
 				accepted.Add(1)
+				if acceptance == nil {
+					t.Error("accepted sampled message did not return rollback state")
+				}
 			}
 		}()
 	}
@@ -147,109 +186,155 @@ func TestNewSubscriptionSamplerValidation(t *testing.T) {
 	}
 }
 
+func TestMessageSamplingConfigsEqual(t *testing.T) {
+	rules := map[string]messageSamplingRule{"counters": {Interval: time.Minute}}
+	if !messageSamplingConfigsEqual(nil, &messageSamplingConfig{}) {
+		t.Fatal("disabled configurations should be equivalent")
+	}
+	if !messageSamplingConfigsEqual(
+		&messageSamplingConfig{BySubscription: rules},
+		&messageSamplingConfig{BySubscription: rules, CacheSize: defaultMessageSamplingCacheSize},
+	) {
+		t.Fatal("default and explicit cache sizes should be equivalent")
+	}
+	if messageSamplingConfigsEqual(
+		&messageSamplingConfig{BySubscription: rules},
+		&messageSamplingConfig{BySubscription: rules, Spread: true},
+	) {
+		t.Fatal("different spread settings should not be equivalent")
+	}
+}
+
 func TestSubscriptionSamplerRollback(t *testing.T) {
-	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
 		BySubscription: map[string]messageSamplingRule{
 			"counters": {Interval: time.Minute},
 		},
 	})
-	if err != nil {
-		t.Fatalf("newSubscriptionSampler() error = %v", err)
-	}
 	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
-	acceptedAt := time.Unix(100, 0)
-	if !sampler.Allow(meta, 0, acceptedAt) {
-		t.Fatal("first message was not accepted")
+	info := streamInfo("stream-1")
+	now := time.Unix(100, 0)
+	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+
+	allowed, acceptance := sampler.Allow(info, meta, updateResponse(nil), now)
+	if !allowed || acceptance == nil {
+		t.Fatal("first post-sync update was not sampled")
 	}
-	sampler.Rollback(meta, acceptedAt)
-	if !sampler.Allow(meta, 0, acceptedAt.Add(time.Second)) {
+	sampler.Rollback(acceptance)
+	allowed, newer := sampler.Allow(info, meta, updateResponse(nil), now.Add(time.Second))
+	if !allowed || newer == nil {
 		t.Fatal("message after rollback was not accepted")
 	}
 
 	// A stale rollback must not remove a newer acceptance.
-	sampler.Rollback(meta, acceptedAt)
-	if sampler.Allow(meta, 0, acceptedAt.Add(2*time.Second)) {
-		t.Fatal("stale rollback removed newer acceptance")
-	}
+	sampler.Rollback(acceptance)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(2*time.Second), false, false)
 }
 
-func TestSubscriptionSamplerSpreadAcceptsInitialBaseline(t *testing.T) {
+func TestSubscriptionSamplerSpread(t *testing.T) {
 	const interval = 10 * time.Second
-	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
 		BySubscription: map[string]messageSamplingRule{
 			"counters": {Interval: interval},
 		},
 		Spread: true,
 	})
-	if err != nil {
-		t.Fatalf("newSubscriptionSampler() error = %v", err)
-	}
 	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	info := streamInfo("stream-1")
 	key := "leaf-1\x00counters"
 	now := time.Unix(123, 456)
 	next := nextSpreadTime(key, now.Add(interval), interval)
+	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
 
-	if !sampler.Allow(meta, 0, now) {
-		t.Fatal("initial baseline was not accepted")
+	allowed, acceptance := sampler.Allow(info, meta, updateResponse(nil), now)
+	if !allowed || acceptance == nil {
+		t.Fatal("first post-sync update was not accepted")
 	}
-	if sampler.Allow(meta, 0, next.Add(-time.Nanosecond)) {
-		t.Fatal("second message before stable phase was accepted")
-	}
-	if !sampler.Allow(meta, 0, next) {
-		t.Fatal("message at stable phase was not accepted")
-	}
-	if sampler.Allow(meta, 0, next.Add(interval-time.Nanosecond)) {
-		t.Fatal("second message inside interval was accepted")
-	}
-	if !sampler.Allow(meta, 0, next.Add(interval)) {
-		t.Fatal("message in next stable phase was not accepted")
-	}
-}
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next.Add(-time.Nanosecond), false, false)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next, true, true)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next.Add(interval-time.Nanosecond), false, false)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next.Add(interval), true, true)
 
-func TestSubscriptionSamplerSpreadRollbackRetriesInitialBaseline(t *testing.T) {
-	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
-		BySubscription: map[string]messageSamplingRule{
-			"counters": {Interval: time.Minute},
-		},
-		Spread: true,
+	sampler = mustSubscriptionSampler(t, &messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{"counters": {Interval: interval}},
+		Spread:         true,
 	})
-	if err != nil {
-		t.Fatalf("newSubscriptionSampler() error = %v", err)
-	}
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
-	acceptedAt := time.Unix(100, 0)
-	if !sampler.Allow(meta, 0, acceptedAt) {
-		t.Fatal("initial baseline was not accepted")
-	}
-
-	sampler.Rollback(meta, acceptedAt)
-	if !sampler.Allow(meta, 0, acceptedAt.Add(time.Second)) {
-		t.Fatal("initial baseline was not accepted after enqueue rollback")
-	}
+	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+	allowed, acceptance = sampler.Allow(info, meta, updateResponse(nil), now)
+	sampler.Rollback(acceptance)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(time.Second), true, true)
 }
 
 func TestSubscriptionSamplerPreservesNarrowUpdates(t *testing.T) {
-	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
 		BySubscription: map[string]messageSamplingRule{
 			"counters": {Interval: 10 * time.Second, MinimumBytes: 1024},
 		},
 	})
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	info := streamInfo("stream-1")
+	now := time.Unix(100, 0)
+	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(time.Second), true, false)
+	wide := updateResponse(make([]byte, 2048))
+	assertSampleDecision(t, sampler, info, meta, wide, now.Add(2*time.Second), true, true)
+	assertSampleDecision(t, sampler, info, meta, wide, now.Add(3*time.Second), false, false)
+	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(4*time.Second), true, false)
+}
+
+func mustSubscriptionSampler(t *testing.T, cfg *messageSamplingConfig) *subscriptionSampler {
+	t.Helper()
+	sampler, err := newSubscriptionSampler(cfg)
 	if err != nil {
 		t.Fatalf("newSubscriptionSampler() error = %v", err)
 	}
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
-	now := time.Unix(100, 0)
+	return sampler
+}
 
-	if !sampler.Allow(meta, 512, now) || !sampler.Allow(meta, 512, now.Add(time.Second)) {
-		t.Fatal("narrow incremental update was sampled")
+func streamInfo(instance string) outputs.SubscriptionInfo {
+	return outputs.SubscriptionInfo{
+		Instance:            instance,
+		Mode:                gnmi.SubscriptionList_STREAM,
+		InitialSyncComplete: true,
 	}
-	if !sampler.Allow(meta, 2048, now.Add(2*time.Second)) {
-		t.Fatal("first wide message was not accepted")
+}
+
+func initialStreamInfo(instance string) outputs.SubscriptionInfo {
+	return outputs.SubscriptionInfo{Instance: instance, Mode: gnmi.SubscriptionList_STREAM}
+}
+
+func syncResponse() *gnmi.SubscribeResponse {
+	return &gnmi.SubscribeResponse{Response: &gnmi.SubscribeResponse_SyncResponse{SyncResponse: true}}
+}
+
+func updateResponse(value []byte) *gnmi.SubscribeResponse {
+	notification := &gnmi.Notification{}
+	if value != nil {
+		notification.Update = []*gnmi.Update{{Val: &gnmi.TypedValue{
+			Value: &gnmi.TypedValue_BytesVal{BytesVal: value},
+		}}}
 	}
-	if sampler.Allow(meta, 2048, now.Add(3*time.Second)) {
-		t.Fatal("second wide message inside interval was accepted")
+	return &gnmi.SubscribeResponse{Response: &gnmi.SubscribeResponse_Update{Update: notification}}
+}
+
+func assertSampleDecision(
+	t *testing.T,
+	sampler *subscriptionSampler,
+	info outputs.SubscriptionInfo,
+	meta outputs.Meta,
+	message proto.Message,
+	now time.Time,
+	wantAllowed bool,
+	wantRecorded bool,
+) {
+	t.Helper()
+	allowed, acceptance := sampler.Allow(info, meta, message, now)
+	if allowed != wantAllowed {
+		t.Fatalf("Allow() = %v, want %v", allowed, wantAllowed)
 	}
-	if !sampler.Allow(meta, 512, now.Add(4*time.Second)) {
-		t.Fatal("narrow update inside wide-message interval was sampled")
+	if gotRecorded := acceptance != nil; gotRecorded != wantRecorded {
+		t.Fatalf("Allow() recorded acceptance = %v, want %v", gotRecorded, wantRecorded)
 	}
 }

--- a/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler_test.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler_test.go
@@ -1,0 +1,255 @@
+// © 2026 Nokia.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheus_write_output
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openconfig/gnmic/pkg/outputs"
+)
+
+func TestSubscriptionSampler(t *testing.T) {
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: 10 * time.Second},
+		},
+		CacheSize: 2,
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	now := time.Unix(100, 0)
+
+	tests := []struct {
+		name string
+		meta outputs.Meta
+		at   time.Time
+		want bool
+	}{
+		{
+			name: "unconfigured subscription",
+			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "state"},
+			at:   now,
+			want: true,
+		},
+		{
+			name: "missing source",
+			meta: outputs.Meta{"subscription-name": "counters"},
+			at:   now,
+			want: true,
+		},
+		{
+			name: "first message",
+			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "counters"},
+			at:   now,
+			want: true,
+		},
+		{
+			name: "same stream inside interval",
+			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "counters"},
+			at:   now.Add(9 * time.Second),
+			want: false,
+		},
+		{
+			name: "different source",
+			meta: outputs.Meta{"source": "leaf-2", "subscription-name": "counters"},
+			at:   now.Add(9 * time.Second),
+			want: true,
+		},
+		{
+			name: "interval elapsed",
+			meta: outputs.Meta{"source": "leaf-1", "subscription-name": "counters"},
+			at:   now.Add(10 * time.Second),
+			want: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := sampler.Allow(test.meta, 0, test.at); got != test.want {
+				t.Fatalf("Allow() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSubscriptionSamplerAllowsOneConcurrentMessage(t *testing.T) {
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	now := time.Unix(100, 0)
+	var accepted atomic.Int64
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if sampler.Allow(meta, 0, now) {
+				accepted.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := accepted.Load(); got != 1 {
+		t.Fatalf("accepted = %d, want 1", got)
+	}
+}
+
+func TestNewSubscriptionSamplerValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *messageSamplingConfig
+	}{
+		{
+			name: "empty subscription",
+			cfg: &messageSamplingConfig{BySubscription: map[string]messageSamplingRule{
+				"": {Interval: time.Second},
+			}},
+		},
+		{
+			name: "non-positive interval",
+			cfg: &messageSamplingConfig{BySubscription: map[string]messageSamplingRule{
+				"counters": {},
+			}},
+		},
+		{
+			name: "negative minimum bytes",
+			cfg: &messageSamplingConfig{BySubscription: map[string]messageSamplingRule{
+				"counters": {Interval: time.Second, MinimumBytes: -1},
+			}},
+		},
+		{
+			name: "negative cache size",
+			cfg: &messageSamplingConfig{
+				BySubscription: map[string]messageSamplingRule{
+					"counters": {Interval: time.Second},
+				},
+				CacheSize: -1,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := newSubscriptionSampler(test.cfg); err == nil {
+				t.Fatal("newSubscriptionSampler() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestSubscriptionSamplerRollback(t *testing.T) {
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	acceptedAt := time.Unix(100, 0)
+	if !sampler.Allow(meta, 0, acceptedAt) {
+		t.Fatal("first message was not accepted")
+	}
+	sampler.Rollback(meta, acceptedAt)
+	if !sampler.Allow(meta, 0, acceptedAt.Add(time.Second)) {
+		t.Fatal("message after rollback was not accepted")
+	}
+
+	// A stale rollback must not remove a newer acceptance.
+	sampler.Rollback(meta, acceptedAt)
+	if sampler.Allow(meta, 0, acceptedAt.Add(2*time.Second)) {
+		t.Fatal("stale rollback removed newer acceptance")
+	}
+}
+
+func TestSubscriptionSamplerSpreadAcceptsInitialBaseline(t *testing.T) {
+	const interval = 10 * time.Second
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: interval},
+		},
+		Spread: true,
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	key := "leaf-1\x00counters"
+	now := time.Unix(123, 456)
+	next := nextSpreadTime(key, now.Add(interval), interval)
+
+	if !sampler.Allow(meta, 0, now) {
+		t.Fatal("initial baseline was not accepted")
+	}
+	if sampler.Allow(meta, 0, next.Add(-time.Nanosecond)) {
+		t.Fatal("second message before stable phase was accepted")
+	}
+	if !sampler.Allow(meta, 0, next) {
+		t.Fatal("message at stable phase was not accepted")
+	}
+	if sampler.Allow(meta, 0, next.Add(interval-time.Nanosecond)) {
+		t.Fatal("second message inside interval was accepted")
+	}
+	if !sampler.Allow(meta, 0, next.Add(interval)) {
+		t.Fatal("message in next stable phase was not accepted")
+	}
+}
+
+func TestSubscriptionSamplerSpreadRollbackRetriesInitialBaseline(t *testing.T) {
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+		Spread: true,
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	acceptedAt := time.Unix(100, 0)
+	if !sampler.Allow(meta, 0, acceptedAt) {
+		t.Fatal("initial baseline was not accepted")
+	}
+
+	sampler.Rollback(meta, acceptedAt)
+	if !sampler.Allow(meta, 0, acceptedAt.Add(time.Second)) {
+		t.Fatal("initial baseline was not accepted after enqueue rollback")
+	}
+}
+
+func TestSubscriptionSamplerPreservesNarrowUpdates(t *testing.T) {
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: 10 * time.Second, MinimumBytes: 1024},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSubscriptionSampler() error = %v", err)
+	}
+	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
+	now := time.Unix(100, 0)
+
+	if !sampler.Allow(meta, 512, now) || !sampler.Allow(meta, 512, now.Add(time.Second)) {
+		t.Fatal("narrow incremental update was sampled")
+	}
+	if !sampler.Allow(meta, 2048, now.Add(2*time.Second)) {
+		t.Fatal("first wide message was not accepted")
+	}
+	if sampler.Allow(meta, 2048, now.Add(3*time.Second)) {
+		t.Fatal("second wide message inside interval was accepted")
+	}
+	if !sampler.Allow(meta, 512, now.Add(4*time.Second)) {
+		t.Fatal("narrow update inside wide-message interval was sampled")
+	}
+}

--- a/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler_test.go
+++ b/pkg/outputs/prometheus_output/prometheus_write_output/subscription_sampler_test.go
@@ -24,23 +24,18 @@ func TestSubscriptionSampler(t *testing.T) {
 		CacheSize: 2,
 	})
 	now := time.Unix(100, 0)
-	leaf1 := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
-	leaf2 := outputs.Meta{"source": "leaf-2", "subscription-name": "counters"}
-	info := streamInfo("stream-1")
+	leaf1 := streamInfoFor("stream-1", "leaf-1", "counters")
+	leaf2 := streamInfoFor("stream-1", "leaf-2", "counters")
 
-	assertSampleDecision(t, sampler, info, leaf1, syncResponse(), now, true, false)
-	assertSampleDecision(t, sampler, info, leaf1, updateResponse(nil), now, true, true)
-	assertSampleDecision(t, sampler, info, leaf1, updateResponse(nil), now.Add(9*time.Second), false, false)
-	assertSampleDecision(t, sampler, info, leaf1, updateResponse(nil), now.Add(10*time.Second), true, true)
+	assertSampleDecision(t, sampler, leaf1, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, leaf1, updateResponse(nil), now, true, true)
+	assertSampleDecision(t, sampler, leaf1, updateResponse(nil), now.Add(9*time.Second), false, false)
+	assertSampleDecision(t, sampler, leaf1, updateResponse(nil), now.Add(10*time.Second), true, true)
 
-	assertSampleDecision(t, sampler, info, leaf2, syncResponse(), now, true, false)
-	assertSampleDecision(t, sampler, info, leaf2, updateResponse(nil), now.Add(time.Second), true, true)
-	assertSampleDecision(t, sampler, info, outputs.Meta{
-		"source": "leaf-1", "subscription-name": "state",
-	}, updateResponse(nil), now, true, false)
-	assertSampleDecision(t, sampler, info, outputs.Meta{
-		"subscription-name": "counters",
-	}, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, leaf2, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, leaf2, updateResponse(nil), now.Add(time.Second), true, true)
+	assertSampleDecision(t, sampler, streamInfoFor("stream-1", "leaf-1", "state"), updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, streamInfoFor("stream-1", "", "counters"), updateResponse(nil), now, true, false)
 }
 
 func TestSubscriptionSamplerPreservesInitialSync(t *testing.T) {
@@ -49,16 +44,15 @@ func TestSubscriptionSamplerPreservesInitialSync(t *testing.T) {
 			"counters": {Interval: time.Minute},
 		},
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	initialInfo := initialStreamInfo("stream-1")
 	info := streamInfo("stream-1")
 	now := time.Unix(100, 0)
 
-	assertSampleDecision(t, sampler, initialInfo, meta, updateResponse(nil), now, true, false)
-	assertSampleDecision(t, sampler, initialInfo, meta, updateResponse(nil), now.Add(time.Second), true, false)
-	assertSampleDecision(t, sampler, initialInfo, meta, syncResponse(), now.Add(2*time.Second), true, false)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(3*time.Second), true, true)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(4*time.Second), false, false)
+	assertSampleDecision(t, sampler, initialInfo, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, initialInfo, updateResponse(nil), now.Add(time.Second), true, false)
+	assertSampleDecision(t, sampler, initialInfo, syncResponse(), now.Add(2*time.Second), true, false)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now.Add(3*time.Second), true, true)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now.Add(4*time.Second), false, false)
 }
 
 func TestSubscriptionSamplerResetsAfterReconnect(t *testing.T) {
@@ -67,15 +61,30 @@ func TestSubscriptionSamplerResetsAfterReconnect(t *testing.T) {
 			"counters": {Interval: time.Minute},
 		},
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	now := time.Unix(100, 0)
 
-	assertSampleDecision(t, sampler, streamInfo("stream-1"), meta, syncResponse(), now, true, false)
-	assertSampleDecision(t, sampler, streamInfo("stream-1"), meta, updateResponse(nil), now, true, true)
-	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), meta, updateResponse(nil), now.Add(time.Second), true, false)
-	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), meta, updateResponse(nil), now.Add(2*time.Second), true, false)
-	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), meta, syncResponse(), now.Add(3*time.Second), true, false)
-	assertSampleDecision(t, sampler, streamInfo("stream-2"), meta, updateResponse(nil), now.Add(4*time.Second), true, true)
+	assertSampleDecision(t, sampler, streamInfo("stream-1"), syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, streamInfo("stream-1"), updateResponse(nil), now, true, true)
+	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), updateResponse(nil), now.Add(time.Second), true, false)
+	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), updateResponse(nil), now.Add(2*time.Second), true, false)
+	assertSampleDecision(t, sampler, initialStreamInfo("stream-2"), syncResponse(), now.Add(3*time.Second), true, false)
+	assertSampleDecision(t, sampler, streamInfo("stream-2"), updateResponse(nil), now.Add(4*time.Second), true, true)
+}
+
+func TestSubscriptionSamplerInterleavedReconnects(t *testing.T) {
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	now := time.Unix(100, 0)
+	oldStream := streamInfo("stream-1")
+	newStream := streamInfo("stream-2")
+
+	assertSampleDecision(t, sampler, oldStream, updateResponse(nil), now, true, true)
+	assertSampleDecision(t, sampler, newStream, updateResponse(nil), now.Add(time.Second), true, true)
+	assertSampleDecision(t, sampler, oldStream, updateResponse(nil), now.Add(2*time.Second), false, false)
+	assertSampleDecision(t, sampler, newStream, updateResponse(nil), now.Add(3*time.Second), false, false)
 }
 
 func TestSubscriptionSamplerControlMessagesDoNotConsumeWindow(t *testing.T) {
@@ -84,13 +93,12 @@ func TestSubscriptionSamplerControlMessagesDoNotConsumeWindow(t *testing.T) {
 			"counters": {Interval: time.Minute},
 		},
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	info := streamInfo("stream-1")
 	now := time.Unix(100, 0)
 
-	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now, true, true)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(time.Second), false, false)
+	assertSampleDecision(t, sampler, info, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now, true, true)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now.Add(time.Second), false, false)
 }
 
 func TestSubscriptionSamplerOnlySamplesKnownStreamUpdates(t *testing.T) {
@@ -99,17 +107,16 @@ func TestSubscriptionSamplerOnlySamplesKnownStreamUpdates(t *testing.T) {
 			"counters": {Interval: time.Minute},
 		},
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	now := time.Unix(100, 0)
 
-	assertSampleDecision(t, sampler, outputs.SubscriptionInfo{}, meta, updateResponse(nil), now, true, false)
-	assertSampleDecision(t, sampler, outputs.SubscriptionInfo{
-		Instance: "once-1", Mode: gnmi.SubscriptionList_ONCE,
-	}, meta, updateResponse(nil), now, true, false)
-	assertSampleDecision(t, sampler, outputs.SubscriptionInfo{
-		Instance: "poll-1", Mode: gnmi.SubscriptionList_POLL,
-	}, meta, updateResponse(nil), now, true, false)
-	assertSampleDecision(t, sampler, streamInfo("stream-1"), meta, &gnmi.GetResponse{}, now, true, false)
+	assertSampleDecision(t, sampler, outputs.SubscriptionInfo{}, updateResponse(nil), now, true, false)
+	onceInfo := streamInfo("once-1")
+	onceInfo.Mode = gnmi.SubscriptionList_ONCE
+	assertSampleDecision(t, sampler, onceInfo, updateResponse(nil), now, true, false)
+	pollInfo := streamInfo("poll-1")
+	pollInfo.Mode = gnmi.SubscriptionList_POLL
+	assertSampleDecision(t, sampler, pollInfo, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, streamInfo("stream-1"), &gnmi.GetResponse{}, now, true, false)
 }
 
 func TestSubscriptionSamplerAllowsOneConcurrentMessage(t *testing.T) {
@@ -118,10 +125,9 @@ func TestSubscriptionSamplerAllowsOneConcurrentMessage(t *testing.T) {
 			"counters": {Interval: time.Minute},
 		},
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	info := streamInfo("stream-1")
 	now := time.Unix(100, 0)
-	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, syncResponse(), now, true, false)
 
 	var accepted atomic.Int64
 	var wg sync.WaitGroup
@@ -129,12 +135,14 @@ func TestSubscriptionSamplerAllowsOneConcurrentMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			allowed, acceptance := sampler.Allow(info, meta, updateResponse(nil), now)
+			allowed, reservation := sampler.Reserve(info, updateResponse(nil), now)
 			if allowed {
 				accepted.Add(1)
-				if acceptance == nil {
-					t.Error("accepted sampled message did not return rollback state")
+				if reservation == nil {
+					t.Error("accepted sampled message did not return a reservation")
+					return
 				}
+				sampler.Commit(reservation)
 			}
 		}()
 	}
@@ -211,24 +219,44 @@ func TestSubscriptionSamplerRollback(t *testing.T) {
 			"counters": {Interval: time.Minute},
 		},
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	info := streamInfo("stream-1")
 	now := time.Unix(100, 0)
-	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, syncResponse(), now, true, false)
 
-	allowed, acceptance := sampler.Allow(info, meta, updateResponse(nil), now)
-	if !allowed || acceptance == nil {
+	allowed, reservation := sampler.Reserve(info, updateResponse(nil), now)
+	if !allowed || reservation == nil {
 		t.Fatal("first post-sync update was not sampled")
 	}
-	sampler.Rollback(acceptance)
-	allowed, newer := sampler.Allow(info, meta, updateResponse(nil), now.Add(time.Second))
+	sampler.Rollback(reservation)
+	allowed, newer := sampler.Reserve(info, updateResponse(nil), now.Add(time.Second))
 	if !allowed || newer == nil {
 		t.Fatal("message after rollback was not accepted")
 	}
+	sampler.Commit(newer)
 
-	// A stale rollback must not remove a newer acceptance.
-	sampler.Rollback(acceptance)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(2*time.Second), false, false)
+	sampler.Rollback(reservation)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now.Add(2*time.Second), false, false)
+}
+
+func TestSubscriptionSamplerRollbackDoesNotEvictCommittedState(t *testing.T) {
+	sampler := mustSubscriptionSampler(t, &messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+		CacheSize: 1,
+	})
+	now := time.Unix(100, 0)
+	leaf1 := streamInfoFor("stream-1", "leaf-1", "counters")
+	leaf2 := streamInfoFor("stream-1", "leaf-2", "counters")
+	assertSampleDecision(t, sampler, leaf1, updateResponse(nil), now, true, true)
+
+	allowed, reservation := sampler.Reserve(leaf2, updateResponse(nil), now.Add(time.Second))
+	if !allowed || reservation == nil {
+		t.Fatal("second source did not reserve a sampling window")
+	}
+	sampler.Rollback(reservation)
+
+	assertSampleDecision(t, sampler, leaf1, updateResponse(nil), now.Add(2*time.Second), false, false)
 }
 
 func TestSubscriptionSamplerSpread(t *testing.T) {
@@ -239,30 +267,30 @@ func TestSubscriptionSamplerSpread(t *testing.T) {
 		},
 		Spread: true,
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	info := streamInfo("stream-1")
-	key := "leaf-1\x00counters"
+	key := sampleKey{source: info.Source, subscription: info.Name, instance: info.Instance}
 	now := time.Unix(123, 456)
 	next := nextSpreadTime(key, now.Add(interval), interval)
-	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, syncResponse(), now, true, false)
 
-	allowed, acceptance := sampler.Allow(info, meta, updateResponse(nil), now)
-	if !allowed || acceptance == nil {
+	allowed, reservation := sampler.Reserve(info, updateResponse(nil), now)
+	if !allowed || reservation == nil {
 		t.Fatal("first post-sync update was not accepted")
 	}
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next.Add(-time.Nanosecond), false, false)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next, true, true)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next.Add(interval-time.Nanosecond), false, false)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), next.Add(interval), true, true)
+	sampler.Commit(reservation)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), next.Add(-time.Nanosecond), false, false)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), next, true, true)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), next.Add(interval-time.Nanosecond), false, false)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), next.Add(interval), true, true)
 
 	sampler = mustSubscriptionSampler(t, &messageSamplingConfig{
 		BySubscription: map[string]messageSamplingRule{"counters": {Interval: interval}},
 		Spread:         true,
 	})
-	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
-	allowed, acceptance = sampler.Allow(info, meta, updateResponse(nil), now)
-	sampler.Rollback(acceptance)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(time.Second), true, true)
+	assertSampleDecision(t, sampler, info, syncResponse(), now, true, false)
+	allowed, reservation = sampler.Reserve(info, updateResponse(nil), now)
+	sampler.Rollback(reservation)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now.Add(time.Second), true, true)
 }
 
 func TestSubscriptionSamplerPreservesNarrowUpdates(t *testing.T) {
@@ -271,17 +299,16 @@ func TestSubscriptionSamplerPreservesNarrowUpdates(t *testing.T) {
 			"counters": {Interval: 10 * time.Second, MinimumBytes: 1024},
 		},
 	})
-	meta := outputs.Meta{"source": "leaf-1", "subscription-name": "counters"}
 	info := streamInfo("stream-1")
 	now := time.Unix(100, 0)
-	assertSampleDecision(t, sampler, info, meta, syncResponse(), now, true, false)
+	assertSampleDecision(t, sampler, info, syncResponse(), now, true, false)
 
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now, true, false)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(time.Second), true, false)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now, true, false)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now.Add(time.Second), true, false)
 	wide := updateResponse(make([]byte, 2048))
-	assertSampleDecision(t, sampler, info, meta, wide, now.Add(2*time.Second), true, true)
-	assertSampleDecision(t, sampler, info, meta, wide, now.Add(3*time.Second), false, false)
-	assertSampleDecision(t, sampler, info, meta, updateResponse(nil), now.Add(4*time.Second), true, false)
+	assertSampleDecision(t, sampler, info, wide, now.Add(2*time.Second), true, true)
+	assertSampleDecision(t, sampler, info, wide, now.Add(3*time.Second), false, false)
+	assertSampleDecision(t, sampler, info, updateResponse(nil), now.Add(4*time.Second), true, false)
 }
 
 func mustSubscriptionSampler(t *testing.T, cfg *messageSamplingConfig) *subscriptionSampler {
@@ -294,7 +321,13 @@ func mustSubscriptionSampler(t *testing.T, cfg *messageSamplingConfig) *subscrip
 }
 
 func streamInfo(instance string) outputs.SubscriptionInfo {
+	return streamInfoFor(instance, "leaf-1", "counters")
+}
+
+func streamInfoFor(instance, source, name string) outputs.SubscriptionInfo {
 	return outputs.SubscriptionInfo{
+		Source:              source,
+		Name:                name,
 		Instance:            instance,
 		Mode:                gnmi.SubscriptionList_STREAM,
 		InitialSyncComplete: true,
@@ -302,7 +335,9 @@ func streamInfo(instance string) outputs.SubscriptionInfo {
 }
 
 func initialStreamInfo(instance string) outputs.SubscriptionInfo {
-	return outputs.SubscriptionInfo{Instance: instance, Mode: gnmi.SubscriptionList_STREAM}
+	info := streamInfo(instance)
+	info.InitialSyncComplete = false
+	return info
 }
 
 func syncResponse() *gnmi.SubscribeResponse {
@@ -323,18 +358,48 @@ func assertSampleDecision(
 	t *testing.T,
 	sampler *subscriptionSampler,
 	info outputs.SubscriptionInfo,
-	meta outputs.Meta,
 	message proto.Message,
 	now time.Time,
 	wantAllowed bool,
 	wantRecorded bool,
 ) {
 	t.Helper()
-	allowed, acceptance := sampler.Allow(info, meta, message, now)
+	allowed, reservation := sampler.Reserve(info, message, now)
 	if allowed != wantAllowed {
-		t.Fatalf("Allow() = %v, want %v", allowed, wantAllowed)
+		t.Fatalf("Reserve() = %v, want %v", allowed, wantAllowed)
 	}
-	if gotRecorded := acceptance != nil; gotRecorded != wantRecorded {
-		t.Fatalf("Allow() recorded acceptance = %v, want %v", gotRecorded, wantRecorded)
+	if gotRecorded := reservation != nil; gotRecorded != wantRecorded {
+		t.Fatalf("Reserve() returned reservation = %v, want %v", gotRecorded, wantRecorded)
+	}
+	if reservation != nil {
+		sampler.Commit(reservation)
+	}
+}
+
+func BenchmarkSubscriptionSamplerRejected(b *testing.B) {
+	sampler, err := newSubscriptionSampler(&messageSamplingConfig{
+		BySubscription: map[string]messageSamplingRule{
+			"counters": {Interval: time.Minute},
+		},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	info := streamInfo("stream-1")
+	message := updateResponse(nil)
+	now := time.Unix(100, 0)
+	allowed, reservation := sampler.Reserve(info, message, now)
+	if !allowed || reservation == nil {
+		b.Fatal("failed to seed sampler")
+	}
+	sampler.Commit(reservation)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		allowed, _ := sampler.Reserve(info, message, now.Add(time.Second))
+		if allowed {
+			b.Fatal("message inside sampling interval was accepted")
+		}
 	}
 }

--- a/pkg/outputs/subscription.go
+++ b/pkg/outputs/subscription.go
@@ -1,0 +1,39 @@
+// © 2026 Nokia.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package outputs
+
+import (
+	"context"
+
+	"github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// SubscriptionInfo identifies one managed subscription attempt and its
+// initial synchronization state.
+type SubscriptionInfo struct {
+	Instance            string
+	Mode                gnmi.SubscriptionList_Mode
+	InitialSyncComplete bool
+}
+
+type subscriptionInfoContextKey struct{}
+
+// WithSubscriptionInfo attaches subscription delivery state to an output call.
+func WithSubscriptionInfo(ctx context.Context, info SubscriptionInfo) context.Context {
+	if info.Instance == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, subscriptionInfoContextKey{}, info)
+}
+
+// SubscriptionInfoFromContext returns subscription delivery state attached by
+// a managed target subscription.
+func SubscriptionInfoFromContext(ctx context.Context) (SubscriptionInfo, bool) {
+	if ctx == nil {
+		return SubscriptionInfo{}, false
+	}
+	info, ok := ctx.Value(subscriptionInfoContextKey{}).(SubscriptionInfo)
+	return info, ok && info.Instance != ""
+}

--- a/pkg/outputs/subscription.go
+++ b/pkg/outputs/subscription.go
@@ -13,6 +13,8 @@ import (
 // SubscriptionInfo identifies one managed subscription attempt and its
 // initial synchronization state.
 type SubscriptionInfo struct {
+	Source              string
+	Name                string
 	Instance            string
 	Mode                gnmi.SubscriptionList_Mode
 	InitialSyncComplete bool

--- a/pkg/outputs/subscription_test.go
+++ b/pkg/outputs/subscription_test.go
@@ -1,0 +1,28 @@
+// © 2026 Nokia.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package outputs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openconfig/gnmi/proto/gnmi"
+)
+
+func TestSubscriptionInfoContext(t *testing.T) {
+	want := SubscriptionInfo{Instance: "stream-1", Mode: gnmi.SubscriptionList_STREAM}
+	ctx := WithSubscriptionInfo(context.Background(), want)
+	got, ok := SubscriptionInfoFromContext(ctx)
+	if !ok || got != want {
+		t.Fatalf("SubscriptionInfoFromContext() = (%v, %v), want (%v, true)", got, ok, want)
+	}
+
+	if _, ok := SubscriptionInfoFromContext(WithSubscriptionInfo(ctx, SubscriptionInfo{})); !ok {
+		t.Fatal("empty subscription info should preserve the existing context value")
+	}
+	if _, ok := SubscriptionInfoFromContext(nil); ok {
+		t.Fatal("nil context returned subscription info")
+	}
+}

--- a/pkg/outputs/subscription_test.go
+++ b/pkg/outputs/subscription_test.go
@@ -12,7 +12,12 @@ import (
 )
 
 func TestSubscriptionInfoContext(t *testing.T) {
-	want := SubscriptionInfo{Instance: "stream-1", Mode: gnmi.SubscriptionList_STREAM}
+	want := SubscriptionInfo{
+		Source:   "leaf-1",
+		Name:     "counters",
+		Instance: "stream-1",
+		Mode:     gnmi.SubscriptionList_STREAM,
+	}
 	ctx := WithSubscriptionInfo(context.Background(), want)
 	got, ok := SubscriptionInfoFromContext(ctx)
 	if !ok || got != want {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -8,10 +8,11 @@ import (
 
 // Msg contains the data to be passed from targets or inputs to outputs.
 type Msg struct {
-	Msg     proto.Message
-	Meta    outputs.Meta
-	Events  []*formatters.EventMsg
-	Outputs map[string]struct{}
+	Msg          proto.Message
+	Meta         outputs.Meta
+	Events       []*formatters.EventMsg
+	Outputs      map[string]struct{}
+	Subscription outputs.SubscriptionInfo
 }
 
 func NewMsg(msg proto.Message, meta outputs.Meta,


### PR DESCRIPTION
## What changed

- add opt-in `message-sampling.by-subscription` rules to the Prometheus write
  output
- configure each rule with an `interval` and optional `minimum-bytes` threshold
- sample managed gNMI STREAM Update responses by source and subscription before
  protobuf-to-event conversion
- preserve every Update response before the first successful SyncResponse
- treat each reconnect as a new stream instance with a new initial snapshot
- let narrow messages, control responses, ONCE/POLL subscriptions, and unmanaged
  messages bypass sampling without consuming the interval
- align later matching messages to stable per-stream phases when `spread` is
  enabled
- bound sampler state with an LRU cache and roll back accepted state when
  enqueueing is canceled
- retain sampler state across unrelated output configuration updates
- expose `gnmic_prometheus_write_output_messages_skipped_total`

## Why

Event processors run after protobuf conversion. High-frequency wide snapshots
therefore consume CPU and allocations even when a later processor discards them.
Some telemetry streams mix a multi-response initial snapshot with narrow
incremental notifications, so sampling must preserve the complete initial sync
and must not consume cadence for narrow deltas.

After initial sync, every matching response at or above `minimum-bytes` must be
independently discardable. Sampling is not safe for a later logical snapshot
that is split across multiple responses because the output cannot infer that
grouping.

## Configuration

```yaml
message-sampling:
  by-subscription:
    port-counters:
      interval: 60s
      minimum-bytes: 262144
  cache-size: 100000
  spread: true
```

## Validation

- `go test -race ./...`
- `cd pkg/api && go test -race ./target`
- `git diff --check`

Fixes #953.
