### PR TITLE
fix(event-jq): preserve delete events

### DIFF
--- a/pkg/formatters/event.go
+++ b/pkg/formatters/event.go
@@ -343,7 +343,11 @@ func (e *EventMsg) ToMap() map[string]interface{} {
 		m["values"] = e.Values
 	}
 	if len(e.Deletes) > 0 {
-		m["deletes"] = e.Deletes
+		deletes := make([]interface{}, len(e.Deletes))
+		for index, path := range e.Deletes {
+			deletes[index] = path
+		}
+		m["deletes"] = deletes
 	}
 	return m
 }

--- a/pkg/formatters/event_jq/event_jq.go
+++ b/pkg/formatters/event_jq/event_jq.go
@@ -141,7 +141,6 @@ func (p *jq) evaluateCondition(input map[string]interface{}) (bool, error) {
 
 func (p *jq) applyExpression(input []interface{}) ([]*formatters.EventMsg, error) {
 	var res []interface{}
-	var err error
 	var evs = make([]*formatters.EventMsg, 0)
 	iter := p.expr.Run(input)
 	for {
@@ -153,7 +152,7 @@ func (p *jq) applyExpression(input []interface{}) ([]*formatters.EventMsg, error
 		p.Logger.Debug("iter result", "type", fmt.Sprintf("%T", r), "value", r)
 		switch r := r.(type) {
 		case error:
-			return nil, err
+			return nil, r
 		default:
 			p.Logger.Debug("adding result", "value", r)
 			res = append(res, r)

--- a/pkg/formatters/event_jq/event_jq_test.go
+++ b/pkg/formatters/event_jq/event_jq_test.go
@@ -782,3 +782,33 @@ func TestEventJQ(t *testing.T) {
 		}
 	}
 }
+
+func TestEventJQPreservesDeleteEvents(t *testing.T) {
+	p := &jq{}
+	err := p.Init(map[string]interface{}{
+		"expression": `.[] | select(((.deletes // []) | length) > 0)`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := &formatters.EventMsg{
+		Name:    "sub1",
+		Deletes: []string{"/interfaces/interface[name=eth0]"},
+	}
+	got := p.Apply(input)
+	if !reflect.DeepEqual(got, []*formatters.EventMsg{input}) {
+		t.Fatalf("Apply() = %#v, want delete event", got)
+	}
+}
+
+func TestApplyExpressionReturnsIteratorError(t *testing.T) {
+	p := &jq{}
+	if err := p.Init(map[string]interface{}{"expression": `.[] | .name + 1`}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := p.applyExpression([]interface{}{map[string]interface{}{"name": "sub1"}}); err == nil {
+		t.Fatal("applyExpression() error = nil")
+	}
+}

--- a/pkg/formatters/event_test.go
+++ b/pkg/formatters/event_test.go
@@ -36,6 +36,16 @@ var eventMsgtestSet = map[string][]item{
 	"filled": {
 		{
 			ev: &EventMsg{
+				Name:    "sub1",
+				Deletes: []string{"/interfaces/interface[name=eth0]"},
+			},
+			m: map[string]interface{}{
+				"name":    "sub1",
+				"deletes": []interface{}{`/interfaces/interface[name=eth0]`},
+			},
+		},
+		{
+			ev: &EventMsg{
 				Timestamp: 100,
 				Values:    map[string]interface{}{"value1": int64(1)},
 				Tags:      map[string]string{"tag1": "1"},


### PR DESCRIPTION
Fixes #956.

`EventMsg.ToMap` now exposes delete paths as a JSON-compatible array before jq evaluation. This lets event-jq expressions inspect and transform `.deletes` without a gojq type error. The processor also returns the actual iterator error instead of a stale nil variable, so invalid expressions are observable.

Regression coverage verifies:

- delete events survive `.deletes | length` selection;
- EventMsg map conversion round-trips delete paths;
- jq iterator errors are returned.

Tests:

- `go test ./pkg/formatters/...`
- `go test -race ./pkg/formatters ./pkg/formatters/event_jq`