### PR TITLE
refactor: update Docker configuration for multi-platform builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,60 +21,38 @@ builds:
       - "386"
       - arm
       - arm64
-dockers:
-  - goos: linux
-    goarch: amd64
+dockers_v2:
+  - id: gnmic
     ids:
       - gnmic
-    image_templates:
-      - &amd64_latest_image "ghcr.io/openconfig/gnmic:latest-amd64"
-      - &amd64_versioned_image 'ghcr.io/openconfig/gnmic:{{ replace .Version "v" ""}}-amd64'
     dockerfile: goreleaser-alpine.dockerfile
-    skip_push: false
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=ALPINE_VERSION={{ .Env.ALPINE_VERSION }}"
+    images:
+      - ghcr.io/openconfig/gnmic
+    tags:
+      - '{{ replace .Version "v" "" }}'
+      - "{{ if not .IsSnapshot }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    sbom: false
+    build_args:
+      ALPINE_VERSION: "{{ .Env.ALPINE_VERSION }}"
+    flags:
       - "--provenance=false"
-      - "--sbom=false"
-  - goos: linux
-    goarch: arm64
+  - id: gnmic-scratch
     ids:
       - gnmic
-    image_templates:
-      - &arm64_latest_image "ghcr.io/openconfig/gnmic:latest-arm64"
-      - &arm64_versioned_image 'ghcr.io/openconfig/gnmic:{{ replace .Version "v" ""}}-arm64'
-    dockerfile: goreleaser-alpine.dockerfile
-    skip_push: false
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--build-arg=ALPINE_VERSION={{ .Env.ALPINE_VERSION }}"
-      - "--provenance=false"
-      - "--sbom=false"
-  - goos: linux
-    goarch: amd64
-    ids:
-      - gnmic
-    image_templates:
-      - "ghcr.io/openconfig/gnmic:latest-scratch"
-      - 'ghcr.io/openconfig/gnmic:{{ replace .Version "v" ""}}-scratch'
     dockerfile: goreleaser-scratch.dockerfile
-    skip_push: false
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
+    images:
+      - ghcr.io/openconfig/gnmic
+    tags:
+      - '{{ replace .Version "v" "" }}-scratch'
+      - "{{ if not .IsSnapshot }}latest-scratch{{ end }}"
+    platforms:
+      - linux/amd64
+    sbom: false
+    flags:
       - "--provenance=false"
-      - "--sbom=false"
-docker_manifests:
-  - name_template: 'ghcr.io/openconfig/gnmic:{{ replace .Version "v" "" }}'
-    image_templates:
-      - *amd64_versioned_image
-      - *arm64_versioned_image
-  - name_template: "{{- if not .IsSnapshot}}ghcr.io/openconfig/gnmic:latest{{- end}}"
-    image_templates:
-      - *amd64_latest_image
-      - *arm64_latest_image
 archives:
   - name_template: >-
       {{ .ProjectName }}_
@@ -88,7 +66,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 changelog:
   use: github-native
 

--- a/goreleaser-alpine.dockerfile
+++ b/goreleaser-alpine.dockerfile
@@ -6,13 +6,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG ALPINE_VERSION
+ARG ALPINE_VERSION=latest
 FROM alpine:${ALPINE_VERSION}
 
 LABEL maintainer="Karim Radhouani <medkarimrdi@gmail.com>, Roman Dodin <dodin.roman@gmail.com>"
 LABEL documentation="https://gnmic.openconfig.net"
 LABEL repo="https://github.com/openconfig/gnmic"
 
-COPY gnmic /app/gnmic
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/gnmic /app/gnmic
 ENTRYPOINT [ "/app/gnmic" ]
 CMD [ "help" ]

--- a/goreleaser-scratch.dockerfile
+++ b/goreleaser-scratch.dockerfile
@@ -12,6 +12,7 @@ LABEL maintainer="Karim Radhouani <medkarimrdi@gmail.com>, Roman Dodin <dodin.ro
 LABEL documentation="https://gnmic.openconfig.net"
 LABEL repo="https://github.com/openconfig/gnmic"
 
-COPY gnmic /app/gnmic
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/gnmic /app/gnmic
 ENTRYPOINT [ "/app/gnmic" ]
 CMD [ "help" ]


### PR DESCRIPTION
- Consolidated Docker configuration under `dockers_v2` for better organization.
- Updated image templates and build arguments to support multi-platform builds.
- Changed `ALPINE_VERSION` argument to default to `latest` in Dockerfiles.
- Modified COPY commands in Dockerfiles to use `TARGETPLATFORM` for architecture-specific binaries.