### PR TITLE
feat(metrics): add cluster metrics update functionality and tests

### DIFF
--- a/pkg/app/metrics.go
+++ b/pkg/app/metrics.go
@@ -65,6 +65,12 @@ var clusterIsLeader = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name:      "is_leader",
 	Help:      "Has value 1 if this gnmic instance is the cluster leader, 0 otherwise",
 })
+var clusterLockerListFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "gnmic",
+	Subsystem: "cluster",
+	Name:      "locker_list_failed_total",
+	Help:      "Number of failed locker List queries while updating cluster gauges",
+}, []string{"query"})
 
 func (a *App) registerTargetMetrics() {
 	err := a.reg.Register(targetUPMetric)
@@ -161,6 +167,10 @@ func (a *App) startClusterMetrics() {
 	if err != nil {
 		logging.LogErrUnlessCanceled(a.Logger, err, "failed to register metric")
 	}
+	err = a.reg.Register(clusterLockerListFailed)
+	if err != nil {
+		logging.LogErrUnlessCanceled(a.Logger, err, "failed to register metric")
+	}
 	ticker := time.NewTicker(clusterMetricsUpdatePeriod)
 	defer ticker.Stop()
 	for {
@@ -168,33 +178,40 @@ func (a *App) startClusterMetrics() {
 		case <-a.ctx.Done():
 			return
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(a.ctx, clusterMetricsUpdatePeriod/2)
-			leaderKey := fmt.Sprintf("gnmic/%s/leader", a.Config.ClusterName)
-			leader, err := a.locker.List(ctx, leaderKey)
-			cancel()
-			if err != nil {
-				logging.LogErrUnlessCanceled(a.Logger, err, "failed to get leader key")
-			}
-			if leader[leaderKey] == a.Config.Clustering.InstanceName {
-				clusterIsLeader.Set(1)
-			} else {
-				clusterIsLeader.Set(0)
-			}
-
-			lockedNodesPrefix := fmt.Sprintf("gnmic/%s/targets", a.Config.ClusterName)
-			ctx, cancel = context.WithTimeout(a.ctx, clusterMetricsUpdatePeriod/2)
-			lockedNodes, err := a.locker.List(ctx, lockedNodesPrefix)
-			cancel()
-			if err != nil {
-				logging.LogErrUnlessCanceled(a.Logger, err, "failed to get locked nodes key")
-			}
-			numLockedNodes := 0
-			for _, v := range lockedNodes {
-				if v == a.Config.Clustering.InstanceName {
-					numLockedNodes++
-				}
-			}
-			clusterNumberOfLockedTargets.Set(float64(numLockedNodes))
+			a.updateClusterMetrics(a.ctx)
 		}
 	}
+}
+
+func (a *App) updateClusterMetrics(ctx context.Context) {
+	timeout := clusterMetricsUpdatePeriod / 2
+	leaderKey := fmt.Sprintf("gnmic/%s/leader", a.Config.ClusterName)
+	leaderCtx, cancel := context.WithTimeout(ctx, timeout)
+	leader, err := a.locker.List(leaderCtx, leaderKey)
+	cancel()
+	if err != nil {
+		logging.LogErrUnlessCanceled(a.Logger, err, "failed to get leader key")
+		clusterLockerListFailed.WithLabelValues("leader").Inc()
+	} else if leader[leaderKey] == a.Config.Clustering.InstanceName {
+		clusterIsLeader.Set(1)
+	} else {
+		clusterIsLeader.Set(0)
+	}
+
+	lockedNodesPrefix := fmt.Sprintf("gnmic/%s/targets", a.Config.ClusterName)
+	lockedCtx, cancel := context.WithTimeout(ctx, timeout)
+	lockedNodes, err := a.locker.List(lockedCtx, lockedNodesPrefix)
+	cancel()
+	if err != nil {
+		logging.LogErrUnlessCanceled(a.Logger, err, "failed to get locked nodes key")
+		clusterLockerListFailed.WithLabelValues("targets").Inc()
+		return
+	}
+	numLockedNodes := 0
+	for _, v := range lockedNodes {
+		if v == a.Config.Clustering.InstanceName {
+			numLockedNodes++
+		}
+	}
+	clusterNumberOfLockedTargets.Set(float64(numLockedNodes))
 }

--- a/pkg/app/metrics_test.go
+++ b/pkg/app/metrics_test.go
@@ -1,0 +1,88 @@
+// © 2026 Nokia.
+//
+// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
+// This code is provided on an “as is” basis without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openconfig/gnmic/pkg/config"
+	"github.com/openconfig/gnmic/pkg/lockers"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestUpdateClusterMetricsSkipsGaugesOnLockerListError(t *testing.T) {
+	a := New()
+	defer a.Cfn()
+	a.Config.ClusterName = "c"
+	a.Config.Clustering = &config.Clustering{InstanceName: "instance-1"}
+	lk := &clusterMetricsLocker{
+		leader: map[string]string{"gnmic/c/leader": "instance-1"},
+		targets: map[string]string{
+			"gnmic/c/targets/device-a": "instance-1",
+			"gnmic/c/targets/device-b": "instance-1",
+			"gnmic/c/targets/device-c": "instance-2",
+		},
+	}
+	a.locker = lk
+
+	a.updateClusterMetrics(context.Background())
+	if got := testutil.ToFloat64(clusterIsLeader); got != 1 {
+		t.Fatalf("is_leader after success = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(clusterNumberOfLockedTargets); got != 2 {
+		t.Fatalf("locked targets after success = %v, want 2", got)
+	}
+
+	leaderFails := testutil.ToFloat64(clusterLockerListFailed.WithLabelValues("leader"))
+	targetFails := testutil.ToFloat64(clusterLockerListFailed.WithLabelValues("targets"))
+	lk.leaderErr = errors.New("leader list failed")
+	lk.targetErr = errors.New("target list failed")
+	a.updateClusterMetrics(context.Background())
+	if got := testutil.ToFloat64(clusterIsLeader); got != 1 {
+		t.Fatalf("is_leader after both failures = %v, want previous 1", got)
+	}
+	if got := testutil.ToFloat64(clusterNumberOfLockedTargets); got != 2 {
+		t.Fatalf("locked targets after both failures = %v, want previous 2", got)
+	}
+	if got := testutil.ToFloat64(clusterLockerListFailed.WithLabelValues("leader")); got != leaderFails+1 {
+		t.Fatalf("leader failures = %v, want %v", got, leaderFails+1)
+	}
+	if got := testutil.ToFloat64(clusterLockerListFailed.WithLabelValues("targets")); got != targetFails+1 {
+		t.Fatalf("target failures = %v, want %v", got, targetFails+1)
+	}
+
+	lk.leaderErr = errors.New("leader list failed")
+	lk.targetErr = nil
+	lk.targets = map[string]string{}
+	a.updateClusterMetrics(context.Background())
+	if got := testutil.ToFloat64(clusterIsLeader); got != 1 {
+		t.Fatalf("is_leader after leader-only failure = %v, want previous 1", got)
+	}
+	if got := testutil.ToFloat64(clusterNumberOfLockedTargets); got != 0 {
+		t.Fatalf("locked targets after empty success = %v, want 0", got)
+	}
+}
+
+type clusterMetricsLocker struct {
+	lockers.Locker
+	leader    map[string]string
+	leaderErr error
+	targets   map[string]string
+	targetErr error
+}
+
+func (l *clusterMetricsLocker) List(_ context.Context, prefix string) (map[string]string, error) {
+	if strings.Contains(prefix, "/targets") {
+		return l.targets, l.targetErr
+	}
+	return l.leader, l.leaderErr
+}

--- a/pkg/app/metrics_test.go
+++ b/pkg/app/metrics_test.go
@@ -1,11 +1,3 @@
-// © 2026 Nokia.
-//
-// This code is a Contribution to the gNMIc project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0.
-// No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose.
-// This code is provided on an “as is” basis without any warranties of any kind.
-//
-// SPDX-License-Identifier: Apache-2.0
-
 package app
 
 import (


### PR DESCRIPTION
- Introduced a new test file for cluster metrics, validating behavior during locker list errors.
- Added a new counter metric `locker_list_failed_total` to track failures in locker list queries.
- Refactored the `startClusterMetrics` method to utilize the new `updateClusterMetrics` method for cleaner logic and error handling.

fix #955 