### PR TITLE
feat(influxdb): implement uint conversion for InfluxDB 1.x versions

### DIFF
--- a/pkg/outputs/influxdb_output/influxdb_output.go
+++ b/pkg/outputs/influxdb_output/influxdb_output.go
@@ -842,7 +842,7 @@ func (i *influxDBOutput) convertUints(ev *formatters.EventMsg) {
 		return
 	}
 	dbVersion, ok := dbVer.(string)
-	if !ok || !strings.HasPrefix(dbVersion, "1.8") {
+	if !ok || !isInfluxDB1(dbVersion) {
 		return
 	}
 
@@ -860,6 +860,15 @@ func (i *influxDBOutput) convertUints(ev *formatters.EventMsg) {
 			ev.Values[k] = int(v)
 		}
 	}
+}
+
+// isInfluxDB1 reports whether version is InfluxDB 1.x. 1.x line protocol
+// rejects the unsigned suffix the v2 client writes, so uints must be
+// converted to int. Matching only "1.8" skipped later 1.x releases.
+func isInfluxDB1(version string) bool {
+	v := strings.TrimPrefix(strings.TrimSpace(version), "v")
+	v = strings.TrimPrefix(v, "V")
+	return v == "1" || strings.HasPrefix(v, "1.")
 }
 
 func clientNeedsRebuild(old, new *Config) bool {

--- a/pkg/outputs/influxdb_output/influxdb_output_test.go
+++ b/pkg/outputs/influxdb_output/influxdb_output_test.go
@@ -243,3 +243,39 @@ func TestInfluxDBOutput_InitDoesNotBlockOnDeadServer(t *testing.T) {
 		t.Fatal("Init blocked while the influx server was unreachable")
 	}
 }
+
+func TestConvertUintsAppliesToInfluxDB1(t *testing.T) {
+	const counter uint64 = 42580201
+	tests := []struct {
+		name    string
+		version string
+		convert bool
+	}{
+		{name: "1.8.10", version: "1.8.10", convert: true},
+		{name: "1.13.0", version: "1.13.0", convert: true},
+		{name: "v1.13.0", version: "v1.13.0", convert: true},
+		{name: "2.7.4", version: "2.7.4", convert: false},
+		{name: "v2.0.0", version: "v2.0.0", convert: false},
+		{name: "unset", convert: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &influxDBOutput{}
+			if tt.version != "" {
+				i.dbVersion.Store(tt.version)
+			}
+			ev := &formatters.EventMsg{Values: map[string]any{"n": counter}}
+			i.convertUints(ev)
+			got := ev.Values["n"]
+			if tt.convert {
+				if _, ok := got.(int); !ok {
+					t.Fatalf("got %T (%v), want int", got, got)
+				}
+				return
+			}
+			if _, ok := got.(uint64); !ok {
+				t.Fatalf("got %T (%v), want uint64", got, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a new function to determine if the InfluxDB version is 1.x and update the uint conversion logic accordingly. Introduce tests to validate the conversion behavior for various InfluxDB versions.
fix #958 