### PR TITLE
fix(clustering): converge concurrent target dispatch and honor cancellation

### DIFF
--- a/pkg/app/clustering.go
+++ b/pkg/app/clustering.go
@@ -322,6 +322,9 @@ func (a *App) dispatchTarget(ctx context.Context, tc *types.TargetConfig, denied
 		denied = make([]string, 0)
 	}
 SELECTSERVICE:
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	service, err := a.selectService(tc.Tags, denied...)
 	if err != nil {
 		return err
@@ -352,10 +355,10 @@ WAIT:
 	values, err := a.locker.List(ctx, key)
 	if err != nil {
 		logging.LogErrUnlessCanceled(a.Logger, err, "failed getting lock key value", "key", key)
-		time.Sleep(lockWaitTime)
-		goto WAIT
-	}
-	if len(values) == 0 {
+	} else if instance, ok := values[key]; ok && instance != "" {
+		a.Logger.Info("[cluster-leader] lock acquired", "lock", key, "instance", instance)
+		return nil
+	} else {
 		retries++
 		if (retries+1)*int(lockWaitTime) >= int(a.Config.Clustering.TargetAssignmentTimeout) {
 			a.Logger.Info("[cluster-leader] max retries reached, reselecting", "target", tc.Name, "service", service.ID)
@@ -365,25 +368,12 @@ WAIT:
 			}
 			goto SELECTSERVICE
 		}
-		time.Sleep(lockWaitTime)
-		goto WAIT
 	}
-	if instance, ok := values[key]; ok {
-		if instance == instanceName {
-			a.Logger.Info("[cluster-leader] lock acquired", "lock", key, "instance", instanceName)
-			return nil
-		}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(lockWaitTime):
 	}
-	retries++
-	if (retries+1)*int(lockWaitTime) >= int(a.Config.Clustering.TargetAssignmentTimeout) {
-		a.Logger.Info("[cluster-leader] max retries reached, reselecting", "target", tc.Name, "service", service.ID)
-		err = a.unassignTarget(ctx, tc.Name, service.ID)
-		if err != nil {
-			a.Logger.Info("failed to unassign target from service", "target", tc.Name, "service", service.ID)
-		}
-		goto SELECTSERVICE
-	}
-	time.Sleep(lockWaitTime)
 	goto WAIT
 }
 

--- a/pkg/app/target_dispatch_race_test.go
+++ b/pkg/app/target_dispatch_race_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openconfig/gnmic/pkg/api/types"
+	"github.com/openconfig/gnmic/pkg/config"
+	"github.com/openconfig/gnmic/pkg/lockers"
+)
+
+type assignmentRaceLocker struct {
+	lockers.Locker
+	cancelOnWait bool
+}
+
+func (l *assignmentRaceLocker) IsLocked(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (l *assignmentRaceLocker) List(ctx context.Context, prefix string) (map[string]string, error) {
+	if l.cancelOnWait && strings.HasSuffix(prefix, "/device-a") {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return map[string]string{"gnmic/test/targets/device-a": "collector-b"}, nil
+}
+
+func TestDispatchAcceptsConcurrentOwnerAndHonorsCancellation(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		name := "concurrent-owner"
+		if canceled {
+			name = "canceled-wait"
+		}
+		t.Run(name, func(t *testing.T) {
+			leader := New()
+			t.Cleanup(leader.Cfn)
+			leader.Config.Clustering = &config.Clustering{ClusterName: "test", TargetAssignmentTimeout: time.Millisecond}
+			leader.locker = &assignmentRaceLocker{cancelOnWait: canceled}
+			var starts, deletes, reconciles atomic.Int32
+			selected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodDelete:
+					deletes.Add(1)
+				case r.URL.Path == "/api/v1/config/targets":
+					w.WriteHeader(http.StatusOK)
+				default:
+					starts.Add(1)
+				}
+			}))
+			t.Cleanup(selected.Close)
+			owner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/api/v1/config/targets" {
+					t.Errorf("unexpected owner request: %s %s", r.Method, r.URL.Path)
+				}
+				reconciles.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(owner.Close)
+			leader.clusteringClient = selected.Client()
+			for instance, endpoint := range map[string]string{"collector-a": selected.URL, "collector-b": owner.URL} {
+				id := instance + "-api"
+				leader.apiServices[id] = &lockers.Service{ID: id, Address: strings.TrimPrefix(endpoint, "http://"), Tags: []string{"instance-name=" + instance}}
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- leader.dispatchTarget(ctx, &types.TargetConfig{Name: "device-a"}) }()
+			select {
+			case err := <-done:
+				if canceled {
+					if err != context.DeadlineExceeded {
+						t.Fatalf("cancellation error = %v", err)
+					}
+				} else if err != nil {
+					t.Fatalf("dispatch to concurrent owner failed: %v", err)
+				}
+			case <-time.After(500 * time.Millisecond):
+				t.Fatal("target dispatch blocked beyond cancellation")
+			}
+			if starts.Load() != 1 || deletes.Load() != 0 {
+				t.Fatalf("unnecessary redispatch: starts=%d deletes=%d", starts.Load(), deletes.Load())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #965.

When concurrent dispatches select different collectors, accept the collector that acquired the target lock first. The previous wait loop kept reassigning to its own selection and could stall subsequent loader targets. Also let context cancellation interrupt lock waits and service reselection.

The change preserves retries for an unowned target and adds deterministic tests for concurrent ownership and canceled locker queries. Both regressions fail on unpatched `fa4eb451b28ed15f6d6e69a281f8cbbe5a781073` and pass on head `b560bdbc0122cd1d02a307fd35046df3c4be49c2`.

Validation passed:

- `go test -race ./pkg/app -run TestDispatchAcceptsConcurrentOwnerAndHonorsCancellation -count=5`
- `CGO_ENABLED=0 bash tests/run_tests.sh` (root, API and cache modules)
- `gofmt` and `git diff --check`
