### PR TITLE
fix(clustering): log service additions only for new members

### DIFF
--- a/pkg/app/clustering.go
+++ b/pkg/app/clustering.go
@@ -217,7 +217,7 @@ func (a *App) updateServices(srvs []*lockers.Service) {
 	numNewSrv := len(srvs)
 	numCurrentSrv := len(a.apiServices)
 
-	a.Logger.Info("received service update", "num_services", numNewSrv)
+	a.Logger.Debug("received service update", "num_services", numNewSrv)
 	// no new services and no current services, continue
 	if numNewSrv == 0 && numCurrentSrv == 0 {
 		return
@@ -251,7 +251,9 @@ func (a *App) updateServices(srvs []*lockers.Service) {
 	}
 	// add new services
 	for n, s := range newSrvs {
-		a.Logger.Info("adding service", "id", n)
+		if _, exists := a.apiServices[n]; !exists {
+			a.Logger.Info("adding service", "id", n)
+		}
 		a.apiServices[n] = s
 	}
 }

--- a/pkg/app/clustering_services_logging_test.go
+++ b/pkg/app/clustering_services_logging_test.go
@@ -1,0 +1,73 @@
+// © 2026 Supranett.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/gnmic/pkg/lockers"
+)
+
+func TestUpdateServicesLogsMembershipChanges(t *testing.T) {
+	var logs bytes.Buffer
+	a := &App{
+		configLock:  new(sync.RWMutex),
+		apiServices: make(map[string]*lockers.Service),
+		Logger:      slog.New(slog.NewJSONHandler(&logs, nil)),
+	}
+	first := &lockers.Service{ID: "first", Address: "192.0.2.1:7890", Tags: []string{"a"}}
+	refreshed := &lockers.Service{ID: "first", Address: "192.0.2.2:7890", Tags: []string{"b"}}
+	second := &lockers.Service{ID: "second", Address: "192.0.2.3:7890"}
+	type record struct {
+		Message string `json:"msg"`
+		ID      string `json:"id"`
+	}
+	for _, tc := range []struct {
+		name     string
+		services []*lockers.Service
+		want     []record
+	}{
+		{name: "empty"},
+		{name: "initial member", services: []*lockers.Service{first}, want: []record{{"adding service", "first"}}},
+		{name: "unchanged", services: []*lockers.Service{first}},
+		{name: "updated endpoint and tags", services: []*lockers.Service{refreshed}},
+		{name: "new member", services: []*lockers.Service{refreshed, second}, want: []record{{"adding service", "second"}}},
+		{name: "removed member", services: []*lockers.Service{second}, want: []record{{"deleting service", "first"}}},
+		{name: "clear", want: []record{{Message: "deleting all services"}}},
+		{name: "still empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logs.Reset()
+			a.updateServices(tc.services)
+			wantServices := make(map[string]*lockers.Service, len(tc.services))
+			for _, service := range tc.services {
+				wantServices[service.ID] = service
+			}
+			if diff := cmp.Diff(wantServices, a.apiServices); diff != "" {
+				t.Errorf("service registry mismatch (-want +got):\n%s", diff)
+			}
+			var got []record
+			decoder := json.NewDecoder(&logs)
+			for {
+				var entry record
+				if err := decoder.Decode(&entry); err == io.EOF {
+					break
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, entry)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("INFO records mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Repeated discovery snapshots currently log every existing member as `adding service` at INFO. With a periodic locker watch this produces misleading membership changes throughout steady state.

Log routine snapshot receipt at DEBUG and emit INFO additions only for previously absent IDs. Existing service entries are still replaced so endpoint and tag updates take effect; removal logs are preserved.

Fixes #967.

Validation at `b32889eac252da68a135d82976838d88f8001802`:

- The new regression fails on main `fa4eb451b28ed15f6d6e69a281f8cbbe5a781073` with duplicate addition/snapshot records.
- `go test -race ./pkg/app -run '^TestUpdateServicesLogsMembershipChanges$' -count=5` passes after the change.
- `go test ./pkg/app` passes.
- Coverage includes empty and repeated snapshots, unchanged members, endpoint/tag replacement, additions, removal, and clearing the registry.
