### PR TITLE
feat(processor): add exact path allow-list matching

### DIFF
--- a/docs/user_guide/event_processors/event_keep.md
+++ b/docs/user_guide/event_processors/event_keep.md
@@ -1,18 +1,23 @@
-The `event-keep` processor removes tags or values that do not match the configured regular expressions. It complements `event-delete` and is useful when an event contains many fields but only a small allow-list is needed.
+The `event-keep` processor removes tags or values that do not match the configured selectors. It complements `event-delete` and is useful when an event contains many fields but only a small allow-list is needed.
 
-Selectors for names and values use OR semantics. Tags are filtered only when `tag-names` or `tags` is configured; values are filtered only when `value-names` or `values` is configured. An unconfigured category is left unchanged.
+Selectors for names and values use OR semantics. Tags are filtered only when `tag-names` or `tags` is configured; values are filtered only when `value-names`, `value-name-paths`, or `values` is configured. An unconfigured category is left unchanged.
 
 Events left without values, tags, or delete paths are discarded. Delete-only events are preserved.
 
 `values` regular expressions match string values only. Retain numeric, boolean, structured,
-or other non-string values with `value-names`.
+or other non-string values with `value-names` or `value-name-paths`.
+
+`value-name-paths` matches absolute, slash-separated paths without regular expressions. Literal segments match exactly and `*` matches one non-empty segment. Use it for large structured path allow-lists where regular expressions would be needlessly expensive.
 
 ```yaml
 processors:
   keep-interface-counters:
     event-keep:
       value-names:
-        - '^/interfaces/[^/]+/(in-octets|out-octets)$'
+        - '^/system/uptime$'
+      value-name-paths:
+        - /interfaces/*/in-octets
+        - /interfaces/*/out-octets
       tag-names:
         - '^(resource_id|source)$'
 ```

--- a/pkg/formatters/event_keep/event_keep.go
+++ b/pkg/formatters/event_keep/event_keep.go
@@ -26,16 +26,18 @@ const processorType = "event-keep"
 type keep struct {
 	formatters.BaseProcessor
 
-	Tags       []string `mapstructure:"tags,omitempty" json:"tags,omitempty"`
-	Values     []string `mapstructure:"values,omitempty" json:"values,omitempty"`
-	TagNames   []string `mapstructure:"tag-names,omitempty" json:"tag-names,omitempty"`
-	ValueNames []string `mapstructure:"value-names,omitempty" json:"value-names,omitempty"`
-	Debug      bool     `mapstructure:"debug,omitempty" json:"debug,omitempty"`
+	Tags           []string `mapstructure:"tags,omitempty" json:"tags,omitempty"`
+	Values         []string `mapstructure:"values,omitempty" json:"values,omitempty"`
+	TagNames       []string `mapstructure:"tag-names,omitempty" json:"tag-names,omitempty"`
+	ValueNames     []string `mapstructure:"value-names,omitempty" json:"value-names,omitempty"`
+	ValueNamePaths []string `mapstructure:"value-name-paths,omitempty" json:"value-name-paths,omitempty"`
+	Debug          bool     `mapstructure:"debug,omitempty" json:"debug,omitempty"`
 
-	tags       []*regexp.Regexp
-	values     []*regexp.Regexp
-	tagNames   []*regexp.Regexp
-	valueNames []*regexp.Regexp
+	tags           []*regexp.Regexp
+	values         []*regexp.Regexp
+	tagNames       []*regexp.Regexp
+	valueNames     []*regexp.Regexp
+	valueNamePaths *pathMatcher
 }
 
 func init() {
@@ -69,6 +71,9 @@ func (p *keep) Init(cfg any, opts ...formatters.Option) error {
 	if p.valueNames, err = compilePatterns("value-names", p.ValueNames); err != nil {
 		return err
 	}
+	if p.valueNamePaths, err = compilePathMatcher(p.ValueNamePaths); err != nil {
+		return err
+	}
 
 	if p.Logger.Enabled(context.Background(), slog.LevelDebug) {
 		if b, err := json.Marshal(p); err == nil {
@@ -93,7 +98,7 @@ func compilePatterns(field string, patterns []string) ([]*regexp.Regexp, error) 
 }
 
 func (p *keep) Apply(events ...*formatters.EventMsg) []*formatters.EventMsg {
-	filterValues := len(p.valueNames) > 0 || len(p.values) > 0
+	filterValues := len(p.valueNames) > 0 || p.valueNamePaths != nil || len(p.values) > 0
 	filterTags := len(p.tagNames) > 0 || len(p.tags) > 0
 	if !filterValues && !filterTags {
 		return events
@@ -107,7 +112,7 @@ func (p *keep) Apply(events ...*formatters.EventMsg) []*formatters.EventMsg {
 		removedValues, removedTags := 0, 0
 		if filterValues {
 			for name, value := range event.Values {
-				if matchesAny(name, p.valueNames) || matchesString(value, p.values) {
+				if matchesAny(name, p.valueNames) || p.valueNamePaths.Match(name) || matchesString(value, p.values) {
 					continue
 				}
 				delete(event.Values, name)

--- a/pkg/formatters/event_keep/event_keep_test.go
+++ b/pkg/formatters/event_keep/event_keep_test.go
@@ -11,6 +11,7 @@ package event_keep
 import (
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/openconfig/gnmic/pkg/formatters"
@@ -49,6 +50,38 @@ func TestKeepApply(t *testing.T) {
 				},
 				Tags: map[string]string{"source": "leaf-1"},
 			},
+		},
+		"structured value paths retain exact segments": {
+			config: map[string]any{"value-name-paths": []string{
+				"/interfaces/*/in-octets",
+				"/system/uptime",
+			}},
+			event: &formatters.EventMsg{Values: map[string]any{
+				"/interfaces/ethernet-1/in-octets":       42,
+				"/interfaces/ethernet-1/state/in-octets": 24,
+				"/interfaces/in-octets":                  12,
+				"/system/uptime":                         10,
+				"/vendor/debug":                          "ignored",
+			}},
+			want: &formatters.EventMsg{Values: map[string]any{
+				"/interfaces/ethernet-1/in-octets": 42,
+				"/system/uptime":                   10,
+			}},
+		},
+		"path and regular expression selectors use OR semantics": {
+			config: map[string]any{
+				"value-name-paths": []string{"/interfaces/*/in-octets"},
+				"value-names":      []string{"^state$"},
+			},
+			event: &formatters.EventMsg{Values: map[string]any{
+				"/interfaces/ethernet-1/in-octets": 42,
+				"state":                            1,
+				"drop":                             2,
+			}},
+			want: &formatters.EventMsg{Values: map[string]any{
+				"/interfaces/ethernet-1/in-octets": 42,
+				"state":                            1,
+			}},
 		},
 		"name and value selectors use OR semantics": {
 			config: map[string]any{
@@ -159,19 +192,62 @@ func TestKeepInitRejectsInvalidPattern(t *testing.T) {
 	}
 }
 
+func TestKeepInitRejectsInvalidValueNamePath(t *testing.T) {
+	for _, selector := range []string{"", "relative/path", "/", "/interfaces//state", "/interfaces/state/"} {
+		t.Run(selector, func(t *testing.T) {
+			processor := &keep{}
+			err := processor.Init(map[string]any{"value-name-paths": []string{selector}})
+			if err == nil {
+				t.Fatalf("Init() error = nil, want invalid selector %q", selector)
+			}
+		})
+	}
+}
+
 func BenchmarkKeepWideEventValueNames(b *testing.B) {
-	processor := &keep{}
-	if err := processor.Init(map[string]any{
+	benchmarkKeepWideEvent(b, map[string]any{
 		"value-names": []string{`^/COUNTERS/[^/]+/(SAI_PORT_STAT_IF_IN_OCTETS|SAI_PORT_STAT_IF_OUT_OCTETS)$`},
-	}); err != nil {
+	}, []string{"SAI_PORT_STAT_IF_IN_OCTETS", "SAI_PORT_STAT_IF_OUT_OCTETS"})
+}
+
+func BenchmarkKeepWideEventValueNamePaths(b *testing.B) {
+	benchmarkKeepWideEvent(b, map[string]any{
+		"value-name-paths": []string{
+			"/COUNTERS/*/SAI_PORT_STAT_IF_IN_OCTETS",
+			"/COUNTERS/*/SAI_PORT_STAT_IF_OUT_OCTETS",
+		},
+	}, []string{"SAI_PORT_STAT_IF_IN_OCTETS", "SAI_PORT_STAT_IF_OUT_OCTETS"})
+}
+
+func BenchmarkKeepWideEventManyFields(b *testing.B) {
+	fields := make([]string, 64)
+	paths := make([]string, 64)
+	for i := range fields {
+		fields[i] = "SAI_PORT_STAT_FIELD_" + strconv.Itoa(i)
+		paths[i] = "/COUNTERS/*/" + fields[i]
+	}
+	b.Run("regular expressions", func(b *testing.B) {
+		benchmarkKeepWideEvent(b, map[string]any{
+			"value-names": []string{`^/COUNTERS/[^/]+/(` + strings.Join(fields, "|") + `)$`},
+		}, fields)
+	})
+	b.Run("structured paths", func(b *testing.B) {
+		benchmarkKeepWideEvent(b, map[string]any{"value-name-paths": paths}, fields)
+	})
+}
+
+func benchmarkKeepWideEvent(b *testing.B, config map[string]any, retained []string) {
+	processor := &keep{}
+	if err := processor.Init(config); err != nil {
 		b.Fatal(err)
 	}
-	template := make(map[string]any, 34_014)
-	for i := range 34_012 {
+	template := make(map[string]any, 34_000+len(retained))
+	for i := range 34_000 {
 		template["/COUNTERS/oid:0x1/VENDOR_FIELD_"+strconv.Itoa(i)] = i
 	}
-	template["/COUNTERS/oid:0x1/SAI_PORT_STAT_IF_IN_OCTETS"] = 1
-	template["/COUNTERS/oid:0x1/SAI_PORT_STAT_IF_OUT_OCTETS"] = 2
+	for i, field := range retained {
+		template["/COUNTERS/oid:0x1/"+field] = i
+	}
 
 	b.ReportAllocs()
 	for b.Loop() {

--- a/pkg/formatters/event_keep/path_matcher.go
+++ b/pkg/formatters/event_keep/path_matcher.go
@@ -1,0 +1,87 @@
+// © 2026 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package event_keep
+
+import (
+	"fmt"
+	"strings"
+)
+
+type pathMatcher struct {
+	root pathNode
+}
+
+type pathNode struct {
+	literals map[string]*pathNode
+	wildcard *pathNode
+	terminal bool
+}
+
+func compilePathMatcher(selectors []string) (*pathMatcher, error) {
+	if len(selectors) == 0 {
+		return nil, nil
+	}
+	m := &pathMatcher{root: pathNode{literals: make(map[string]*pathNode)}}
+	for _, selector := range selectors {
+		if selector == "" || selector[0] != '/' {
+			return nil, fmt.Errorf("invalid value-name-paths selector %q: must be absolute", selector)
+		}
+		segments := strings.Split(selector[1:], "/")
+		node := &m.root
+		for _, segment := range segments {
+			if segment == "" {
+				return nil, fmt.Errorf("invalid value-name-paths selector %q: empty path segment", selector)
+			}
+			if segment == "*" {
+				if node.wildcard == nil {
+					node.wildcard = newPathNode()
+				}
+				node = node.wildcard
+				continue
+			}
+			child := node.literals[segment]
+			if child == nil {
+				child = newPathNode()
+				node.literals[segment] = child
+			}
+			node = child
+		}
+		node.terminal = true
+	}
+	return m, nil
+}
+
+func newPathNode() *pathNode {
+	return &pathNode{literals: make(map[string]*pathNode)}
+}
+
+func (m *pathMatcher) Match(value string) bool {
+	if m == nil || len(value) < 2 || value[0] != '/' {
+		return false
+	}
+	return m.root.match(value[1:])
+}
+
+func (n *pathNode) match(value string) bool {
+	segment, remaining, more := strings.Cut(value, "/")
+	if segment == "" {
+		return false
+	}
+	if child := n.literals[segment]; child != nil && child.matchesRemaining(remaining, more) {
+		return true
+	}
+	return n.wildcard != nil && n.wildcard.matchesRemaining(remaining, more)
+}
+
+func (n *pathNode) matchesRemaining(remaining string, more bool) bool {
+	if !more {
+		return n.terminal
+	}
+	return n.match(remaining)
+}


### PR DESCRIPTION
Wide telemetry events currently require large regular expressions for exact structured-path allow-lists. A 64-leaf, 34k-field benchmark takes about 7.4 ms per event, and a production 67-leaf, 44.5k-field event takes about 51 ms in the complete processor configuration.

This adds `value-name-paths`, compiled once into a literal/single-segment-wildcard trie. It keeps existing regex selectors and OR semantics intact. The 64-leaf benchmark drops to about 3.6 ms; the production filter drops to about 4 ms while retaining the same 17,164 fields.

Validation:

- `go test -race ./pkg/formatters/event_keep`
- `CGO_ENABLED=0 bash tests/run_tests.sh`
- `go test ./pkg/formatters/event_keep -run '^$' -bench BenchmarkKeepWideEventManyFields -benchmem -count=5`

Fixes #970.
