### PR TITLE
fix(api): synchronize runtime target map access

### DIFF
--- a/pkg/app/api.go
+++ b/pkg/app/api.go
@@ -284,14 +284,15 @@ func (a *App) handleTargetsGet(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 	if id == "" {
-		out := make(map[string]*runtimeTargetAPIView, len(a.Targets))
-		for k, t := range a.Targets {
+		targets := a.targetsSnapshot()
+		out := make(map[string]*runtimeTargetAPIView, len(targets))
+		for k, t := range targets {
 			out[k] = a.runtimeTargetAPIView(t)
 		}
 		a.handlerCommonGet(w, out)
 		return
 	}
-	if t, ok := a.Targets[id]; ok {
+	if t, ok := a.targetByName(id); ok {
 		a.handlerCommonGet(w, a.runtimeTargetAPIView(t))
 		return
 	}
@@ -322,7 +323,7 @@ func (a *App) handleTargetsDelete(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	if _, ok := a.Targets[id]; !ok {
+	if _, ok := a.targetByName(id); !ok {
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(APIErrors{Errors: []string{fmt.Sprintf("target %q not found", id)}})
 		return

--- a/pkg/app/api_runtime_targets_test.go
+++ b/pkg/app/api_runtime_targets_test.go
@@ -1,0 +1,112 @@
+// © 2026 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/openconfig/gnmic/pkg/api/target"
+	"github.com/openconfig/gnmic/pkg/api/types"
+)
+
+func TestRuntimeTargetsAPIConcurrentMutation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		method string
+		id     string
+	}{
+		{name: "list", method: http.MethodGet},
+		{name: "get", method: http.MethodGet, id: "changing"},
+		{name: "delete missing", method: http.MethodDelete, id: "missing"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a := New()
+			defer a.Cfn()
+			fixed := target.NewTarget(&types.TargetConfig{Name: "fixed"})
+			changing := target.NewTarget(&types.TargetConfig{Name: "changing"})
+			a.Targets["fixed"] = fixed
+			stop, done, started := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			go func() {
+				defer close(done)
+				close(started)
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					a.operLock.Lock()
+					a.Targets["changing"] = changing
+					a.operLock.Unlock()
+					runtime.Gosched()
+					a.operLock.Lock()
+					delete(a.Targets, "changing")
+					a.operLock.Unlock()
+				}
+			}()
+			defer func() { close(stop); <-done }()
+			<-started
+			for range 1000 {
+				request := httptest.NewRequest(test.method, "/api/v1/targets/"+test.id, nil)
+				request = mux.SetURLVars(request, map[string]string{"id": test.id})
+				response := httptest.NewRecorder()
+				if test.method == http.MethodDelete {
+					a.handleTargetsDelete(response, request)
+				} else {
+					a.handleTargetsGet(response, request)
+				}
+				if response.Code != http.StatusOK && response.Code != http.StatusNotFound {
+					t.Fatalf("unexpected status %d: %s", response.Code, response.Body.String())
+				}
+			}
+		})
+	}
+}
+
+func TestRuntimeTargetsAPIResponseReleasesOperationalLock(t *testing.T) {
+	a := New()
+	defer a.Cfn()
+	password := "test-only-password"
+	a.Targets["device"] = target.NewTarget(&types.TargetConfig{Name: "device", Password: &password})
+	for _, id := range []string{"", "device", "missing"} {
+		request := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v1/targets", nil), map[string]string{"id": id})
+		response := &operationalLockResponseWriter{ResponseRecorder: httptest.NewRecorder(), app: a, test: t}
+		a.handleTargetsGet(response, request)
+		if strings.Contains(response.Body.String(), password) {
+			t.Fatal("runtime target response exposed the password")
+		}
+		wantStatus := http.StatusOK
+		if id == "missing" {
+			wantStatus = http.StatusNotFound
+		}
+		if response.Code != wantStatus {
+			t.Fatalf("GET %q status = %d, want %d", id, response.Code, wantStatus)
+		}
+	}
+}
+
+type operationalLockResponseWriter struct {
+	*httptest.ResponseRecorder
+	app  *App
+	test *testing.T
+}
+
+func (w *operationalLockResponseWriter) Write(body []byte) (int, error) {
+	if w.app.operLock.TryLock() {
+		w.app.operLock.Unlock()
+	} else {
+		w.test.Error("HTTP response writing blocks runtime target mutations")
+	}
+	return w.ResponseRecorder.Write(body)
+}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -443,7 +443,7 @@ func (a *App) loadTargets(e fsnotify.Event) {
 			return
 		}
 		if !a.inCluster() {
-			currentTargets := a.Targets
+			currentTargets := a.targetsSnapshot()
 			// delete targets
 			for n := range currentTargets {
 				if _, ok := newTargets[n]; !ok {

--- a/pkg/app/runtime_targets.go
+++ b/pkg/app/runtime_targets.go
@@ -1,0 +1,28 @@
+// © 2026 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"maps"
+
+	"github.com/openconfig/gnmic/pkg/api/target"
+)
+
+func (a *App) targetsSnapshot() map[string]*target.Target {
+	a.operLock.RLock()
+	defer a.operLock.RUnlock()
+	return maps.Clone(a.Targets)
+}
+
+func (a *App) targetByName(name string) (*target.Target, bool) {
+	a.operLock.RLock()
+	defer a.operLock.RUnlock()
+	t, ok := a.Targets[name]
+	return t, ok
+}

--- a/pkg/app/subscribe.go
+++ b/pkg/app/subscribe.go
@@ -415,7 +415,7 @@ func (a *App) subscriptionMode(name string) string {
 // polledSubscriptionsTargets returns a map of target name to a list of subscription names that have Mode == POLL
 func (a *App) polledSubscriptionsTargets() map[string][]string {
 	result := make(map[string][]string)
-	for tn, target := range a.Targets {
+	for tn, target := range a.targetsSnapshot() {
 		for _, sub := range target.Subscriptions {
 			if strings.ToUpper(sub.Mode) == subscriptionModePOLL {
 				if result[tn] == nil {

--- a/pkg/app/subscribe_prompt.go
+++ b/pkg/app/subscribe_prompt.go
@@ -18,7 +18,7 @@ import (
 
 func (a *App) SubscribeRunPrompt(cmd *cobra.Command, args []string) error {
 	// stop running subscriptions
-	for _, t := range a.Targets {
+	for _, t := range a.targetsSnapshot() {
 		t.StopSubscriptions()
 	}
 	// reset subscriptions config map


### PR DESCRIPTION
## Problem

Runtime target loader updates can mutate `App.Targets` while the HTTP runtime target API or subscription helpers read the same map. A concurrent `GET /api/v1/targets` can therefore terminate the process with `fatal error: concurrent map iteration and map write`.

## Change

- synchronize point lookups with `operLock`
- clone the target map under a read lock before iteration
- use the same snapshot helper in config reconciliation and subscription readers
- release the lock before JSON serialization and target shutdown work

## Validation

- `go test -race ./pkg/app -run 'TestRuntimeTargetsAPI|Test.*polled' -count=10`
- `go test -race ./pkg/app`
- `CGO_ENABLED=0 bash tests/run_tests.sh`

Fixes #969
