### PR TITLE
fix: update containerlab links in documentation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -850,7 +850,7 @@
 
 - [Deployment Examples](deployments/deployments_intro.md):
 
-    Add [containerlab](https://containerlab.srlinux.dev) based deployment examples.
+    Add [containerlab](https://containerlab.dev) based deployment examples.
     These deployment come with a router fabric built using Nokia's [SRL](https://learn.srlinux.dev)
 
 - [API server](user_guide/api/api_intro.md):

--- a/docs/deployments/deployments_intro.md
+++ b/docs/deployments/deployments_intro.md
@@ -4,14 +4,14 @@ Whether it is gNMI telemetry collection and export to a single output,
 or clustered data pipelines with high availability and redundancy, 
 the below examples should cover the most common use cases.
 
-In this section you will find multiple deployment examples, using [docker-compose](https://docs.docker.com/compose/) or [containerlab](https://containerlab.srlinux.dev/).
+In this section you will find multiple deployment examples, using [docker-compose](https://docs.docker.com/compose/) or [containerlab](https://containerlab.dev/).
 Each deployment comes with:
 
 - a `docker-compose` or `clab` file 
 - one or multiple `gnmic` configuration file(s)
 - extra configuration files if required by the use case (e.g: prometheus, grafana,...)
 
-The [containerlab](https://containerlab.srlinux.dev/) examples come with a fabric deployed using Nokia's [SR Linux](https://learn.srlinux.dev)
+The [containerlab](https://containerlab.dev/) examples come with a fabric deployed using Nokia's [SR Linux](https://learn.srlinux.dev)
 
 If you don't find an example that fits your needs, feel free to open an issue on [github](https://github.com/openconfig/gnmic/issues/new)
 

--- a/docs/user_guide/event_processors/event_trigger.md
+++ b/docs/user_guide/event_processors/event_trigger.md
@@ -124,7 +124,7 @@ actions:
 
 #### Clone a network topology and deploy it using containerlab
 
-Using lldp neighbor information it's possible to build a [containerlab](https://containerlab.srlinux.dev) topology using `gnmic` actions.
+Using lldp neighbor information it's possible to build a [containerlab](https://containerlab.dev) topology using `gnmic` actions.
 
 In the below configuration file, an event processor called `clone-topology` is defined.
 

--- a/docs/user_guide/targets/target_discovery/docker_discovery.md
+++ b/docs/user_guide/targets/target_discovery/docker_discovery.md
@@ -111,7 +111,7 @@ loader:
 
 A simple docker loader with a single docker container filter.
 
-It loads all containers deployed with [containerlab](https://containerlab.srlinux.dev/), in lab called `lab1`.
+It loads all containers deployed with [containerlab](https://containerlab.dev/), in lab called `lab1`.
 
 ```yaml
 loader:
@@ -131,7 +131,7 @@ Default configuration applies to those added targets
 
 A simple docker loader with a single docker container filter.
 
-It loads all containers deployed with [containerlab](https://containerlab.srlinux.dev/), having kind `srl`.
+It loads all containers deployed with [containerlab](https://containerlab.dev/), having kind `srl`.
 
 ```yaml
 loader:


### PR DESCRIPTION
supersedes #868 